### PR TITLE
docs: fix field names, mock LLM port, and endpoint paths

### DIFF
--- a/docs-site/docs/development/setup.md
+++ b/docs-site/docs/development/setup.md
@@ -85,7 +85,7 @@ SyncProbesJob.perform_now
 
 ## Mock LLM
 
-The dev compose file starts the Mock LLM server automatically. It's available at `http://mock-llm:5000` from within the Docker network. Use it to run scans during development without API keys.
+The dev compose file starts the Mock LLM server automatically. It's available at `http://mock-llm:9292` from within the Docker network (endpoint: `/api/v1/mock_llm/chat`). Use it to run scans during development without API keys.
 
 ## Port Conflicts
 

--- a/docs-site/docs/getting-started/first-scan.md
+++ b/docs-site/docs/getting-started/first-scan.md
@@ -22,18 +22,18 @@ Scanner must already be running. See [Quick Start](./quick-start) if you haven't
    | Field | Value |
    |---|---|
    | **Name** | `Mock LLM - Vulnerable` |
-   | **Generator** | `rest.RestGenerator` |
-   | **URI** | `http://mock-llm:5000/vulnerable` |
+   | **Model Type** | `rest.RestGenerator` |
+   | **Model** | `http://mock-llm:9292/api/v1/mock_llm/chat` |
 
 5. Click **Create Target**
 
-:::tip Other Mock LLM endpoints
-The mock server exposes three endpoints:
-- `http://mock-llm:5000/safe` — always passes probes
-- `http://mock-llm:5000/vulnerable` — always fails probes (good for testing)
-- `http://mock-llm:5000/mixed` — mixed results
+:::tip Mock LLM modes
+The mock server supports three response modes, set via the `mode` field in the JSON config:
+- `safe` — always passes probes
+- `vulnerable` — always fails probes (good for testing)
+- `mixed` — mixed results (default if no mode is specified)
 
-Use `vulnerable` for your first scan so you can see what a report with findings looks like.
+See [Mock LLM](../user-guide/mock-llm) for details on configuring modes.
 :::
 
 ## Step 2: Start a Scan

--- a/docs-site/docs/user-guide/core-concepts.md
+++ b/docs-site/docs/user-guide/core-concepts.md
@@ -55,8 +55,8 @@ Each target stores:
 
 | Field | Description |
 |---|---|
-| **Generator class** | Which garak generator to use |
-| **Generator URI** | The model endpoint or identifier |
+| **Model Type** | Which garak generator to use |
+| **Model** | The model endpoint or identifier |
 | **Environment variables** | Per-target API keys (encrypted at rest) |
 | **JSON config** | Additional generator-specific settings (encrypted at rest) |
 

--- a/docs-site/docs/user-guide/mock-llm.md
+++ b/docs-site/docs/user-guide/mock-llm.md
@@ -14,15 +14,15 @@ Use the Mock LLM to:
 - Understand what a scan report looks like with known outcomes
 - Develop and test custom probe sources
 
-## Endpoints
+## Modes
 
-The Mock LLM exposes three endpoints that simulate different model behaviors:
+The Mock LLM supports three response modes that simulate different model behaviors. The mode is specified via the `mode` field in the JSON request body (or the `X-Mock-Mode` HTTP header). If no mode is specified, it defaults to `mixed`.
 
-| Endpoint | Behavior | Use Case |
+| Mode | Behavior | Use Case |
 |---|---|---|
-| `/safe` | Always responds safely — all probes pass | Verify Scanner correctly scores a "good" model |
-| `/vulnerable` | Always responds vulnerably — all probes fail | Verify Scanner correctly scores a "bad" model |
-| `/mixed` | Random mix of safe and vulnerable responses | Realistic-looking test report with partial ASR |
+| `safe` | Always responds safely — all probes pass | Verify Scanner correctly scores a "good" model |
+| `vulnerable` | Always responds vulnerably — all probes fail | Verify Scanner correctly scores a "bad" model |
+| `mixed` | Mix of safe and vulnerable responses (default) | Realistic-looking test report with partial ASR |
 
 ## Connecting a Target
 
@@ -30,20 +30,22 @@ Create a target using `rest.RestGenerator` and the Mock LLM's internal Docker ho
 
 | Field | Value |
 |---|---|
-| **Generator** | `rest.RestGenerator` |
-| **URI** | `http://mock-llm:5000/vulnerable` |
+| **Model Type** | `rest.RestGenerator` |
+| **Model** | `http://mock-llm:9292/api/v1/mock_llm/chat` |
 
 The hostname `mock-llm` is the Docker Compose service name — it's only resolvable from within the Docker network (i.e., from the `scanner` container).
 
+The default mode is `mixed`. To force a specific mode, add `X-Mock-Mode: vulnerable` (or `safe`) as a custom request header in your target's JSON config.
+
 ## Expected Results
 
-| Endpoint | Expected ASR |
+| Mode | Expected ASR |
 |---|---|
-| `/safe` | ~0% |
-| `/vulnerable` | ~100% |
-| `/mixed` | ~50% |
+| `safe` | ~0% |
+| `vulnerable` | ~100% |
+| `mixed` | ~50% |
 
-Use `/vulnerable` for your [first scan](../getting-started/first-scan) to see what a report with significant findings looks like.
+Use `vulnerable` mode for your [first scan](../getting-started/first-scan) to see what a report with significant findings looks like.
 
 ## Mock LLM in Development
 
@@ -51,4 +53,4 @@ When running the dev environment (`docker compose -f docker-compose.dev.yml up`)
 
 ## Source Code
 
-The Mock LLM is a small Python Flask server located in `mock-llm/` at the repo root. It's intentionally minimal — if you need more sophisticated simulation (e.g., specific response patterns), you can modify it directly.
+The Mock LLM is a small Ruby Rack application located in `mock-llm/` at the repo root. It's intentionally minimal — if you need more sophisticated simulation (e.g., specific response patterns), you can modify it directly.

--- a/docs-site/docs/user-guide/targets.md
+++ b/docs-site/docs/user-guide/targets.md
@@ -18,8 +18,8 @@ A **target** represents an AI system you want to test. Scanner supports API-base
 | Field | Required | Description |
 |---|---|---|
 | **Name** | Yes | Display name for this target |
-| **Generator** | Yes | The garak generator class (e.g., `rest.RestGenerator`) |
-| **URI** | Varies | Model endpoint URL or model identifier |
+| **Model Type** | Yes | The garak generator class (e.g., `rest.RestGenerator`) |
+| **Model** | Varies | Model endpoint URL or model identifier |
 | **JSON Config** | No | Additional generator options as JSON |
 
 ## Common Target Templates
@@ -28,8 +28,8 @@ A **target** represents an AI system you want to test. Scanner supports API-base
 
 | Field | Value |
 |---|---|
-| Generator | `openai.OpenAIGenerator` |
-| URI | `gpt-4o` (or any OpenAI model ID) |
+| Model Type | `openai.OpenAIGenerator` |
+| Model | `gpt-4o` (or any OpenAI model ID) |
 
 Set `OPENAI_API_KEY` as a target-specific environment variable (see [Environment Variables](./environment-variables)).
 
@@ -37,8 +37,8 @@ Set `OPENAI_API_KEY` as a target-specific environment variable (see [Environment
 
 | Field | Value |
 |---|---|
-| Generator | `openai.OpenAIGenerator` |
-| URI | `openai/gpt-4o` |
+| Model Type | `openai.OpenAIGenerator` |
+| Model | `openai/gpt-4o` |
 | JSON Config | `{"api_base": "https://openrouter.ai/api/v1"}` |
 
 Set `OPENROUTER_API_KEY`.
@@ -47,8 +47,8 @@ Set `OPENROUTER_API_KEY`.
 
 | Field | Value |
 |---|---|
-| Generator | `litellm.LiteLLMGenerator` |
-| URI | `claude-3-5-sonnet-20241022` |
+| Model Type | `litellm.LiteLLMGenerator` |
+| Model | `claude-3-5-sonnet-20241022` |
 
 Set `ANTHROPIC_API_KEY`.
 
@@ -56,8 +56,8 @@ Set `ANTHROPIC_API_KEY`.
 
 | Field | Value |
 |---|---|
-| Generator | `azure.AzureOpenAIGenerator` |
-| URI | Your deployment name |
+| Model Type | `azure.AzureOpenAIGenerator` |
+| Model | Your deployment name |
 | JSON Config | `{"api_base": "https://YOUR_RESOURCE.openai.azure.com/"}` |
 
 Set `AZURE_API_KEY`.
@@ -66,8 +66,8 @@ Set `AZURE_API_KEY`.
 
 | Field | Value |
 |---|---|
-| Generator | `ollama.OllamaGenerator` |
-| URI | `llama3.2` (or any Ollama model name) |
+| Model Type | `ollama.OllamaGenerator` |
+| Model | `llama3.2` (or any Ollama model name) |
 
 No API key needed. Ollama must be accessible from within the Docker network. If running Ollama on your host machine, use `http://host.docker.internal:11434` as the base URL in your JSON config.
 
@@ -75,8 +75,8 @@ No API key needed. Ollama must be accessible from within the Docker network. If 
 
 | Field | Value |
 |---|---|
-| Generator | `huggingface.HFInferenceAPIGenerator` |
-| URI | `mistralai/Mixtral-8x7B-Instruct-v0.1` |
+| Model Type | `huggingface.HFInferenceAPIGenerator` |
+| Model | `mistralai/Mixtral-8x7B-Instruct-v0.1` |
 
 Set `HF_TOKEN`.
 
@@ -86,17 +86,17 @@ For any OpenAI-compatible HTTP endpoint:
 
 | Field | Value |
 |---|---|
-| Generator | `rest.RestGenerator` |
-| URI | `http://your-api-host/v1/chat/completions` |
+| Model Type | `rest.RestGenerator` |
+| Model | `http://your-api-host/v1/chat/completions` |
 
 ### Mock LLM (Testing)
 
 | Field | Value |
 |---|---|
-| Generator | `rest.RestGenerator` |
-| URI | `http://mock-llm:5000/vulnerable` |
+| Model Type | `rest.RestGenerator` |
+| Model | `http://mock-llm:9292/api/v1/mock_llm/chat` |
 
-The Mock LLM ships with the Docker Compose setup and requires no API keys. See [Mock LLM](./mock-llm) for details on all available endpoints.
+The Mock LLM ships with the Docker Compose setup and requires no API keys. See [Mock LLM](./mock-llm) for details on available modes.
 
 ## Per-Target API Keys
 


### PR DESCRIPTION
- Replace 'Generator'/'URI' field labels with 'Model Type'/'Model' to match the actual UI (first-scan.md, targets.md, mock-llm.md, core-concepts.md)
- Correct Mock LLM port from 5000 to 9292 across all docs
- Replace nonexistent /safe, /vulnerable, /mixed URL paths with the actual single endpoint /api/v1/mock_llm/chat and explain that mode is set via JSON body field or X-Mock-Mode header
- Fix 'Python Flask server' → 'Ruby Rack application' in mock-llm.md