### PR TITLE
fix(runtime): harden scanner execution paths and preserve variant report flows

### DIFF
--- a/app/controllers/admin/targets_controller.rb
+++ b/app/controllers/admin/targets_controller.rb
@@ -161,15 +161,10 @@ module Admin
         return
       end
 
-      # Validate URL format
-      begin
-        uri = URI.parse(url)
-        unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
-          render json: { error: "Invalid URL format. Please provide a valid HTTP/HTTPS URL." }, status: :bad_request
-          return
-        end
-      rescue URI::InvalidURIError
-        render json: { error: "Invalid URL format" }, status: :bad_request
+      # Validate URL format and SSRF safety
+      safety_result = UrlSafetyValidator.safe_url?(url, allow_localhost: UrlSafetyValidator.allow_localhost?)
+      unless safety_result.safe?
+        render json: { error: safety_result.error }, status: :bad_request
         return
       end
 
@@ -229,7 +224,7 @@ module Admin
     end
 
     def target_params
-      params.require(:target).permit(:name, :model_type, :model, :description, :json_config, :status, :target_type, :web_config)
+      params.require(:target).permit(:name, :model_type, :model, :description, :json_config, :target_type, :web_config)
     end
   end
 end

--- a/app/controllers/report_details_controller.rb
+++ b/app/controllers/report_details_controller.rb
@@ -1,8 +1,11 @@
 class ReportDetailsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [ :show ], if: :valid_pdf_token?
-  skip_before_action :set_tenant, only: [ :show ], if: :valid_pdf_token?
+  SHOW_INCLUDES = [ :target, :scan, probe_results: [ :probe, :detector ] ].freeze
+
+  skip_before_action :authenticate_user!, only: [ :show ]
+  skip_before_action :set_tenant, only: [ :show ]
+  before_action :authenticate_show, only: [ :show ]
+  before_action :set_show_tenant, only: [ :show ]
   before_action :set_report
-  before_action :set_tenant_from_report, only: [ :show ], if: :valid_pdf_token?
 
   def show
   end
@@ -60,7 +63,8 @@ class ReportDetailsController < ApplicationController
   private
 
   def set_report
-    @report = ReportDecorator.new(Report.find(params[:id]))
+    report = @_unscoped_report || Report.includes(*SHOW_INCLUDES).find(params[:id])
+    @report = ReportDecorator.new(report)
   end
 
   def pdf_filename
@@ -70,19 +74,33 @@ class ReportDetailsController < ApplicationController
   # Verify a short-lived signed token from the internal PDF renderer.
   # This allows the headless browser to access the report without a Devise session.
   def valid_pdf_token?
-    return false unless params[:pdf_token].present? && params[:pdf].present?
+    return @_valid_pdf_token if defined?(@_valid_pdf_token)
 
-    report_id = Rails.application.message_verifier("pdf").verify(
-      params[:pdf_token],
-      purpose: :pdf_render
-    )
-    report_id.to_s == params[:id].to_s
+    @_valid_pdf_token = if params[:pdf_token].present? && params[:pdf].present?
+      report_id = Rails.application.message_verifier("pdf").verify(
+        params[:pdf_token],
+        purpose: :pdf_render
+      )
+      report_id.to_s == params[:id].to_s
+    else
+      false
+    end
   rescue ActiveSupport::MessageVerifier::InvalidSignature
-    false
+    @_valid_pdf_token = false
   end
 
-  def set_tenant_from_report
-    report = Report.find(params[:id])
-    ActsAsTenant.current_tenant = report.company
+  def authenticate_show
+    return if valid_pdf_token?
+
+    redirect_to new_user_session_path unless current_user
+  end
+
+  def set_show_tenant
+    if valid_pdf_token?
+      @_unscoped_report = Report.includes(*SHOW_INCLUDES).find(params[:id])
+      ActsAsTenant.current_tenant = @_unscoped_report.company
+    else
+      set_tenant
+    end
   end
 end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -47,7 +47,7 @@ module ReportsHelper
 
     if probe_result.nil?
       "bg-zinc-800 text-zinc-500" # Gray - not run
-    elsif probe_result.passed > 0
+    elsif probe_result.any_detector_passed
       "bg-red-950 text-red-400" # Red - ran and detected (attack passed)
     else
       "bg-purple-950 text-purple-400" # Purple - ran but not detected (attack failed/blocked)

--- a/app/jobs/generate_variant_reports_job.rb
+++ b/app/jobs/generate_variant_reports_job.rb
@@ -25,8 +25,8 @@ class GenerateVariantReportsJob < ApplicationJob
   private
 
   def extract_passed_probes(report)
-    report.probe_results.includes(:probe).filter_map { |pr|
-      pr.probe&.full_name if pr.passed > 0 && pr.probe.present?
+    report.probe_results.where(any_detector_passed: true).includes(:probe).filter_map { |pr|
+      pr.probe&.full_name
     }.uniq
   end
 

--- a/app/models/output_server.rb
+++ b/app/models/output_server.rb
@@ -1,6 +1,10 @@
 class OutputServer < ApplicationRecord
   acts_as_tenant :company
 
+  encrypts :access_token, key_provider: Encryption::TenantKeyProvider.new
+  encrypts :api_key, key_provider: Encryption::TenantKeyProvider.new
+  encrypts :password, key_provider: Encryption::TenantKeyProvider.new
+
   # Known SIEM types (engine can extend via class attribute)
   ALL_SIEM_TYPES = %w[splunk rsyslog].freeze
 

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -28,9 +28,13 @@ class Target < ApplicationRecord
     webchat: 1
   }
 
+  MODEL_FORMAT = /\A[a-zA-Z0-9\-_\/.:@]+\z/
+
   validates :name, presence: true, uniqueness: { scope: :company_id }
   validates :model_type, presence: true, if: :api?
+  validates :model_type, inclusion: { in: INVERTED_MODEL_TYPES.keys, message: "%{value} is not a recognized generator type" }, if: -> { api? && model_type.present? }
   validates :model, presence: true, if: :api?
+  validates :model, format: { with: MODEL_FORMAT, message: "contains invalid characters (only letters, numbers, hyphens, underscores, slashes, dots, colons, and @ are allowed)" }, if: -> { api? && model.present? }
   validate :json_config_is_valid_json, if: :json_config_should_be_validated?
   validate :web_config_is_valid, if: :webchat?
 
@@ -98,7 +102,8 @@ class Target < ApplicationRecord
   def parsed_web_config
     return nil if web_config.blank?
     web_config.is_a?(String) ? JSON.parse(web_config) : web_config
-  rescue JSON::ParserError
+  rescue JSON::ParserError => e
+    Rails.logger.warn("Target#parsed_web_config: invalid JSON for target #{id}: #{e.message}")
     nil
   end
 
@@ -193,9 +198,7 @@ class Target < ApplicationRecord
   end
 
   def valid_url?(url)
-    uri = URI.parse(url)
-    uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
-  rescue URI::InvalidURIError
-    false
+    result = UrlSafetyValidator.safe_url?(url, allow_localhost: UrlSafetyValidator.allow_localhost?)
+    result.safe?
   end
 end

--- a/app/models/threat_variant.rb
+++ b/app/models/threat_variant.rb
@@ -3,7 +3,7 @@ class ThreatVariant < ApplicationRecord
   belongs_to :threat_variant_subindustry
   has_one :threat_variant_industry, through: :threat_variant_subindustry
 
-  validates :prompt, presence: true
+  validates :prompt, presence: true, uniqueness: { scope: :probe_id }
 
   scope :by_industry, ->(industry) {
     joins(:threat_variant_subindustry)

--- a/app/policies/tenant_scoped_policy.rb
+++ b/app/policies/tenant_scoped_policy.rb
@@ -1,22 +1,7 @@
 # frozen_string_literal: true
 
-# Base policy for resources that are already scoped by ActsAsTenant.
-#
-# IMPORTANT: This policy relies on ActsAsTenant being properly configured:
-# - Models using this policy MUST have `acts_as_tenant :company`
-# - ApplicationController MUST call `set_current_tenant(current_user.company)`
-# - Tenant context MUST be set before any database queries
-#
-# With ActsAsTenant active, all queries are automatically scoped to the current
-# tenant (company), so Pundit permissions can be permissive - users can only
-# access records within their tenant by default.
-#
-# WARNING: If ActsAsTenant is bypassed (e.g., via `ActsAsTenant.without_tenant`),
-# these permissive defaults could expose data across tenants. Only bypass tenant
-# scoping in super_admin contexts with explicit authorization checks.
-#
-# Used by: Target, Scan, Report, EnvironmentVariable, OutputServer, Metadatum
-#
+# All tenant members have equal access to tenant-scoped resources.
+# Cross-tenant isolation is enforced by ActsAsTenant, not this policy.
 class TenantScopedPolicy < ApplicationPolicy
   def index?
     true

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -20,15 +20,14 @@ class UserPolicy < ApplicationPolicy
 
   def update?
     return true if super_admin?
-    return false if record.super_admin? # Can't edit super admins
-    same_company?
+    return false if record.super_admin?
+    record == user
   end
 
   def destroy?
     return false if record == user # Can't delete self
     return false if record.super_admin? # Can't delete super admins
-    return true if super_admin?
-    same_company?
+    super_admin?
   end
 
   # Custom permissions

--- a/app/services/browser_automation/playwright_service.rb
+++ b/app/services/browser_automation/playwright_service.rb
@@ -18,18 +18,26 @@ module BrowserAutomation
       @temp_script = nil
     end
 
-    # Execute a block with a new page context
     def with_page(url = nil, options = {})
-      script = build_page_script(url, options)
-      execute_playwright_script(script)
+      validate_url_safety!(url) if url
+      script, data = build_page_script(url, options)
+      execute_playwright_script(script, data: data)
     end
 
-    # Take a screenshot of a URL
     def screenshot(url, output_path = nil, options = {})
+      validate_url_safety!(url)
       output_path ||= generate_screenshot_path
+
+      data = {
+        url: url,
+        output_path: output_path.to_s,
+        wait_until: options[:wait_until] || "networkidle",
+        type: options[:type] || "png"
+      }
 
       script = <<~JS
         const { chromium } = require('playwright');
+        const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
 
         (async () => {
           const browser = await chromium.launch({
@@ -39,22 +47,22 @@ module BrowserAutomation
 
           try {
             const context = await browser.newContext({
-              viewport: { width: #{options[:width] || 1920}, height: #{options[:height] || 1080} }
+              viewport: { width: #{(options[:width] || 1920).to_i}, height: #{(options[:height] || 1080).to_i} }
             });
             const page = await context.newPage();
 
-            await page.goto('#{url}', {
-              waitUntil: '#{options[:wait_until] || 'networkidle'}',
-              timeout: #{options[:timeout] || 30000}
+            await page.goto(__data.url, {
+              waitUntil: __data.wait_until,
+              timeout: #{(options[:timeout] || 30000).to_i}
             });
 
             await page.screenshot({
-              path: '#{output_path}',
-              fullPage: #{options[:full_page] || false},
-              type: '#{options[:type] || 'png'}'
+              path: __data.output_path,
+              fullPage: #{options[:full_page] == true},
+              type: __data.type
             });
 
-            console.log(JSON.stringify({ success: true, path: '#{output_path}' }));
+            console.log(JSON.stringify({ success: true, path: __data.output_path }));
           } catch (error) {
             console.error(JSON.stringify({ error: error.message }));
             process.exitCode = 1;
@@ -64,7 +72,7 @@ module BrowserAutomation
         })();
       JS
 
-      result = execute_playwright_script(script)
+      result = execute_playwright_script(script, data: data)
 
       if result["success"]
         output_path
@@ -73,16 +81,20 @@ module BrowserAutomation
       end
     end
 
-    # Generate a PDF from a URL
-    # Note: PDF generation requires Chromium (not available in Firefox)
     def generate_pdf(url, output_path = nil, options = {})
+      validate_url_safety!(url, allow_localhost: options[:allow_localhost])
       output_path ||= generate_pdf_path
 
-      # Escape single quotes in URL for JavaScript string
-      escaped_url = url.gsub("'", "\\\\'")
+      data = {
+        url: url,
+        output_path: output_path.to_s,
+        wait_until: options[:wait_until] || "load",
+        format: options[:format] || "A4"
+      }
 
       script = <<~JS
         const { chromium } = require('playwright');
+        const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
 
         (async () => {
           const browser = await chromium.launch({
@@ -97,23 +109,23 @@ module BrowserAutomation
 
           try {
             const context = await browser.newContext({
-              viewport: { width: #{options[:width] || 1200}, height: #{options[:height] || 1600} }
+              viewport: { width: #{(options[:width] || 1200).to_i}, height: #{(options[:height] || 1600).to_i} }
             });
             const page = await context.newPage();
 
-            await page.goto('#{escaped_url}', {
-              waitUntil: '#{options[:wait_until] || 'load'}',
-              timeout: #{options[:timeout] || 30000}
+            await page.goto(__data.url, {
+              waitUntil: __data.wait_until,
+              timeout: #{(options[:timeout] || 30000).to_i}
             });
 
             await page.pdf({
-              path: '#{output_path}',
-              format: '#{options[:format] || 'A4'}',
-              printBackground: #{options[:print_background] || true},
-              preferCSSPageSize: #{options[:prefer_css_page_size] || true}
+              path: __data.output_path,
+              format: __data.format,
+              printBackground: #{options.fetch(:print_background, true) == true},
+              preferCSSPageSize: #{options.fetch(:prefer_css_page_size, true) == true}
             });
 
-            console.log(JSON.stringify({ success: true, path: '#{output_path}' }));
+            console.log(JSON.stringify({ success: true, path: __data.output_path }));
           } catch (error) {
             console.error(JSON.stringify({ error: error.message }));
             process.exitCode = 1;
@@ -123,7 +135,7 @@ module BrowserAutomation
         })();
       JS
 
-      result = execute_playwright_script(script)
+      result = execute_playwright_script(script, data: data)
 
       if result["success"]
         output_path
@@ -132,8 +144,8 @@ module BrowserAutomation
       end
     end
 
-    # Validate webchat config by testing it with a real message
     def validate_webchat_config(url, config)
+      validate_url_safety!(url)
       selectors = config[:selectors] || config["selectors"]
       wait_times = config[:wait_times] || config["wait_times"] || {}
 
@@ -142,9 +154,20 @@ module BrowserAutomation
       container_selector = selectors[:response_container] || selectors["response_container"]
 
       test_message = "Hello"
+      page_load_timeout = (wait_times[:page_load] || wait_times["page_load"] || 30000).to_i
+      response_timeout = (wait_times[:response] || wait_times["response"] || 5000).to_i
+
+      data = {
+        url: url,
+        input_selector: input_selector,
+        container_selector: container_selector,
+        send_selector: (send_selector.present? && send_selector != "null") ? send_selector : nil,
+        test_message: test_message
+      }
 
       script = <<~JS
         const { chromium } = require('playwright');
+        const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
 
         (async () => {
           const browser = await chromium.launch({
@@ -158,72 +181,62 @@ module BrowserAutomation
             });
             const page = await context.newPage();
 
-            // Navigate to page
-            await page.goto('#{url}', {
+            await page.goto(__data.url, {
               waitUntil: 'domcontentloaded',
-              timeout: #{wait_times[:page_load] || 30000}
+              timeout: #{page_load_timeout}
             });
 
-            // PHASE 2: Smart Wait Strategy - Use network idle with fallback
             try {
               await page.waitForLoadState('networkidle', { timeout: 15000 });
             } catch (error) {
-              // Network idle timeout - SPA may have continuous network activity
-              // Fall back to fixed wait
               await page.waitForTimeout(3000);
             }
 
             const errors = [];
 
-            // PHASE 2: Element-based wait for input field (visible + enabled)
             try {
-              await page.waitForSelector('#{input_selector.gsub("'", "\\\\'")}', {
+              await page.waitForSelector(__data.input_selector, {
                 state: 'visible',
                 timeout: 15000
               });
 
-              // Wait for input to be enabled (not disabled)
               await page.waitForFunction(
                 (selector) => {
                   const el = document.querySelector(selector);
                   return el && !el.disabled && !el.readOnly;
                 },
-                '#{input_selector.gsub("'", "\\\\'")}',
+                __data.input_selector,
                 { timeout: 5000 }
               );
             } catch (error) {
-              errors.push('Input field not ready: #{input_selector} - ' + error.message);
+              errors.push('Input field not ready: ' + __data.input_selector + ' - ' + error.message);
             }
 
-            // Check if input field exists and is visible
-            const inputField = page.locator('#{input_selector.gsub("'", "\\\\'")}');
+            const inputField = page.locator(__data.input_selector);
             const inputCount = await inputField.count();
 
             if (inputCount === 0) {
-              errors.push('Input field not found: #{input_selector}');
+              errors.push('Input field not found: ' + __data.input_selector);
             } else if (!await inputField.first().isVisible()) {
-              errors.push('Input field not visible: #{input_selector}');
+              errors.push('Input field not visible: ' + __data.input_selector);
             }
 
-            // PHASE 2: Element-based wait for response container
             try {
-              await page.waitForSelector('#{container_selector.gsub("'", "\\\\'")}', {
+              await page.waitForSelector(__data.container_selector, {
                 state: 'attached',
                 timeout: 15000
               });
             } catch (error) {
-              errors.push('Response container not ready: #{container_selector} - ' + error.message);
+              errors.push('Response container not ready: ' + __data.container_selector + ' - ' + error.message);
             }
 
-            // Check if response container exists
-            const responseContainer = page.locator('#{container_selector.gsub("'", "\\\\'")}');
+            const responseContainer = page.locator(__data.container_selector);
             const containerCount = await responseContainer.count();
 
             if (containerCount === 0) {
-              errors.push('Response container not found: #{container_selector}');
+              errors.push('Response container not found: ' + __data.container_selector);
             }
 
-            // If we have errors already, bail early
             if (errors.length > 0) {
               console.log(JSON.stringify({
                 success: false,
@@ -234,26 +247,22 @@ module BrowserAutomation
               return;
             }
 
-            // Get baseline chat history
             const baselineHistory = await responseContainer.first().textContent();
 
-            // PHASE 2: Retry logic with exponential backoff for message sending
             let retryDelay = 1000;
             let messageSent = false;
             let lastError = null;
 
             for (let attempt = 0; attempt < 3; attempt++) {
               try {
-                // Fill input field
-                await inputField.first().fill('#{test_message}');
+                await inputField.first().fill(__data.test_message);
                 await page.waitForTimeout(500);
 
-                // Send message
-                #{if send_selector.present? && send_selector != "null"
-                    "await page.click('#{send_selector.gsub("'", "\\\\'")}');"
-                  else
-                    "await inputField.first().press('Enter');"
-                  end}
+                if (__data.send_selector) {
+                  await page.click(__data.send_selector);
+                } else {
+                  await inputField.first().press('Enter');
+                }
 
                 messageSent = true;
                 break;
@@ -261,7 +270,7 @@ module BrowserAutomation
                 lastError = error;
                 if (attempt < 2) {
                   await page.waitForTimeout(retryDelay);
-                  retryDelay *= 2; // 1s, 2s, 4s
+                  retryDelay *= 2;
                 }
               }
             }
@@ -277,13 +286,11 @@ module BrowserAutomation
               return;
             }
 
-            // Wait for response
-            await page.waitForTimeout(#{wait_times[:response] || 5000});
+            await page.waitForTimeout(#{response_timeout});
 
-            // Check if content changed
             const newHistory = await responseContainer.first().textContent();
             const contentChanged = newHistory !== baselineHistory;
-            const testMessagePresent = newHistory.includes('#{test_message}');
+            const testMessagePresent = newHistory.includes(__data.test_message);
 
             console.log(JSON.stringify({
               success: true,
@@ -306,7 +313,7 @@ module BrowserAutomation
         })();
       JS
 
-      result = execute_playwright_script(script)
+      result = execute_playwright_script(script, data: data)
 
       if result && result["success"]
         {
@@ -326,10 +333,16 @@ module BrowserAutomation
       end
     end
 
-    # Extract DOM structure for LLM analysis
     def extract_page_structure(url, options = {})
+      validate_url_safety!(url)
+      data = {
+        url: url,
+        user_agent: options[:user_agent] || "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+      }
+
       script = <<~JS
         const { chromium } = require('playwright');
+        const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
 
         (async () => {
           const browser = await chromium.launch({
@@ -339,26 +352,22 @@ module BrowserAutomation
 
           try {
             const context = await browser.newContext({
-              viewport: { width: #{options[:width] || 1920}, height: #{options[:height] || 1080} },
-              userAgent: '#{options[:user_agent] || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'}'
+              viewport: { width: #{(options[:width] || 1920).to_i}, height: #{(options[:height] || 1080).to_i} },
+              userAgent: __data.user_agent
             });
             const page = await context.newPage();
 
-            await page.goto('#{url}', {
+            await page.goto(__data.url, {
               waitUntil: 'domcontentloaded',
-              timeout: #{options[:timeout] || 15000}
+              timeout: #{(options[:timeout] || 15000).to_i}
             });
 
-            // PHASE 2: Smart Wait Strategy - Use network idle with fallback
             try {
               await page.waitForLoadState('networkidle', { timeout: 15000 });
             } catch (error) {
-              // Network idle timeout - SPA may have continuous network activity
-              // Fall back to fixed wait
               await page.waitForTimeout(8000);
             }
 
-            // Extract DOM elements with semantic attributes
             const domElements = await page.evaluate(() => {
               const elements = {
                 inputs: [],
@@ -367,37 +376,31 @@ module BrowserAutomation
                 iframes: []
               };
 
-              // Simple visibility check
               function isVisible(el) {
                 const rect = el.getBoundingClientRect();
                 return rect.width > 0 && rect.height > 0;
               }
 
-              // Filter out framework-generated dynamic classes that change on each page load
               function isStableClass(className) {
                 if (!className) return false;
 
-                // Patterns for unstable framework-generated classes
                 const unstablePatterns = [
-                  /^ng-/,           // Angular (.ng-tns-*, .ng-star-inserted, .ng-trigger)
-                  /_[a-z0-9]{5,}/,  // CSS modules (_a3k2f, _3kf2a)
-                  /^jsx-/,          // Styled-jsx (.jsx-1234567)
-                  /^css-/,          // Emotion/styled-components (.css-abc123)
-                  /^sc-/,           // Styled-components (.sc-hash)
-                  /-c\d{8,}-/,      // Angular component IDs (-c3371048223-)
-                  /^MuiBox-root-/,  // Material-UI dynamic classes
-                  /^makeStyles-/    // Material-UI makeStyles
+                  /^ng-/,
+                  /_[a-z0-9]{5,}/,
+                  /^jsx-/,
+                  /^css-/,
+                  /^sc-/,
+                  /-c\d{8,}-/,
+                  /^MuiBox-root-/,
+                  /^makeStyles-/
                 ];
 
                 return !unstablePatterns.some(pattern => pattern.test(className));
               }
 
-              // Enhanced selector generation with semantic attributes and stable class filtering
               function getSelector(el) {
-                // Priority 1: Unique ID (but only if stable)
                 if (el.id && isStableClass(el.id)) return '#' + el.id;
 
-                // Priority 2: Semantic attributes (role, data-testid)
                 if (el.getAttribute('role')) {
                   return '[role="' + el.getAttribute('role') + '"]';
                 }
@@ -405,7 +408,6 @@ module BrowserAutomation
                   return '[data-testid="' + el.getAttribute('data-testid') + '"]';
                 }
 
-                // Priority 3: STABLE classes only (filter out framework-generated dynamic classes)
                 if (el.className && typeof el.className === 'string') {
                   const stableClasses = el.className.trim()
                     .split(/\s+/)
@@ -416,17 +418,14 @@ module BrowserAutomation
                   }
                 }
 
-                // Priority 4: aria-label
                 if (el.getAttribute('aria-label')) {
                   const label = el.getAttribute('aria-label').substring(0, 30);
                   return el.tagName.toLowerCase() + '[aria-label="' + label + '"]';
                 }
 
-                // Fallback: tag name
                 return el.tagName.toLowerCase();
               }
 
-              // Extract semantic attributes
               function getSemanticAttributes(el) {
                 return {
                   role: el.getAttribute('role') || '',
@@ -436,7 +435,6 @@ module BrowserAutomation
                 };
               }
 
-              // Find inputs with semantic attributes
               const inputSelectors = 'input[type="text"], textarea, [contenteditable="true"], [role="textbox"]';
               document.querySelectorAll(inputSelectors).forEach(el => {
                 if (isVisible(el)) {
@@ -454,7 +452,6 @@ module BrowserAutomation
                 }
               });
 
-              // Find buttons with semantic attributes
               const buttonSelectors = 'button, input[type="submit"], [role="button"]';
               document.querySelectorAll(buttonSelectors).forEach(el => {
                 if (isVisible(el)) {
@@ -462,7 +459,7 @@ module BrowserAutomation
                   const text = el.innerText || el.value || '';
                   elements.buttons.push({
                     selector: getSelector(el),
-                    text: text, // Full text, not truncated
+                    text: text,
                     id: el.id || '',
                     classes: el.className || '',
                     role: attrs.role,
@@ -472,7 +469,6 @@ module BrowserAutomation
                 }
               });
 
-              // Find containers with semantic attributes
               const containerSelectors = 'div, main, section, [role="main"], [role="region"], [role="log"]';
               document.querySelectorAll(containerSelectors).forEach(el => {
                 const rect = el.getBoundingClientRect();
@@ -489,7 +485,6 @@ module BrowserAutomation
                 }
               });
 
-              // Find iframes
               document.querySelectorAll('iframe').forEach(el => {
                 elements.iframes.push({
                   selector: getSelector(el),
@@ -507,7 +502,6 @@ module BrowserAutomation
               };
             });
 
-            // Capture screenshot as Base64
             const screenshotBuffer = await page.screenshot({
               type: 'png',
               fullPage: false
@@ -533,7 +527,7 @@ module BrowserAutomation
         })();
       JS
 
-      result = execute_playwright_script(script)
+      result = execute_playwright_script(script, data: data)
 
       if result && result["success"]
         result["data"]
@@ -544,12 +538,19 @@ module BrowserAutomation
       end
     end
 
-    # Stop any running browser processes
     def stop_browser
       @mutex.synchronize do
         if @browser_process
-          Process.kill("TERM", @browser_process) rescue nil
-          Process.wait(@browser_process) rescue nil
+          begin
+            Process.kill("TERM", @browser_process)
+          rescue Errno::ESRCH, Errno::ECHILD => e
+            Rails.logger.warn "PlaywrightService: failed to kill process #{@browser_process}: #{e.message}"
+          end
+          begin
+            Process.wait(@browser_process)
+          rescue Errno::ESRCH, Errno::ECHILD => e
+            Rails.logger.warn "PlaywrightService: failed to wait on process #{@browser_process}: #{e.message}"
+          end
           @browser_process = nil
           @browser_ready = false
         end
@@ -560,21 +561,33 @@ module BrowserAutomation
 
     private
 
-    def execute_playwright_script(script)
+    def validate_url_safety!(url, allow_localhost: nil)
+      allow = allow_localhost.nil? ? UrlSafetyValidator.allow_localhost? : allow_localhost
+      result = UrlSafetyValidator.safe_url?(url, allow_localhost: allow)
+      raise ArgumentError, "SSRF protection: #{result.error}" unless result.safe?
+    end
+
+    def execute_playwright_script(script, data: nil)
       @mutex.synchronize do
+        data_file = nil
         begin
-          # Create temporary script file
+          if data
+            data_file = Tempfile.new([ "playwright_data", ".json" ], Rails.root.join("tmp"))
+            data_file.write(JSON.generate(data))
+            data_file.close
+          end
+
           temp_file = Tempfile.new([ "playwright_script", ".cjs" ], Rails.root.join("tmp"))
           temp_file.write(script)
           temp_file.close
 
-          # Execute script with Node.js, setting NODE_PATH to find modules
           env = {
             "NODE_PATH" => Rails.root.join("node_modules").to_s
           }
+          env["PLAYWRIGHT_DATA_PATH"] = data_file.path if data_file
+
           output, error, status = Open3.capture3(env, "node", temp_file.path)
 
-          # Helper to pull a JSON object from text by scanning lines
           extract_json = lambda do |text|
             next nil unless text && !text.empty?
             line = text.lines.reverse.find { |l| (s = l.strip).start_with?("{") && s.end_with?("}") }
@@ -584,7 +597,6 @@ module BrowserAutomation
           end
 
           if status.success?
-            # Prefer stdout JSON; do not fail silently—include stderr/stdout if missing
             result = extract_json.call(output)
             if result
               result
@@ -594,7 +606,6 @@ module BrowserAutomation
               { "error" => "No JSON found in output (stdout/stderr attached)", "stdout" => output.to_s[0, 4000], "stderr" => error.to_s[0, 4000] }
             end
           else
-            # On non-zero exit, try to parse structured error emitted via console.error(JSON.stringify(...))
             result = extract_json.call(error)
             if result
               result
@@ -606,31 +617,36 @@ module BrowserAutomation
           end
         ensure
           temp_file&.unlink
+          data_file&.unlink
         end
       end
     end
 
     def build_page_script(url, options)
-      <<~JS
+      data = {
+        url: url,
+        wait_until: options[:wait_until] || "networkidle"
+      }
+
+      script = <<~JS
         const { chromium } = require('playwright');
+        const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
 
         (async () => {
           const browser = await chromium.launch({
-            headless: #{options[:headless] != false},
-            firefoxUserPrefs: {
-              'security.sandbox.content.level': 0
-            }
+            headless: #{options[:headless] != false}
           });
 
           try {
             const context = await browser.newContext({
-              viewport: { width: #{options[:width] || 1920}, height: #{options[:height] || 1080} }
+              viewport: { width: #{(options[:width] || 1920).to_i}, height: #{(options[:height] || 1080).to_i} }
             });
             const page = await context.newPage();
 
-            #{url ? "await page.goto('#{url}', { waitUntil: '#{options[:wait_until] || 'networkidle'}' });" : '// No URL provided'}
+            if (__data.url) {
+              await page.goto(__data.url, { waitUntil: __data.wait_until });
+            }
 
-            // Custom code execution would go here
             console.log(JSON.stringify({ success: true }));
           } catch (error) {
             console.error(JSON.stringify({ error: error.message }));
@@ -640,6 +656,8 @@ module BrowserAutomation
           }
         })();
       JS
+
+      [ script, data ]
     end
 
     def generate_screenshot_path
@@ -657,8 +675,10 @@ module BrowserAutomation
     end
 
     def cleanup_temp_files
-      # Clean up any temporary files if needed
-      @temp_script&.unlink rescue nil
+      @temp_script&.unlink
+    rescue Errno::ENOENT, Errno::EACCES => e
+      Rails.logger.warn "PlaywrightService: failed to unlink temp script: #{e.message}"
+    ensure
       @temp_script = nil
     end
   end

--- a/app/services/output_servers/connection_test.rb
+++ b/app/services/output_servers/connection_test.rb
@@ -18,6 +18,9 @@ module OutputServers
     def call
       return { success: false, message: "Integration is not enabled" } unless output_server.enabled?
 
+      safety = validate_host_safety
+      return safety unless safety.nil?
+
       case output_server.server_type
       when "splunk"
         test_splunk
@@ -36,12 +39,36 @@ module OutputServers
 
     private
 
+    def validate_host_safety
+      result = UrlSafetyValidator.safe_host?(output_server.host, allow_localhost: UrlSafetyValidator.allow_localhost?)
+      return { success: false, message: "Connection blocked: #{result.error}" } unless result.safe?
+
+      @pinned_ip = result.resolved_ips&.first
+
+      url = output_server.connection_string
+      begin
+        parsed_host = URI.parse(url).host
+      rescue URI::InvalidURIError
+        return { success: false, message: "Connection blocked: constructed URL is invalid" }
+      end
+      if parsed_host && parsed_host != output_server.host
+        url_result = UrlSafetyValidator.safe_host?(parsed_host, allow_localhost: UrlSafetyValidator.allow_localhost?)
+        return { success: false, message: "Connection blocked: constructed URL resolves to a different host" } unless url_result.safe?
+      end
+
+      nil
+    end
+
+    def connection_host
+      @pinned_ip || output_server.host
+    end
+
     def test_splunk
       base_url = output_server.connection_string
       base_url += "/services/collector/event" unless output_server.endpoint_path.present?
       uri = URI.parse(base_url)
 
-      http = Net::HTTP.new(uri.host, uri.port)
+      http = Net::HTTP.new(connection_host, uri.port)
       http.use_ssl = (output_server.protocol == "https")
       http.open_timeout = 10
       http.read_timeout = 10
@@ -88,32 +115,38 @@ module OutputServers
 
     def test_rsyslog_udp
       socket = UDPSocket.new
-      socket.send(test_syslog_message, 0, output_server.host, output_server.port || 514)
-      socket.close
+      socket.send(test_syslog_message, 0, connection_host, output_server.port || 514)
       { success: true, message: "Successfully sent test message via UDP to #{output_server.host}:#{output_server.port || 514}" }
+    ensure
+      safe_close(socket)
     end
 
     def test_rsyslog_tcp
-      socket = TCPSocket.new(output_server.host, output_server.port || 514)
+      socket = TCPSocket.new(connection_host, output_server.port || 514)
       socket.puts(test_syslog_message)
-      socket.close
       { success: true, message: "Successfully connected via TCP to #{output_server.host}:#{output_server.port || 514}" }
+    ensure
+      safe_close(socket)
     end
 
     def test_rsyslog_tls
-      tcp = TCPSocket.new(output_server.host, output_server.port || 6514)
+      tcp = TCPSocket.new(connection_host, output_server.port || 6514)
       ctx = OpenSSL::SSL::SSLContext.new
+      ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      ctx.cert_store = OpenSSL::X509::Store.new.tap(&:set_default_paths)
       ssl = OpenSSL::SSL::SSLSocket.new(tcp, ctx)
+      ssl.hostname = output_server.host
       ssl.connect
       ssl.puts(test_syslog_message)
-      ssl.close
-      tcp.close
       { success: true, message: "Successfully connected via TLS to #{output_server.host}:#{output_server.port || 6514}" }
+    ensure
+      safe_close(ssl)
+      safe_close(tcp)
     end
 
     def test_rsyslog_http
       uri = URI.parse(output_server.connection_string)
-      http = Net::HTTP.new(uri.host, uri.port)
+      http = Net::HTTP.new(connection_host, uri.port)
       http.use_ssl = (output_server.protocol == "https")
       http.open_timeout = 10
       http.read_timeout = 10
@@ -147,6 +180,12 @@ module OutputServers
       when :basic
         request.basic_auth(output_server.username, output_server.password)
       end
+    end
+
+    def safe_close(io)
+      io&.close
+    rescue IOError, Errno::EBADF
+      # already closed or invalid descriptor
     end
 
     def test_syslog_message

--- a/app/services/reports/pdf_generator.rb
+++ b/app/services/reports/pdf_generator.rb
@@ -39,7 +39,8 @@ module Reports
             format: "A4",
             print_background: true,
             prefer_css_page_size: true,
-            timeout: 20000
+            timeout: 20000,
+            allow_localhost: true
           }
         )
 

--- a/app/services/reports/process.rb
+++ b/app/services/reports/process.rb
@@ -65,16 +65,23 @@ module Reports
             next
           end
 
-          process_method = "process_#{data['entry_type']}"
-          if respond_to?(process_method, true)
-            send(process_method, data)
-            valid_lines += 1
-            processed = true
-
-            # Track if we've processed attempts and evals
-            attempts_processed = true if data["entry_type"] == "attempt"
-            evals_processed = true if data["entry_type"] == "eval"
+          case data["entry_type"]
+          when "init"
+            process_init(data)
+          when "attempt"
+            process_attempt(data)
+            attempts_processed = true
+          when "eval"
+            process_eval(data)
+            evals_processed = true
+          when "completion"
+            process_completion(data)
+          else
+            next
           end
+
+          valid_lines += 1
+          processed = true
         rescue JSON::ParserError => e
           # Log the error but continue processing other lines
           Rails.logger.error "Report #{report.id}: JSON parse error on line #{line_number}: #{e.message}"
@@ -89,21 +96,20 @@ module Reports
 
       # Mark as completed only if we processed attempts AND evals AND created probe results.
       # Having attempts but no evals indicates a malformed report (garak exited early).
-      # Having evals but no probe_results means all probes were unknown/skipped.
+      # Having evals but no probe_results means all probes were unknown/skipped — treat as failed
+      # so operators see the drift between the runtime probe catalog and the database.
       if !attempts_processed
         Rails.logger.warn "Report #{report.id}: No attempts found in report, marking as failed"
         report.status = :failed
       elsif !evals_processed
         Rails.logger.warn "Report #{report.id}: Attempts found but no eval results - scan may have been interrupted, marking as failed"
         report.status = :failed
-      elsif processed && valid_lines > 0 && report.probe_results.exists?
+      elsif processed && valid_lines > 0 && @probe_results_saved_this_run
         report.status = :completed
       else
         Rails.logger.warn "Report #{report.id}: No probe results created despite processing lines, marking as failed"
         report.status = :failed
       end
-      # Note: logs, save, and save_detector_results are handled by callers
-      # (process_from_database or process_from_file)
     end
 
     def save_detector_results
@@ -150,49 +156,42 @@ module Reports
       passed = total - data["passed"].to_i
       max_score = report_data.dig(probe_classname, "stats", "max_score")
 
-      # Resolve the probe from the classname, passing detector to disambiguate
-      # variant probes with shared class names (base + CM probe pairs)
-      resolved_list = resolve_probe(probe_classname, detector_name)
-      return if resolved_list.all? { |r| r[:skip] }
+      # Resolve the probe from the classname (cached to avoid repeated queries)
+      resolved = resolve_probe(probe_classname)
+      if resolved[:skip]
+        report_data.delete(probe_classname)
+        return
+      end
 
+      # Use find_or_initialize_by to handle resumed scans where
+      # probe_results may already exist from a previous partial processing run
+      probe_result = report.probe_results.find_or_initialize_by(
+        probe_id: resolved[:probe_id],
+        threat_variant_id: resolved[:variant]&.id
+      )
       attempts_data = report_data.dig(probe_classname, "attempts")
-      token_estimate = nil
+      if attempts_data.present?
+        probe_result.attempts = attempts_data
+        token_estimate = TokenEstimator.estimate_from_attempts(probe_result.attempts)
+        probe_result.input_tokens = token_estimate[:input_tokens]
+        probe_result.output_tokens = token_estimate[:output_tokens]
+      end
+
+      probe_result.max_score = max_score unless max_score.nil?
+
+      # Multi-detector: keep the max passed across detectors; new_record?
+      # ensures first eval always sets the detector even when passed=0.
       detector_id = find_or_create_detector(detector_name).id
-
-      # Create a ProbeResult for each resolved probe
-      tokens_assigned = false
-      resolved_list.each do |resolved|
-        next if resolved[:skip]
-
-        # Use find_or_initialize_by to handle resumed scans where
-        # probe_results may already exist from a previous partial processing run
-        probe_result = report.probe_results.find_or_initialize_by(
-          probe_id: resolved[:probe_id],
-          threat_variant_id: resolved[:variant]&.id
-        )
-        probe_result.attempts = attempts_data if attempts_data.present?
-
-        # Assign tokens only to the first result to avoid inflating totals
-        if !tokens_assigned
-          token_estimate ||= TokenEstimator.estimate_from_attempts(probe_result.attempts)
-          probe_result.input_tokens = token_estimate[:input_tokens]
-          probe_result.output_tokens = token_estimate[:output_tokens]
-          tokens_assigned = true
-        else
-          probe_result.input_tokens = 0
-          probe_result.output_tokens = 0
-        end
-
-        probe_result.max_score = max_score
+      if passed > probe_result.passed.to_i || probe_result.new_record?
         probe_result.passed = passed
         probe_result.total = total
         probe_result.detector_id = detector_id
-        probe_result.save!
       end
-
+      probe_result.any_detector_passed ||= passed.positive?
+      probe_result.save!
+      @probe_results_saved_this_run = true
       report_data.delete(probe_classname)
 
-      # Count detector stats once per eval line (not per resolved probe)
       detector_stats[detector_name] ||= { passed: 0, total: 0 }
       detector_stats[detector_name][:passed] += passed
       detector_stats[detector_name][:total] += total
@@ -202,57 +201,69 @@ module Reports
       end
     end
 
-    # Resolves a probe classname to an array of { probe_id:, variant:, skip: } hashes.
-    def resolve_probe(probe_classname, detector_name = nil)
+    # Resolves a probe classname to a probe_id and optional variant.
+    # Tries full classname first, then falls back to last segment for 0din probes.
+    # Skips unknown probes with a warning.
+    def resolve_probe(probe_classname)
+      @resolved_probes ||= {}
+      return @resolved_probes[probe_classname] if @resolved_probes.key?(probe_classname)
+
+      result = resolve_probe_uncached(probe_classname)
+      @resolved_probes[probe_classname] = result
+    end
+
+    def resolve_probe_uncached(probe_classname)
+      # Variant probes: runtime emits "0din_variants.<VariantPrompt>" (see
+      # script/garak_plugins/probes/0din_variants.py and VariantProbeMapper).
+      # Map the variant prompt back to its base probe via ThreatVariant.
       if probe_classname.start_with?("0din_variants.")
-        return resolve_variant_probe(probe_classname, detector_name)
+        variant_prompt = probe_classname.split(".", 2).last
+
+        scope = ThreatVariant.where(prompt: variant_prompt)
+        scope = scope.where(probe_id: variant_probe_ids) if variant_probe_ids&.any?
+        # Order deterministically — prompts are unique per probe at the DB level,
+        # but the same prompt can exist across probes. Fall back to a stable pick
+        # and warn so operators see any future data drift.
+        matches = scope.order(:probe_id, :id).limit(2).to_a
+        variant = matches.first
+
+        unless variant
+          Rails.logger.warn("Report #{report.id}: Unknown variant probe: #{variant_prompt}, skipping")
+          return { probe_id: nil, variant: nil, skip: true }
+        end
+
+        if matches.size > 1
+          Rails.logger.warn("Report #{report.id}: Ambiguous variant prompt #{variant_prompt} matches multiple ThreatVariants; picked probe_id=#{variant.probe_id}")
+        end
+
+        return { probe_id: variant.probe_id, variant: variant }
       end
 
-      probe_name = probe_classname
-      probe_id = Probe.where(name: probe_name).limit(1).pluck(:id).first
+      # Standard probes: try full classname, then fall back to last segment
+      # for any dotted name (e.g., "0din.Foo" → "Foo", "dan.DAN_Jailbreak" → "DAN_Jailbreak").
+      probe_id = Probe.where(name: probe_classname).limit(1).pluck(:id).first
       if probe_id.nil? && probe_classname.include?(".")
         probe_name = probe_classname.split(".").last
         probe_id = Probe.where(name: probe_name).limit(1).pluck(:id).first
       end
+
       if probe_id.nil?
-        Rails.logger.warn("[Reports::Process] Unknown probe classname: #{probe_classname}, skipping")
-        return [ { probe_id: nil, variant: nil, skip: true } ]
-      end
-      [ { probe_id: probe_id, variant: nil } ]
-    end
-
-    def resolve_variant_probe(probe_classname, detector_name = nil)
-      variant_class_name = probe_classname.split(".").last
-
-      variants = if report.is_variant_report? && report.variant_probes.any?
-        ThreatVariant.where(prompt: variant_class_name, probe_id: report.variant_probes.select(:id)).to_a
-      else
-        ThreatVariant.where(prompt: variant_class_name).to_a
+        Rails.logger.warn("Report #{report.id}: Unknown probe classname: #{probe_classname}, skipping")
+        return { probe_id: nil, variant: nil, skip: true }
       end
 
-      if variants.empty?
-        Rails.logger.warn("[Reports::Process] Unknown variant probe: #{variant_class_name}, skipping")
-        return [ { probe_id: nil, variant: nil, skip: true } ]
-      end
-
-      # When multiple variants match (base + CM probe pairs sharing a class name),
-      # filter to the variant whose probe uses the matching detector. The garak
-      # variant plugin evaluates with a single detector per run, so fanning out
-      # to probes with a different detector would fabricate incorrect results.
-      if variants.size > 1 && detector_name.present?
-        detector = Detector.find_by(name: detector_name)
-        if detector
-          matching = variants.select { |v| v.probe.detector_id == detector.id }
-          variants = matching if matching.any?
-        end
-      end
-
-      variants.map { |v| { probe_id: v.probe_id, variant: v } }
+      { probe_id: probe_id, variant: nil }
     end
 
     def find_or_create_detector(detector_name)
       @detectors ||= {}
       @detectors[detector_name] ||= Detector.find_or_create_by(name: detector_name)
+    end
+
+    def variant_probe_ids
+      return @variant_probe_ids if defined?(@variant_probe_ids)
+
+      @variant_probe_ids = report.is_variant_report? ? report.variant_probes.pluck(:id) : nil
     end
 
     # Refine target's tokens_per_second using weighted average from actual report data
@@ -292,12 +303,22 @@ module Reports
         report_data.clear
         return
       end
-      report.start_time = Time.parse(data["start_time"]) rescue nil
+      begin
+        report.start_time = Time.parse(data["start_time"])
+      rescue ArgumentError, TypeError => e
+        Rails.logger.warn("Report #{report.id}: invalid start_time '#{data['start_time']}': #{e.message}")
+        report.start_time = nil
+      end
       report.save! if report.start_time_changed?
     end
 
     def process_completion(data)
-      report.end_time = Time.parse(data["end_time"]) rescue nil
+      begin
+        report.end_time = Time.parse(data["end_time"])
+      rescue ArgumentError, TypeError => e
+        Rails.logger.warn("Report #{report.id}: invalid end_time '#{data['end_time']}': #{e.message}")
+        report.end_time = nil
+      end
       report.save! if report.end_time_changed?
     end
 

--- a/app/services/run_command.rb
+++ b/app/services/run_command.rb
@@ -1,38 +1,61 @@
 class RunCommand
-  # Brief sleep to detect immediate process failures after launch.
-  # 0.5 seconds balances two goals:
-  # - Long enough to catch most immediate startup failures
-  # - Short enough to avoid noticeable delays in normal operation
-  PROCESS_START_DETECTION_DELAY = 0.5
+  class ImmediateExitError < StandardError
+    attr_reader :exit_status
 
-  attr_reader :command
-
-  def initialize(command)
-    @command = command
+    def initialize(exit_status, command_desc)
+      @exit_status = exit_status
+      super("Process exited immediately with status #{exit_status}: #{command_desc}")
+    end
   end
 
-  def call
-    stdout, stderr, status = Open3.capture3(command)
+  # Brief sleep to detect immediate process failures after launch.
+  PROCESS_START_DETECTION_DELAY = 0.5
+  REDACTED = "[REDACTED]"
+  SENSITIVE_FLAG_NAME = /\b(api[_-]?key|token|password|secret|access[_-]?token|auth[_-]?token|credential|authorization|bearer)\b/i
+  SENSITIVE_OUTPUT_PATTERN = /((?:api[_-]?key|token|password|secret|access[_-]?token|auth[_-]?token|credential|bearer|authorization|database[_-]?url|redis[_-]?url|secret[_-]?key[_-]?base)["']?\s*[=:]\s*["']?(?:(?:bearer|basic|splunk|negotiate|digest|token|bot)\s+)?)[^\s"',}\]&;]+/i
 
-    raise "Command failed with error: #{stderr}" unless status.success?
+  attr_reader :command, :env
+
+  def initialize(command, env: {})
+    @command = command
+    @env = env
+  end
+
+  def call(log_file: nil)
+    stdout, stderr, status = Open3.capture3(env, *command)
+
+    if log_file
+      FileUtils.mkdir_p(File.dirname(log_file))
+      File.open(log_file, "a") do |f|
+        f.write(sanitize_output(stdout, truncate: false))
+        f.write(sanitize_output(stderr, truncate: false))
+      end
+    end
+
+    raise "Command failed with error: #{sanitize_output(stderr)}" unless status.success?
 
     stdout
   end
 
-  def call_async
-    # Run through bash shell to handle env vars, pipes, and redirections
-    # Command string already includes env vars as prefix (e.g., "VAR=value command")
-    Rails.logger.info("RunCommand.call_async executing: #{sanitize_command_for_logging(command)}")
+  def call_async(log_file: nil)
+    Rails.logger.info("RunCommand.call_async executing: #{sanitize_for_logging}")
 
-    stdin, stdout, stderr, wait_thr = Open3.popen3("/bin/bash", "-c", command)
+    stdin, stdout, stderr, wait_thr = Open3.popen3(env, *command)
     stdin.close
 
-    # Spawn a thread to monitor stdout and log to Rails logger
-    # This makes process output visible in docker compose logs
-    Thread.new do
+    log_io = if log_file
+      FileUtils.mkdir_p(File.dirname(log_file))
+      File.open(log_file, "a")
+    end
+
+    stdout_thread = Thread.new do
       begin
         stdout.each_line do |line|
-          Rails.logger.info("Process: #{line.chomp}")
+          Rails.logger.info("Process: #{sanitize_output(line.chomp)}")
+          if log_io
+            log_io.write(sanitize_output(line, truncate: false))
+            log_io.flush
+          end
         end
       rescue => e
         Rails.logger.error("Error reading stdout: #{e.message}")
@@ -41,11 +64,14 @@ class RunCommand
       end
     end
 
-    # Spawn a thread to monitor stderr and log any errors
-    Thread.new do
+    stderr_thread = Thread.new do
       begin
         stderr.each_line do |line|
-          Rails.logger.error("Process stderr: #{line.chomp}")
+          Rails.logger.error("Process stderr: #{sanitize_output(line.chomp)}")
+          if log_io
+            log_io.write(sanitize_output(line, truncate: false))
+            log_io.flush
+          end
         end
       rescue => e
         Rails.logger.error("Error reading stderr: #{e.message}")
@@ -54,11 +80,24 @@ class RunCommand
       end
     end
 
-    # Brief sleep to detect immediate failures
+    if log_io
+      Thread.new do
+        stdout_thread.join
+        stderr_thread.join
+        log_io.close
+      end
+    end
+
     sleep PROCESS_START_DETECTION_DELAY
     if wait_thr.status == false || wait_thr.status.nil?
-      Rails.logger.error("Process exited immediately with status: #{wait_thr.value.exitstatus}")
-      Rails.logger.error("Command was: #{command}")
+      exit_status = wait_thr.value.exitstatus
+      if exit_status != 0
+        Rails.logger.error("Process exited immediately with status: #{exit_status}")
+        Rails.logger.error("Command was: #{sanitize_for_logging}")
+        stdout_thread.join(2)
+        stderr_thread.join(2)
+        raise ImmediateExitError.new(exit_status, sanitize_for_logging)
+      end
     else
       Rails.logger.info("Process started successfully with PID: #{wait_thr.pid}")
     end
@@ -68,26 +107,45 @@ class RunCommand
 
   private
 
-  def sanitize_command_for_logging(cmd)
-    # Mask sensitive environment variables (API keys, tokens, secrets)
-    sanitized = cmd.dup
+  def sanitize_for_logging
+    sanitized = redact_sensitive_args(command)
+    cmd_str = sanitized.join(" ")
+    cmd_str.length > 300 ? "#{cmd_str[0..297]}..." : cmd_str
+  end
 
-    # List of env var patterns to sanitize
-    sensitive_patterns = [
-      /([A-Z_]*API[_A-Z]*KEY=)[^\s]+/i,
-      /([A-Z_]*TOKEN[_A-Z]*=)[^\s]+/i,
-      /([A-Z_]*SECRET[_A-Z]*=)[^\s]+/i,
-      /([A-Z_]*PASSWORD[_A-Z]*=)[^\s]+/i,
-      /(OPENAI_API_KEY=)[^\s]+/,
-      /(HF_INFERENCE_TOKEN=)[^\s]+/,
-      /(OPENROUTER_API_KEY=)[^\s]+/
-    ]
+  def sanitize_output(text, truncate: true)
+    return "" if text.nil? || text.empty?
+    sanitized = text.gsub(SENSITIVE_OUTPUT_PATTERN, "\\1#{REDACTED}")
+    return sanitized unless truncate
+    sanitized.length > 500 ? "#{sanitized[0..497]}..." : sanitized
+  end
 
-    sensitive_patterns.each do |pattern|
-      sanitized.gsub!(pattern, '\1***REDACTED***')
+  def redact_sensitive_args(args)
+    result = []
+    redact_next = false
+    args.each do |arg|
+      if redact_next
+        result << REDACTED
+        redact_next = false
+      elsif (m = arg.match(/\A(--[\w-]+)=(.+)\z/))
+        flag_name = m[1].sub(/\A--/, "")
+        if SENSITIVE_FLAG_NAME.match?(flag_name)
+          result << "#{m[1]}=#{REDACTED}"
+        else
+          result << arg
+        end
+      elsif sensitive_flag?(arg)
+        result << arg
+        redact_next = true
+      else
+        result << arg
+      end
     end
+    result
+  end
 
-    # Truncate to avoid logging extremely long commands
-    sanitized.length > 300 ? "#{sanitized[0..297]}..." : sanitized
+  def sensitive_flag?(arg)
+    name = arg.sub(/\A-{1,2}/, "")
+    SENSITIVE_FLAG_NAME.match?(name)
   end
 end

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -38,15 +38,84 @@ class RunGarakScan
 
         report.update(status: :starting) unless report.starting?
 
-        RunCommand.new(command).call_async
+        execute_scan
       end
     else
       report.update(status: :starting) unless report.starting?
-      RunCommand.new(command).call_async
+      execute_scan
     end
   end
 
   private
+
+  def execute_scan
+    ActsAsTenant.with_tenant(report.company) do
+      argv = build_argv
+      env = build_env
+      log_path = scan_log_path
+      log_scan_debug_info(argv)
+      RunCommand.new(argv, env: env).call_async(log_file: log_path)
+    rescue RunCommand::ImmediateExitError => e
+      Rails.logger.error("Scan process failed to start for report #{report.uuid}: #{e.message}")
+      stderr_tail = read_log_tail
+      message = "Scan process failed to start (exit status #{e.exit_status})."
+      message += " Output: #{stderr_tail}" if stderr_tail.present?
+      report.update(status: :failed, logs: message)
+    end
+  end
+
+  def build_argv
+    script_path = Rails.root.join("script", "run_garak.py")
+    [ "/opt/venv/bin/python3", script_path.to_s, report.uuid ] + params
+  end
+
+  def build_env
+    # Tenant context needed for decrypting EnvironmentVariable.env_value
+    # via per-tenant key provider
+    merged = merged_env_vars
+    env = merged.dup
+
+    env["HOME"] = "/home/rails"
+    env["VARIANT_SCAN"] = "true" if report.is_variant_report?
+
+    env["LOG_FILE_PATH"] = scan_log_path
+    env["DATABASE_URL"] = database_url_for_python
+
+    if MonitoringService.active?
+      MonitoringService.trace_context.each do |key, value|
+        env[key] = value
+      end
+    end
+
+    env["REPORT_UUID"] = report.uuid
+    env["SCAN_ID"] = report.scan.id.to_s
+    env["SCAN_NAME"] = report.scan.name
+    env["TARGET_ID"] = target.id.to_s
+    env["TARGET_NAME"] = target.name
+
+    env
+  end
+
+  def scan_log_path
+    @scan_log_path ||= LogPathManager.scan_log_file_for_report(report).to_s
+  end
+
+  def log_scan_debug_info(argv)
+    if Rails.configuration.log_level.to_s == "debug" || MonitoringService.active?
+      trace_id = MonitoringService.current_trace_id
+      yellow = "\e[33m"
+      reset = "\e[0m"
+      separator = yellow + ("-" * 80) + reset
+      Rails.logger.info(separator)
+      Rails.logger.info(yellow + "GARAK SCAN COMMAND:" + reset)
+      Rails.logger.info(yellow + "Report UUID: #{report.uuid}" + reset)
+      Rails.logger.info(yellow + "Scan: #{report.scan.name}" + reset)
+      Rails.logger.info(yellow + "Target: #{target.name}" + reset)
+      Rails.logger.info(yellow + "Monitoring Trace ID: #{trace_id}" + reset) if trace_id
+      Rails.logger.info(yellow + "argv: #{argv.inspect}" + reset)
+      Rails.logger.info(separator)
+    end
+  end
 
   def handle_invalid_target_status
     case target.status
@@ -69,73 +138,7 @@ class RunGarakScan
     )
   end
 
-  def command
-    # Tenant context needed for decrypting target.json_config, target.web_config,
-    # and EnvironmentVariable.env_value via per-tenant key provider
-    ActsAsTenant.with_tenant(report.company) do
-      script_path = Rails.root.join("script", "run_garak.py")
-      # Environment variables are passed as a string prefix for bash shell execution.
-      # This approach ensures variables are available in the shell context for proper command execution.
-      evs = env_vars_string
-      c = "#{evs} /opt/venv/bin/python3 #{script_path} '#{report.uuid}' '#{params}' #{log_file}"
-      if Rails.configuration.log_level.to_s == "debug" || MonitoringService.active?
-        trace_id = MonitoringService.current_trace_id
-        yellow = "\e[33m"
-        reset = "\e[0m"
-        separator = yellow + ("-" * 80) + reset
-        Rails.logger.info(separator)
-        Rails.logger.info(yellow + "GARAK SCAN COMMAND:" + reset)
-        Rails.logger.info(yellow + "Report UUID: #{report.uuid}" + reset)
-        Rails.logger.info(yellow + "Scan: #{report.scan.name}" + reset)
-        Rails.logger.info(yellow + "Target: #{target.name}" + reset)
-        Rails.logger.info(yellow + "Monitoring Trace ID: #{trace_id}" + reset) if trace_id
-        Rails.logger.info(yellow + c.sub(evs, "[REDACTED_ENV_VARS]") + reset)
-        Rails.logger.info(separator)
-      end
-      c
-    end
-  end
-
-  def env_vars_string
-    # Build environment variables as a string prefix for bash command
-    # Tenant context is set by the command method's with_tenant wrapper
-    # Per-target vars override global vars with the same name
-    merged = merged_env_vars
-    vars = merged.map { |name, value| "#{name}=#{Shellwords.escape(value)}" }
-
-    # Add HOME directory for rails user
-    vars << "HOME=/home/rails"
-
-    # Add variant scan flag for child reports with variants
-    vars << "VARIANT_SCAN=true" if report.is_variant_report?
-
-    # Pass log file path to Python for correct log reading/cleanup
-    # This ensures Python reads from the same path Ruby writes to via LogPathManager
-    log_path = LogPathManager.scan_log_file_for_report(report)
-    vars << "LOG_FILE_PATH=#{Shellwords.escape(log_path.to_s)}"
-
-    # Add DATABASE_URL for Python db_notifier to connect to PostgreSQL
-    # Required for multi-pod IPC: Python writes to raw_report_data and enqueues Solid Queue jobs
-    vars << "DATABASE_URL=#{Shellwords.escape(database_url_for_python)}"
-
-    if MonitoringService.active?
-      trace_context = MonitoringService.trace_context
-      trace_context.each do |key, value|
-        vars << "#{key}=#{Shellwords.escape(value)}"
-      end
-    end
-
-    vars << "REPORT_UUID=#{Shellwords.escape(report.uuid)}"
-    vars << "SCAN_ID=#{Shellwords.escape(report.scan.id.to_s)}"
-    vars << "SCAN_NAME=#{Shellwords.escape(report.scan.name)}"
-    vars << "TARGET_ID=#{Shellwords.escape(target.id.to_s)}"
-    vars << "TARGET_NAME=#{Shellwords.escape(target.name)}"
-
-    vars.join(" ")
-  end
-
   def database_url_for_python
-    # Use existing DATABASE_URL if set, otherwise construct from Rails config
     return ENV["DATABASE_URL"] if ENV["DATABASE_URL"].present?
 
     config = ActiveRecord::Base.connection_db_config.configuration_hash
@@ -160,7 +163,7 @@ class RunGarakScan
 
   def api_params
     [
-      "--skip_unknown",
+      [ "--skip_unknown" ],
       target_type_arg,
       target_name_arg,
       probes_config,
@@ -168,20 +171,20 @@ class RunGarakScan
       evaluation_threshold,
       parallel_attempts,
       generator_options
-    ].compact.join(" ")
+    ].compact.flatten
   end
 
   def web_chat_params
     [
-      "--skip_unknown",
-      "--target_type web_chatbot.WebChatbotGenerator",
+      [ "--skip_unknown" ],
+      [ "--target_type", "web_chatbot.WebChatbotGenerator" ],
       web_chat_target_name,
       probes_config,
       report_prefix,
       evaluation_threshold,
       parallel_attempts,
       web_chat_generator_options
-    ].compact.join(" ")
+    ].compact.flatten
   end
 
   def target
@@ -189,15 +192,15 @@ class RunGarakScan
   end
 
   def target_type_arg
-    "--target_type #{Target::INVERTED_MODEL_TYPES[target.model_type]}.#{target.model_type}"
+    [ "--target_type", "#{Target::INVERTED_MODEL_TYPES[target.model_type]}.#{target.model_type}" ]
   end
 
   def target_name_arg
-    "--target_name #{target.model}"
+    [ "--target_name", target.model ]
   end
 
   def web_chat_target_name
-    "--target_name web_chatbot"
+    [ "--target_name", "web_chatbot" ]
   end
 
   # Build a temporary YAML config containing the probe_spec, and return --config <path>
@@ -205,19 +208,19 @@ class RunGarakScan
     probes_list = scan_probes
 
     probes_csv = probes_list.join(",")
-    "--config #{write_probes_yaml(probes_csv)}"
+    [ "--config", write_probes_yaml(probes_csv) ]
   end
 
   def generator_options
     return if target.json_config.blank?
 
-    "--generator_option_file #{temp_json_file_path}"
+    [ "--generator_option_file", temp_json_file_path ]
   end
 
   def web_chat_generator_options
     return if target.web_config.blank?
 
-    "--generator_option_file #{temp_web_config_file_path}"
+    [ "--generator_option_file", temp_web_config_file_path ]
   end
 
   def temp_json_file_path
@@ -280,15 +283,15 @@ class RunGarakScan
   end
 
   def parallel_attempts
-    "--parallel_attempts #{SettingsService.parallel_attempts}"
+    [ "--parallel_attempts", SettingsService.parallel_attempts.to_s ]
   end
 
   def report_prefix
-    "--report_prefix #{report.uuid}"
+    [ "--report_prefix", report.uuid ]
   end
 
   # Merge global and per-target env vars. Per-target overrides global on name collision.
-  # Memoized — called from both env_vars_string and substitute_env_vars.
+  # Memoized — called from both build_env and substitute_env_vars.
   def merged_env_vars
     @merged_env_vars ||= begin
       global_vars = EnvironmentVariable
@@ -308,11 +311,15 @@ class RunGarakScan
   end
 
   def evaluation_threshold
-    # Tenant context is set by the command method's with_tenant wrapper
+    # Tenant context is set by execute_scan's with_tenant wrapper
     env_var = target.environment_variables.find_by(env_name: EVALUATION_THRESHOLD_ENV_NAME) ||
       EnvironmentVariable.global.find_by(env_name: EVALUATION_THRESHOLD_ENV_NAME)
 
-    "--eval_threshold #{Shellwords.escape(env_var.env_value)}" if env_var&.env_value
+    if env_var&.env_value
+      value = env_var.env_value.to_s.strip
+      raise ArgumentError, "Invalid evaluation threshold: #{value}" unless value.match?(/\A\d+(\.\d+)?\z/)
+      [ "--eval_threshold", value ]
+    end
   end
 
   # Returns the list of remaining probes for a regular report, filtering out
@@ -433,21 +440,21 @@ class RunGarakScan
     Rails.logger.warn("[ScanResume] Report #{report.uuid}: Could not persist logs: #{e.message}")
   end
 
+  def read_log_tail
+    log_path = LogPathManager.scan_log_file_for_report(report)
+    return nil unless log_path && File.exist?(log_path.to_s)
+
+    content = File.read(log_path.to_s)
+    content.lines.last(10).join.strip.truncate(500)
+  rescue StandardError
+    nil
+  end
+
   def log_resumption_info(total, remaining)
     completed = total - remaining
     Rails.logger.info(
       "[ScanResume] Report #{report.uuid}: Resuming scan — " \
       "#{completed}/#{total} probes already completed, #{remaining} remaining"
     )
-  end
-
-  def log_file
-    Rails.logger.info("Creating log file for report: #{report.uuid}")
-
-    full_log_path = LogPathManager.scan_log_file_for_report(report)
-
-    Rails.logger.info("Log file path: #{full_log_path}")
-
-    " 2>&1 | tee -a #{Shellwords.escape(full_log_path.to_s)} "
   end
 end

--- a/app/services/scans/stats_serializer.rb
+++ b/app/services/scans/stats_serializer.rb
@@ -77,19 +77,23 @@ module Scans
       total_tests = totals&.total_tests.to_i
       overall_asr = total_tests > 0 ? (total_passed.to_f / total_tests * 100).round(2) : 0
 
-      # Per-target breakdown
-      by_target = scan.targets.map do |target|
-        target_totals = completed_reports
-          .where(target_id: target.id)
-          .joins(:detector_results)
-          .select(
-            "SUM(detector_results.passed) as passed",
-            "SUM(detector_results.total) as total"
-          )
-          .take
+      # Per-target breakdown (single grouped query instead of N+1)
+      grouped = completed_reports
+        .joins(:detector_results)
+        .group(:target_id)
+        .pluck(
+          Arel.sql("reports.target_id"),
+          Arel.sql("SUM(detector_results.passed)"),
+          Arel.sql("SUM(detector_results.total)")
+        )
+        .each_with_object({}) do |(tid, passed, total), hash|
+          hash[tid] = { passed: passed.to_i, total: total.to_i }
+        end
 
-        passed = target_totals&.passed.to_i
-        total = target_totals&.total.to_i
+      by_target = scan.targets.map do |target|
+        stats = grouped[target.id] || { passed: 0, total: 0 }
+        passed = stats[:passed]
+        total = stats[:total]
         asr = total > 0 ? (passed.to_f / total * 100).round(2) : 0
 
         {
@@ -218,11 +222,13 @@ module Scans
     def top_vulnerabilities_info
       return [] if completed_reports.empty?
 
-      # Find probes with successful attacks, prioritized by risk level
-      ProbeResult
+      # Find probes with successful attacks, prioritized by risk level.
+      # Uses any_detector_passed so multi-detector probes where any detector
+      # was bypassed count as vulnerable, even if the last detector defended.
+      vulnerable_probes = ProbeResult
         .joins(:probe)
         .where(report_id: completed_reports.select(:id))
-        .where("probe_results.passed > 0")
+        .where(any_detector_passed: true)
         .group("probes.id", "probes.name", "probes.category", "probes.social_impact_score", "probes.disclosure_status")
         .select(
           "probes.id",
@@ -235,21 +241,22 @@ module Scans
         )
         .order("probes.social_impact_score DESC NULLS LAST, total_passed DESC")
         .limit(10)
-        .map do |row|
-          risk_levels = Probe.social_impact_scores.invert
-          disclosure_statuses = Probe.disclosure_statuses.invert
 
-          {
-            probe_id: row.id,
-            probe_name: row.name,
-            category: row.category,
-            risk_level: risk_levels[row.social_impact_score] || "Unknown",
-            disclosure_status: disclosure_statuses[row.disclosure_status] || "Unknown",
-            passed: row.total_passed.to_i,
-            total: row.total_tests.to_i,
-            success_rate: row.total_tests.to_i > 0 ? (row.total_passed.to_f / row.total_tests * 100).round(2) : 0
-          }
-        end
+      risk_levels = Probe.social_impact_scores.invert
+      disclosure_statuses = Probe.disclosure_statuses.invert
+
+      vulnerable_probes.map do |row|
+        {
+          probe_id: row.id,
+          probe_name: row.name,
+          category: row.category,
+          risk_level: risk_levels[row.social_impact_score] || "Unknown",
+          disclosure_status: disclosure_statuses[row.disclosure_status] || "Unknown",
+          passed: row.total_passed.to_i,
+          total: row.total_tests.to_i,
+          success_rate: row.total_tests.to_i > 0 ? (row.total_passed.to_f / row.total_tests * 100).round(2) : 0
+        }
+      end
     end
 
     # TIER 1: Detector breakdown - per-detector success rates
@@ -430,11 +437,13 @@ module Scans
     def calculate_risk_penalty
       return 0 if completed_reports.empty?
 
-      # Get successful attacks by risk level
+      # Get successful attacks by risk level. Filter by any_detector_passed
+      # for correct multi-detector semantics; sum still uses passed (last
+      # detector's value) which is the best signal we have for magnitude.
       risk_data = ProbeResult
         .joins(:probe)
         .where(report_id: completed_reports.select(:id))
-        .where("probe_results.passed > 0")
+        .where(any_detector_passed: true)
         .group("probes.social_impact_score")
         .sum("probe_results.passed")
 

--- a/app/services/validate_target.rb
+++ b/app/services/validate_target.rb
@@ -23,9 +23,8 @@ class ValidateTarget
       if target.webchat?
         ValidateWebChatTarget.new(target).call
       else
-        # Run external validator (command string may include secrets; do not log it verbatim at info level)
         Rails.logger.info("validation.invoking")
-        RunCommand.new(command).call
+        RunCommand.new(build_argv, env: build_env).call(log_file: validation_log_path)
         result = process_validation_result
         dur_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000).round
         Logging.with(event: "validation.finished", target_id: target.id, validation_uuid: validation_uuid, decision: (target.good? ? "valid" : "invalid"), response_count: result[:response_count], evaluation: result[:evaluation_result], duration_ms: dur_ms) do
@@ -43,22 +42,20 @@ class ValidateTarget
 
   private
 
-  def command
+  def build_argv
     script_path = Rails.root.join("script", "run_garak.py")
-    evs = env_vars
-    c = "#{evs} HOME=/home/rails /opt/venv/bin/python3 #{script_path} '#{validation_uuid}' '#{params}' #{log_file}"
+    [ "/opt/venv/bin/python3", script_path.to_s, validation_uuid ] + params
+  end
 
-    if Rails.configuration.log_level.to_s == "debug"
-      yellow = "\e[33m"
-      reset = "\e[0m"
-      separator = yellow + ("-" * 80) + reset
-      Rails.logger.info(separator)
-      Rails.logger.info(yellow + "TARGET VALIDATION COMMAND:" + reset)
-      Rails.logger.info(yellow + c.sub(evs, "[REDACTED_ENV_VARS]") + reset)
-      Rails.logger.info(separator)
-    end
+  def build_env
+    env = merged_env_vars_hash.dup
+    env["HOME"] = "/home/rails"
+    env
+  end
 
-    c
+  def validation_log_path
+    FileUtils.mkdir_p(LOGS_PATH) unless Dir.exist?(LOGS_PATH)
+    LOGS_PATH.join("#{validation_uuid}.log").to_s
   end
 
   def merged_env_vars_hash
@@ -81,12 +78,6 @@ class ValidateTarget
     end
   end
 
-  def env_vars
-    merged_env_vars_hash
-      .map { |name, value| "#{name}=#{Shellwords.escape(value)}" }
-      .join(" ")
-  end
-
   def params
     [
       target_type_arg,
@@ -94,25 +85,25 @@ class ValidateTarget
       probe,
       report_prefix,
       generator_options
-    ].compact.join(" ")
+    ].compact.flatten
   end
 
   def target_type_arg
-    "--target_type #{Target::INVERTED_MODEL_TYPES[target.model_type]}.#{target.model_type}"
+    [ "--target_type", "#{Target::INVERTED_MODEL_TYPES[target.model_type]}.#{target.model_type}" ]
   end
 
   def target_name_arg
-    "--target_name #{target.model}"
+    [ "--target_name", target.model ]
   end
 
   def probe
-    "--probes \"#{Scanner.configuration.validation_probe}\""
+    [ "--probes", Scanner.configuration.validation_probe ]
   end
 
   def generator_options
     return if target.json_config.blank?
 
-    "--generator_option_file #{temp_json_file_path}"
+    [ "--generator_option_file", temp_json_file_path ]
   end
 
   def temp_json_file_path
@@ -137,17 +128,11 @@ class ValidateTarget
   end
 
   def report_prefix
-    "--report_prefix #{validation_uuid}"
+    [ "--report_prefix", validation_uuid ]
   end
 
   def validation_uuid
     @validation_uuid ||= "validation_#{target.id}_#{SecureRandom.hex(8)}"
-  end
-
-  def log_file
-    Rails.logger.info("Creating validation log file for target: #{target.id}")
-    FileUtils.mkdir_p(LOGS_PATH) unless Dir.exist?(LOGS_PATH)
-    " 2>&1 | tee -a #{LOGS_PATH.join("#{validation_uuid}.log")} "
   end
 
   def process_validation_result

--- a/app/services/validate_web_chat_target.rb
+++ b/app/services/validate_web_chat_target.rb
@@ -107,9 +107,7 @@ class ValidateWebChatTarget
   end
 
   def valid_url?(url)
-    uri = URI.parse(url)
-    uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
-  rescue URI::InvalidURIError
-    false
+    result = UrlSafetyValidator.safe_url?(url, allow_localhost: UrlSafetyValidator.allow_localhost?)
+    result.safe?
   end
 end

--- a/app/validators/url_safety_validator.rb
+++ b/app/validators/url_safety_validator.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "resolv"
+require "ipaddr"
+
+class UrlSafetyValidator
+  BLOCKED_RANGES = [
+    IPAddr.new("127.0.0.0/8"),       # loopback
+    IPAddr.new("10.0.0.0/8"),        # RFC1918
+    IPAddr.new("172.16.0.0/12"),     # RFC1918
+    IPAddr.new("192.168.0.0/16"),    # RFC1918
+    IPAddr.new("169.254.0.0/16"),    # link-local / cloud metadata
+    IPAddr.new("0.0.0.0/8"),         # "this" network
+    IPAddr.new("::1/128"),           # IPv6 loopback
+    IPAddr.new("fc00::/7"),          # IPv6 unique local
+    IPAddr.new("fe80::/10"),         # IPv6 link-local
+    IPAddr.new("100.64.0.0/10"),     # CGN shared address space (RFC 6598)
+    IPAddr.new("240.0.0.0/4"),       # reserved for future use
+    IPAddr.new("224.0.0.0/4"),       # multicast
+    IPAddr.new("255.255.255.255/32"), # broadcast
+    IPAddr.new("::/128"),            # IPv6 unspecified
+    IPAddr.new("ff00::/8")           # IPv6 multicast
+  ].freeze
+
+  Result = Struct.new(:safe?, :error, :resolved_ips, keyword_init: true)
+
+  def self.safe_url?(url, allow_localhost: false)
+    new(url, allow_localhost: allow_localhost).validate
+  end
+
+  def self.safe_host?(host, allow_localhost: false)
+    new(nil, allow_localhost: allow_localhost).validate_host(host)
+  end
+
+  def self.allow_localhost?
+    Rails.env.development? || Rails.env.test?
+  end
+
+  def self.resolve_addresses(host)
+    resolver = Resolv::DNS.new
+    resolver.timeouts = [ 2, 2 ]
+    results = resolver.getaddresses(host).map(&:to_s)
+    return results if results.any?
+
+    Timeout.timeout(4) { Resolv.getaddresses(host) }
+  rescue Resolv::ResolvError, Resolv::ResolvTimeout, Timeout::Error
+    []
+  ensure
+    resolver&.close
+  end
+
+  def initialize(url, allow_localhost: false)
+    @url = url
+    @allow_localhost = allow_localhost
+  end
+
+  def validate
+    uri = parse_uri
+    return Result.new("safe?": false, error: "Invalid URL") unless uri
+    return Result.new("safe?": false, error: "Only HTTP and HTTPS URLs are allowed") unless http_scheme?(uri)
+    return Result.new("safe?": false, error: "URL must not contain credentials") if uri.userinfo.present?
+    return Result.new("safe?": false, error: "IPv6 zone IDs are not allowed") if uri.host&.include?("%")
+
+    validate_host(uri.host)
+  end
+
+  def validate_host(host)
+    return Result.new("safe?": false, error: "Host is blank") if host.blank?
+
+    resolved_ips = resolve_host(host)
+    return Result.new("safe?": false, error: "Could not resolve hostname") if resolved_ips.empty?
+
+    resolved_ips.each do |ip_str|
+      ip = IPAddr.new(ip_str)
+      ip = ip.native if ip.ipv4_mapped? || ip.ipv4_compat?
+      BLOCKED_RANGES.each do |range|
+        if range.include?(ip)
+          next if @allow_localhost && loopback?(ip)
+          return Result.new("safe?": false, error: "URL resolves to blocked internal address (#{ip_str})")
+        end
+      end
+    end
+
+    Result.new("safe?": true, error: nil, resolved_ips: resolved_ips)
+  rescue IPAddr::InvalidAddressError
+    Result.new("safe?": false, error: "Invalid IP address in hostname")
+  end
+
+  private
+
+  def parse_uri
+    URI.parse(@url)
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def http_scheme?(uri)
+    uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+  end
+
+  def resolve_host(host)
+    ip = parse_ip(host)
+    return [ ip.to_s ] if ip
+
+    self.class.resolve_addresses(host)
+  end
+
+  def parse_ip(str)
+    clean = str.gsub(/\A\[|\]\z/, "")
+    ip = IPAddr.new(clean)
+    ip = ip.native if ip.ipv4_mapped? || ip.ipv4_compat?
+    ip
+  rescue IPAddr::InvalidAddressError
+    nil
+  end
+
+  LOOPBACK_V4 = BLOCKED_RANGES[0]
+  LOOPBACK_V6 = BLOCKED_RANGES[6]
+
+  def loopback?(ip)
+    LOOPBACK_V4.include?(ip) || LOOPBACK_V6.include?(ip)
+  end
+end

--- a/app/views/admin/reports/_variant_industries_pills.html.erb
+++ b/app/views/admin/reports/_variant_industries_pills.html.erb
@@ -16,7 +16,7 @@
               probe_result = probe_results_map[subindustry.id]
               tooltip_text = if probe_result.nil?
                 "Not tested - This industry variant was not included in the scan"
-              elsif probe_result.passed > 0
+              elsif probe_result.any_detector_passed
                 "Attack successful - This industry variant detected a vulnerability"
               else
                 "Attack blocked - This industry variant was tested but the target successfully defended"

--- a/app/views/report_details/show.html.erb
+++ b/app/views/report_details/show.html.erb
@@ -1,7 +1,9 @@
 <% pdf_mode = params[:pdf] == 'true' %>
 
 <% unless pdf_mode %>
-  <%= turbo_stream_from "pdf_notifications:company_#{current_user.current_company_id}" %>
+  <% if current_user %>
+    <%= turbo_stream_from "pdf_notifications:company_#{current_user.current_company_id}" %>
+  <% end %>
   <div id="pdf-status-<%= @report.id %>" style="display: none;"></div>
 <% end %>
 
@@ -107,7 +109,7 @@
             </div>
             <div class="<%= pdf_mode ? 'flex items-center gap-1.5 ml-3 mt-0.5' : 'flex items-center gap-2 ml-4' %>">
               <div class="flex items-center gap-1">
-                <span class="<%= pdf_mode ? 'font-medium' : 'font-semibold' %> <%= result.passed > 0 ? 'text-red-600' : 'text-emerald-600' %>">
+                <span class="<%= pdf_mode ? 'font-medium' : 'font-semibold' %> <%= result.passed.to_i > 0 ? 'text-red-600' : 'text-emerald-600' %>">
                   <%= result.passed %>
                 </span>
                 <span class="text-gray-500">/</span>
@@ -235,7 +237,7 @@
         detector_name = result.detector&.name || "Unknown"
         short_name = detector_name != "Unknown" ? detector_name.split(".").last : "Unknown"
         translated_name = I18n.t("detectors.names.#{short_name}", default: short_name)
-        is_vulnerable = result.passed > 0
+        is_vulnerable = result.any_detector_passed
         card_border_class = is_vulnerable ?
           (pdf_mode ? 'border-red-200/80' : 'border-red-200/80 hover:border-red-300/60') :
           (pdf_mode ? 'border-gray-200/80' : 'border-gray-200/80 hover:border-gray-300/60')
@@ -246,7 +248,7 @@
         indicator_animation = is_vulnerable && !pdf_mode ? 'animate-pulse' : ''
       %>
 
-      <details id="probe-<%= probe.id %>" class="group" data-report-target="details" <%= 'open' if pdf_mode && result.passed > 0 %>>
+      <details id="probe-<%= probe.id %>" class="group" data-report-target="details" <%= 'open' if pdf_mode && result.any_detector_passed %>>
         <summary class="<%= pdf_mode ? 'bg-white/90 backdrop-blur-sm rounded-lg border p-4 cursor-pointer list-none' : 'bg-white/90 backdrop-blur-sm rounded-xl border p-5 cursor-pointer list-none transition-all duration-300' %> <%= card_border_class %> <%= card_shadow_class %>">
           <div class="<%= pdf_mode ? 'flex items-start justify-between gap-4' : 'flex items-start justify-between gap-6' %>">
             <div class="flex-1 min-w-0">

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,20 +3,20 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "00801ec8c2d369aa7c758f954543a2690a3f3744cc381399cabdc03880521ca0",
+      "fingerprint": "bf6481d9a583704c4e72449022387d49463c496a4b09852f91e87d21bb16c06b",
       "check_name": "SendFile",
       "message": "Model attribute used in file name",
       "file": "app/controllers/report_details_controller.rb",
-      "line": 16,
+      "line": 22,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(ReportDecorator.new(Report.find(params[:id])).report_pdf.file_path, :filename => pdf_filename, :type => \"application/pdf\", :disposition => \"attachment\")",
+      "code": "send_file(ReportDecorator.new((Report.includes(:target, :scan, :probe_results => ([:probe, :detector])).find(params[:id]) or Report.includes(:target, :scan, :probe_results => ([:probe, :detector])).find(params[:id]))).report_pdf.file_path, :filename => pdf_filename, :type => \"application/pdf\", :disposition => \"attachment\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "ReportDetailsController",
         "method": "pdf"
       },
-      "user_input": "Report.find(params[:id])",
+      "user_input": "Report.includes(:target, :scan, :probe_results => ([:probe, :detector])).find(params[:id])",
       "confidence": "Weak",
       "cwe_id": [
         22

--- a/db/migrate/20260412043238_add_variant_uniqueness_and_passed_flag.rb
+++ b/db/migrate/20260412043238_add_variant_uniqueness_and_passed_flag.rb
@@ -1,0 +1,5 @@
+class AddVariantUniquenessAndPassedFlag < ActiveRecord::Migration[8.1]
+  def change
+    add_column :probe_results, :any_detector_passed, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260412044226_backfill_any_detector_passed_on_probe_results.rb
+++ b/db/migrate/20260412044226_backfill_any_detector_passed_on_probe_results.rb
@@ -1,0 +1,14 @@
+class BackfillAnyDetectorPassedOnProbeResults < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  # passed > 0 is exact for post-max-merge rows; historical multi-detector
+  # rows where the final detector defended may be missed (no reconstruction path).
+  def up
+    ProbeResult.reset_column_information
+    ProbeResult.where("passed > 0").in_batches(of: 5_000).update_all(any_detector_passed: true)
+  end
+
+  def down
+    # No-op: the column itself is removed by the companion migration on rollback.
+  end
+end

--- a/db/migrate/20260412050000_add_threat_variant_indexes_concurrently.rb
+++ b/db/migrate/20260412050000_add_threat_variant_indexes_concurrently.rb
@@ -1,0 +1,62 @@
+class AddThreatVariantIndexesConcurrently < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    cleanup_duplicate_threat_variants
+
+    unless index_exists?(:threat_variants, [ :probe_id, :prompt ], name: "index_threat_variants_on_probe_and_prompt")
+      add_index :threat_variants, [ :probe_id, :prompt ], unique: true,
+                name: "index_threat_variants_on_probe_and_prompt",
+                algorithm: :concurrently
+    end
+
+    unless index_exists?(:threat_variants, :prompt, name: "index_threat_variants_on_prompt")
+      add_index :threat_variants, :prompt,
+                name: "index_threat_variants_on_prompt",
+                algorithm: :concurrently
+    end
+  end
+
+  def down
+    remove_index :threat_variants, name: "index_threat_variants_on_prompt", if_exists: true
+    remove_index :threat_variants, name: "index_threat_variants_on_probe_and_prompt", if_exists: true
+  end
+
+  private
+
+  def cleanup_duplicate_threat_variants
+    duplicates = execute(<<~SQL).to_a
+      SELECT probe_id, prompt, COUNT(*) AS cnt
+      FROM threat_variants
+      GROUP BY probe_id, prompt
+      HAVING COUNT(*) > 1
+    SQL
+
+    return if duplicates.empty?
+
+    say "Found #{duplicates.size} duplicate threat_variant groups — keeping newest, removing rest"
+
+    execute(<<~SQL)
+      UPDATE probe_results
+      SET threat_variant_id = keeper.id
+      FROM (
+        SELECT DISTINCT ON (probe_id, prompt) id, probe_id, prompt
+        FROM threat_variants
+        ORDER BY probe_id, prompt, created_at DESC
+      ) AS keeper
+      WHERE probe_results.threat_variant_id IN (
+        SELECT tv.id FROM threat_variants tv
+        WHERE tv.probe_id = keeper.probe_id AND tv.prompt = keeper.prompt AND tv.id != keeper.id
+      )
+    SQL
+
+    execute(<<~SQL)
+      DELETE FROM threat_variants
+      WHERE id NOT IN (
+        SELECT DISTINCT ON (probe_id, prompt) id
+        FROM threat_variants
+        ORDER BY probe_id, prompt, created_at DESC
+      )
+    SQL
+  end
+end

--- a/db/migrate/20260412060000_encrypt_output_server_secrets.rb
+++ b/db/migrate/20260412060000_encrypt_output_server_secrets.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Encrypts sensitive credential fields on OutputServer at rest using
+# Rails ActiveRecord Encryption with per-tenant key isolation.
+#
+# Phase 1: Changes column types from string to text (encrypted payloads
+#           are opaque strings that may exceed varchar limits).
+# Phase 2: Encrypts existing plaintext records with per-tenant derived keys.
+class EncryptOutputServerSecrets < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    change_column :output_servers, :access_token, :text
+    change_column :output_servers, :api_key, :text
+    change_column :output_servers, :password, :text
+
+    say_with_time "Encrypting output server secrets with per-tenant keys" do
+      count = 0
+      failures = []
+      ActsAsTenant.without_tenant do
+        OutputServer.in_batches(of: 100) do |batch|
+          batch.each do |server|
+            ActsAsTenant.with_tenant(server.company) do
+              if server.access_token.present? || server.api_key.present? || server.password.present?
+                server.encrypt
+                count += 1
+              end
+            end
+          rescue StandardError => e
+            failures << { id: server.id, error: e.message }
+            say "Failed to encrypt output server #{server.id}: #{e.message}"
+          end
+        end
+      end
+      raise "Failed to encrypt #{failures.size} output server(s): #{failures.inspect}" if failures.any?
+      count
+    end
+  end
+
+  def down
+    unless OutputServer.encrypted_attributes&.include?(:access_token)
+      raise "Cannot rollback: OutputServer model must still have 'encrypts' declarations. " \
+            "Restore model code first, then rollback migration."
+    end
+
+    ActsAsTenant.without_tenant do
+      say_with_time "Decrypting output server secrets" do
+        count = 0
+        failures = []
+        OutputServer.find_each do |server|
+          updates = {}
+          ActsAsTenant.with_tenant(server.company) do
+            updates[:access_token] = server.access_token if server.access_token.present?
+            updates[:api_key] = server.api_key if server.api_key.present?
+            updates[:password] = server.password if server.password.present?
+          end
+          if updates.any?
+            OutputServer.where(id: server.id).update_all(updates)
+            count += 1
+          end
+        rescue StandardError => e
+          failures << { id: server.id, error: e.message }
+          say "Failed to decrypt output server #{server.id}: #{e.message}"
+        end
+        raise "Failed to decrypt #{failures.size} output server(s): #{failures.inspect}" if failures.any?
+        count
+      end
+    end
+
+    change_column :output_servers, :access_token, :string
+    change_column :output_servers, :api_key, :string
+    change_column :output_servers, :password, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_19_001013) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_060000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -122,9 +122,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_001013) do
   end
 
   create_table "output_servers", force: :cascade do |t|
-    t.string "access_token"
+    t.text "access_token"
     t.json "additional_settings"
-    t.string "api_key"
+    t.text "api_key"
     t.bigint "company_id", null: false
     t.datetime "created_at", null: false
     t.text "description"
@@ -132,7 +132,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_001013) do
     t.string "endpoint_path"
     t.string "host", null: false
     t.string "name", null: false
-    t.string "password"
+    t.text "password"
     t.integer "port"
     t.integer "protocol", default: 0, null: false
     t.integer "server_type", null: false
@@ -145,6 +145,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_001013) do
   end
 
   create_table "probe_results", force: :cascade do |t|
+    t.boolean "any_detector_passed", default: false, null: false
     t.json "attempts", default: []
     t.datetime "created_at", null: false
     t.integer "detector_id"
@@ -411,8 +412,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_001013) do
     t.text "rationale"
     t.integer "threat_variant_subindustry_id", null: false
     t.datetime "updated_at", null: false
+    t.index ["probe_id", "prompt"], name: "index_threat_variants_on_probe_and_prompt", unique: true
     t.index ["probe_id", "threat_variant_subindustry_id"], name: "index_tv_on_probe_and_subindustry"
     t.index ["probe_id"], name: "index_threat_variants_on_probe_id"
+    t.index ["prompt"], name: "index_threat_variants_on_prompt"
     t.index ["threat_variant_subindustry_id"], name: "index_threat_variants_on_threat_variant_subindustry_id"
   end
 

--- a/script/db_notifier.py
+++ b/script/db_notifier.py
@@ -827,7 +827,7 @@ def get_db_connection(database: str = "primary"):
     return psycopg2.connect(url)
 
 
-def _enqueue_broadcast_stats_job(queue_conn) -> int:
+def _enqueue_broadcast_stats_job(company_id: int, queue_conn) -> int:
     """
     Enqueue BroadcastRunningStatsJob in Solid Queue.
 
@@ -836,6 +836,7 @@ def _enqueue_broadcast_stats_job(queue_conn) -> int:
     since that bypasses Rails callbacks.
 
     Args:
+        company_id: Company ID for company-scoped broadcast stats
         queue_conn: Connection to the queue database
 
     Returns:
@@ -852,7 +853,7 @@ def _enqueue_broadcast_stats_job(queue_conn) -> int:
         "provider_job_id": None,
         "queue_name": "default",
         "priority": None,
-        "arguments": [],  # No arguments needed
+        "arguments": [company_id],
         "executions": 0,
         "exception_executions": {},
         "locale": "en",
@@ -861,14 +862,16 @@ def _enqueue_broadcast_stats_job(queue_conn) -> int:
         "scheduled_at": now_str,
     }
 
+    concurrency_key = f"BroadcastRunningStatsJob/broadcast_running_stats:{company_id}"
+
     with queue_conn.cursor() as queue_cur:
         # Insert into solid_queue_jobs
         queue_cur.execute(
             """
             INSERT INTO solid_queue_jobs
                 (class_name, arguments, queue_name, priority, active_job_id,
-                 scheduled_at, created_at, updated_at)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                 concurrency_key, scheduled_at, created_at, updated_at)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -877,6 +880,7 @@ def _enqueue_broadcast_stats_job(queue_conn) -> int:
                 "default",
                 0,  # priority
                 job_uuid,
+                concurrency_key,
                 now,  # scheduled_at
                 now,  # created_at
                 now,  # updated_at
@@ -922,15 +926,18 @@ def notify_report_running(report_uuid: str, pid: int) -> bool:
                     UPDATE reports
                     SET status = %s, pid = %s, heartbeat_at = NOW(), updated_at = NOW()
                     WHERE uuid = %s
+                    RETURNING company_id
                     """,
                     (REPORT_STATUS_RUNNING, pid, report_uuid),
                 )
-                rows_affected = cur.rowcount
+                report_row = cur.fetchone()
             conn.commit()
 
-            if rows_affected == 0:
+            if report_row is None:
                 logger.warning(f"Report not found: {report_uuid}")
                 return False
+
+            company_id = report_row[0]
 
             logger.info(f"Report {report_uuid} marked as running (pid={pid})")
 
@@ -938,7 +945,7 @@ def notify_report_running(report_uuid: str, pid: int) -> bool:
         try:
             with pooled_connection("queue") as queue_conn:
                 queue_conn.autocommit = False
-                _enqueue_broadcast_stats_job(queue_conn)
+                _enqueue_broadcast_stats_job(company_id, queue_conn)
                 queue_conn.commit()
                 logger.debug(f"Broadcast stats job enqueued for {report_uuid}")
         except Exception as broadcast_err:

--- a/script/run_garak.py
+++ b/script/run_garak.py
@@ -28,7 +28,6 @@ Example:
 
 import os
 import sys
-import argparse
 import shlex
 import signal
 import logging
@@ -92,7 +91,10 @@ signal.signal(signal.SIGINT, signal_handler)
 def run_garak_scan(garak_params):
     """Run the Garak scan with the provided parameters."""
     try:
-        params_list = shlex.split(garak_params)
+        if isinstance(garak_params, str):
+            params_list = shlex.split(garak_params)
+        else:
+            params_list = list(garak_params)
 
         sys.argv = ['garak'] + params_list
 
@@ -168,25 +170,12 @@ def notify_report_stopped(report_uuid):
 
 def main():
     """Main function to parse arguments and run the Garak scan."""
-    parser = argparse.ArgumentParser(
-        description='Run Garak scan with database PID management',
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__
-    )
+    if len(sys.argv) < 2:
+        print("Usage: python3 run_garak.py <report_uuid> [garak_params...]", file=sys.stderr)
+        sys.exit(1)
 
-    parser.add_argument(
-        'report_uuid',
-        help='UUID of the report to update with the process ID'
-    )
-
-    parser.add_argument(
-        'garak_params',
-        help='Garak parameters as a single string (will be parsed into arguments)'
-    )
-
-    args = parser.parse_args()
-
-    report_uuid = args.report_uuid
+    report_uuid = sys.argv[1]
+    garak_params = sys.argv[2:]
     scan_id = os.environ.get('SCAN_ID', 'unknown')
     scan_name = os.environ.get('SCAN_NAME', 'unknown')
     target_id = os.environ.get('TARGET_ID', 'unknown')
@@ -226,7 +215,7 @@ def main():
             current_journal_sync = journal_sync
             journal_sync.start()
 
-        exit_code = run_garak_scan(args.garak_params)
+        exit_code = run_garak_scan(garak_params)
         logger.info(f"Garak scan completed - Report: {report_uuid}, "
                    f"Exit code: {exit_code}")
         print(f"Garak scan completed with exit code: {exit_code}")

--- a/script/tests/test_db_notifier_broadcast_job.py
+++ b/script/tests/test_db_notifier_broadcast_job.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Regression tests for BroadcastRunningStatsJob enqueueing from db_notifier.
+"""
+
+import json
+import os
+import sys
+import unittest
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+# Stub psycopg2 before importing db_notifier
+_mock_psycopg2 = ModuleType("psycopg2")
+_mock_psycopg2.OperationalError = type("OperationalError", (Exception,), {})
+_mock_psycopg2.pool = ModuleType("psycopg2.pool")
+_mock_psycopg2.pool.ThreadedConnectionPool = MagicMock
+sys.modules.setdefault("psycopg2", _mock_psycopg2)
+sys.modules.setdefault("psycopg2.pool", _mock_psycopg2.pool)
+
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__), "..")
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
+if "db_notifier" in sys.modules:
+    cached = sys.modules["db_notifier"]
+    if not hasattr(cached, "pooled_connection"):
+        del sys.modules["db_notifier"]
+
+import db_notifier  # noqa: E402
+
+
+class TestNotifyReportRunningBroadcastJob(unittest.TestCase):
+    def _make_mock_conn(self, rowcount=1, fetchone_result=None):
+        mock_cur = MagicMock()
+        mock_cur.rowcount = rowcount
+        mock_cur.fetchone.return_value = fetchone_result
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        return mock_conn, mock_cur
+
+    @patch("db_notifier.pooled_connection")
+    def test_notify_report_running_enqueues_company_scoped_broadcast_job(self, mock_pooled):
+        primary_conn, primary_cur = self._make_mock_conn(
+            rowcount=1,
+            fetchone_result=(17,),
+        )
+        queue_conn, queue_cur = self._make_mock_conn(fetchone_result=(123,))
+        mock_pooled.side_effect = [primary_conn, queue_conn]
+
+        result = db_notifier.notify_report_running("report-uuid", pid=456)
+
+        self.assertTrue(result)
+
+        update_sql, update_params = primary_cur.execute.call_args[0]
+        self.assertIn("RETURNING company_id", update_sql)
+        self.assertEqual(update_params, (db_notifier.REPORT_STATUS_RUNNING, 456, "report-uuid"))
+
+        insert_sql, insert_params = queue_cur.execute.call_args_list[0][0]
+        arguments_payload = json.loads(insert_params[1])
+
+        self.assertIn("concurrency_key", insert_sql)
+        self.assertEqual(arguments_payload["job_class"], "BroadcastRunningStatsJob")
+        self.assertEqual(arguments_payload["arguments"], [17])
+        self.assertEqual(insert_params[5], "BroadcastRunningStatsJob/broadcast_running_stats:17")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/controllers/admin/targets_controller_spec.rb
+++ b/spec/controllers/admin/targets_controller_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::TargetsController, type: :controller do
+  let!(:company) { create(:company, name: "Test Company", tier: :tier_2) }
+  let!(:user) { create(:user, company: company) }
+
+  before do
+    user.update!(current_company: company)
+    sign_in user
+    ActsAsTenant.current_tenant = company
+  end
+
+  describe "POST #create" do
+    let(:valid_params) do
+      {
+        target: {
+          name: "Test Target",
+          model_type: "OpenAIGenerator",
+          model: "gpt-3.5-turbo",
+          description: "A test target"
+        }
+      }
+    end
+
+    it "creates a target with permitted params" do
+      expect {
+        post :create, params: valid_params
+      }.to change(Target, :count).by(1)
+    end
+
+    it "does not allow setting status through params" do
+      post :create, params: valid_params.deep_merge(target: { status: "good" })
+      target = Target.last
+      expect(target.status).not_to eq("good")
+    end
+
+    it "ignores status param and uses default status" do
+      post :create, params: valid_params.deep_merge(target: { status: "good" })
+      target = Target.last
+      expect(target.status).to eq("validating")
+    end
+  end
+
+  describe "PATCH #update" do
+    let!(:target) { create(:target, company: company, name: "Original") }
+
+    it "updates permitted attributes" do
+      patch :update, params: { id: target.id, target: { name: "Updated" } }
+      expect(target.reload.name).to eq("Updated")
+    end
+
+    it "does not allow changing status through params" do
+      target.update_column(:status, Target.statuses[:bad])
+      patch :update, params: { id: target.id, target: { status: "good", name: "Updated" } }
+      target.reload
+      expect(target.status).to eq("bad")
+      expect(target.name).to eq("Updated")
+    end
+
+    it "does not allow bypassing validation by setting status to good" do
+      patch :update, params: { id: target.id, target: { status: "good" } }
+      target.reload
+      expect(target.status).not_to eq("good")
+    end
+  end
+end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -213,13 +213,11 @@ RSpec.describe Admin::UsersController, type: :controller do
         ActsAsTenant.current_tenant = company_a
       end
 
-      it "can delete same-company user" do
+      it "cannot delete same-company user (only super_admins can delete users)" do
         expect {
           delete :destroy, params: { id: same_company_user.id }
-        }.to change(User, :count).by(-1)
+        }.not_to change(User, :count)
       end
-
-      # Note: Super admin protection is tested in policy specs
     end
 
     context "as OAuth user" do
@@ -232,10 +230,10 @@ RSpec.describe Admin::UsersController, type: :controller do
         ActsAsTenant.current_tenant = company_a
       end
 
-      it "can delete same-company user (no OAuth restriction in OSS)" do
+      it "cannot delete same-company user (only super_admins can delete users)" do
         expect {
           delete :destroy, params: { id: same_company_target.id }
-        }.to change(User, :count).by(-1)
+        }.not_to change(User, :count)
       end
     end
   end

--- a/spec/controllers/report_details_controller_spec.rb
+++ b/spec/controllers/report_details_controller_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe ReportDetailsController, type: :controller do
 
   before do
     sign_in user
-    allow(Report).to receive(:find).with("1").and_return(report)
+    report_scope = double("Report::Relation")
+    allow(Report).to receive(:includes).with(*ReportDetailsController::SHOW_INCLUDES).and_return(report_scope)
+    allow(report_scope).to receive(:find).with("1").and_return(report)
     allow(ReportDecorator).to receive(:new).with(report).and_return(decorated_report)
   end
 
@@ -15,7 +17,6 @@ RSpec.describe ReportDetailsController, type: :controller do
     it 'renders the show template with status 200' do
       get :show, params: { id: 1 }
 
-      expect(Report).to have_received(:find).with("1")
       expect(ReportDecorator).to have_received(:new).with(report)
       expect(response).to have_http_status(:ok)
     end

--- a/spec/factories/probe_results.rb
+++ b/spec/factories/probe_results.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     max_score { rand(1..5) }
     passed { rand(0..10) }
     total { rand(10..20) }
+    any_detector_passed { passed.to_i.positive? }
 
     trait :high_score do
       max_score { 5 }

--- a/spec/factories/targets.rb
+++ b/spec/factories/targets.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :target do
     association :company
     sequence(:name) { |n| "Target #{Faker::Internet.domain_name}-#{n}" }
-    model_type { 'text-generation' }
+    model_type { 'OpenAIGenerator' }
     model { 'gpt-3.5-turbo' }
     description { Faker::Lorem.paragraph }
 

--- a/spec/helpers/reports_helper_spec.rb
+++ b/spec/helpers/reports_helper_spec.rb
@@ -144,8 +144,8 @@ RSpec.describe ReportsHelper, type: :helper do
   end
 
   describe '#variant_pill_classes' do
-    let(:probe_result_passed) { instance_double('ProbeResult', passed: 1) }
-    let(:probe_result_blocked) { instance_double('ProbeResult', passed: 0) }
+    let(:probe_result_passed) { instance_double('ProbeResult', any_detector_passed: true) }
+    let(:probe_result_blocked) { instance_double('ProbeResult', any_detector_passed: false) }
 
     context 'when subindustry was not tested' do
       it 'returns grey background' do

--- a/spec/jobs/generate_variant_reports_job_spec.rb
+++ b/spec/jobs/generate_variant_reports_job_spec.rb
@@ -79,11 +79,32 @@ RSpec.describe GenerateVariantReportsJob, type: :job do
     context "when no probes passed in parent report" do
       before do
         scan.threat_variant_subindustries << subindustry
-        create(:probe_result, report: report, probe: probe, detector: detector, passed: 0, total: 10)
+        create(:probe_result, report: report, probe: probe, detector: detector, passed: 0, total: 10, any_detector_passed: false)
       end
 
       it "does nothing" do
         expect { described_class.new.perform(report.id) }.not_to change(Report, :count)
+      end
+    end
+
+    context "when a backfilled historical row has passed=0 but any_detector_passed=true" do
+      # Historical rows predate max-merge on probe_result.passed and may retain
+      # the last detector's inverted count. The migration backfills
+      # any_detector_passed=true wherever passed>0, but rows that were
+      # post-processed to passed=0 keep any_detector_passed=true if set
+      # by the live processing code. Variant reports must still fire on that
+      # signal regardless of the stored passed magnitude.
+      before do
+        scan.threat_variant_subindustries << subindustry
+        create(:probe_result,
+               report: report, probe: probe, detector: detector,
+               passed: 0, total: 10, any_detector_passed: true)
+      end
+
+      it "creates a child variant report using any_detector_passed" do
+        allow_any_instance_of(RunGarakScan).to receive(:call)
+
+        expect { described_class.new.perform(report.id) }.to change(Report, :count).by(1)
       end
     end
 

--- a/spec/migrations/add_threat_variant_indexes_concurrently_spec.rb
+++ b/spec/migrations/add_threat_variant_indexes_concurrently_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+require Rails.root.join("db/migrate/20260412050000_add_threat_variant_indexes_concurrently")
+
+RSpec.describe AddThreatVariantIndexesConcurrently do
+  let(:migration) { described_class.new }
+
+  describe "migration safety" do
+    it "disables DDL transaction for concurrent index creation" do
+      expect(described_class.disable_ddl_transaction).to be true
+    end
+  end
+
+  describe "#up" do
+    it "is idempotent when indexes already exist" do
+      conn = ActiveRecord::Base.connection
+      expect(conn.index_exists?(
+        :threat_variants, [ :probe_id, :prompt ],
+        name: "index_threat_variants_on_probe_and_prompt"
+      )).to be true
+
+      expect(conn.index_exists?(
+        :threat_variants, :prompt,
+        name: "index_threat_variants_on_prompt"
+      )).to be true
+
+      expect { migration.up }.not_to raise_error
+    end
+  end
+
+  describe "duplicate cleanup" do
+    around do |example|
+      conn = ActiveRecord::Base.connection
+      conn.remove_index :threat_variants, name: "index_threat_variants_on_probe_and_prompt", if_exists: true
+      example.run
+    ensure
+      unless conn.index_exists?(:threat_variants, [ :probe_id, :prompt ], name: "index_threat_variants_on_probe_and_prompt")
+        conn.add_index :threat_variants, [ :probe_id, :prompt ], unique: true,
+                       name: "index_threat_variants_on_probe_and_prompt"
+      end
+    end
+
+    it "removes duplicate threat_variants keeping the newest" do
+      probe = create(:probe)
+      subindustry = create(:threat_variant_subindustry)
+      conn = ActiveRecord::Base.connection
+      now = Time.current.utc.iso8601
+
+      conn.execute(<<~SQL)
+        INSERT INTO threat_variants (probe_id, threat_variant_subindustry_id, prompt, created_at, updated_at)
+        VALUES (#{probe.id}, #{subindustry.id}, 'dup_prompt', '#{(Time.current - 1.hour).utc.iso8601}', '#{now}')
+      SQL
+
+      conn.execute(<<~SQL)
+        INSERT INTO threat_variants (probe_id, threat_variant_subindustry_id, prompt, created_at, updated_at)
+        VALUES (#{probe.id}, #{subindustry.id}, 'dup_prompt', '#{now}', '#{now}')
+      SQL
+
+      newer_id = conn.execute("SELECT id FROM threat_variants WHERE probe_id = #{probe.id} AND prompt = 'dup_prompt' ORDER BY created_at DESC LIMIT 1").first["id"]
+
+      expect(ThreatVariant.where(probe: probe, prompt: "dup_prompt").count).to eq(2)
+
+      migration.send(:cleanup_duplicate_threat_variants)
+
+      remaining = ThreatVariant.where(probe: probe, prompt: "dup_prompt")
+      expect(remaining.count).to eq(1)
+      expect(remaining.first.id).to eq(newer_id)
+    end
+
+    it "reassigns probe_results to the kept record before deleting duplicates" do
+      probe = create(:probe)
+      subindustry = create(:threat_variant_subindustry)
+      conn = ActiveRecord::Base.connection
+      now = Time.current.utc.iso8601
+
+      conn.execute(<<~SQL)
+        INSERT INTO threat_variants (probe_id, threat_variant_subindustry_id, prompt, created_at, updated_at)
+        VALUES (#{probe.id}, #{subindustry.id}, 'fk_prompt', '#{(Time.current - 1.hour).utc.iso8601}', '#{now}')
+      SQL
+
+      conn.execute(<<~SQL)
+        INSERT INTO threat_variants (probe_id, threat_variant_subindustry_id, prompt, created_at, updated_at)
+        VALUES (#{probe.id}, #{subindustry.id}, 'fk_prompt', '#{now}', '#{now}')
+      SQL
+
+      older_id = conn.execute("SELECT id FROM threat_variants WHERE probe_id = #{probe.id} AND prompt = 'fk_prompt' ORDER BY created_at ASC LIMIT 1").first["id"]
+      newer_id = conn.execute("SELECT id FROM threat_variants WHERE probe_id = #{probe.id} AND prompt = 'fk_prompt' ORDER BY created_at DESC LIMIT 1").first["id"]
+
+      report = create(:report)
+      pr = create(:probe_result, report: report, probe: probe, threat_variant_id: older_id)
+
+      expect { migration.send(:cleanup_duplicate_threat_variants) }.not_to raise_error
+
+      pr.reload
+      expect(pr.threat_variant_id).to eq(newer_id)
+      expect(ThreatVariant.where(probe: probe, prompt: "fk_prompt").count).to eq(1)
+    end
+
+    it "does not remove non-duplicate records" do
+      probe = create(:probe)
+      subindustry = create(:threat_variant_subindustry)
+
+      v1 = create(:threat_variant, probe: probe, threat_variant_subindustry: subindustry, prompt: "prompt_a")
+      v2 = create(:threat_variant, probe: probe, threat_variant_subindustry: subindustry, prompt: "prompt_b")
+
+      migration.send(:cleanup_duplicate_threat_variants)
+
+      expect(ThreatVariant.exists?(v1.id)).to be true
+      expect(ThreatVariant.exists?(v2.id)).to be true
+    end
+  end
+end

--- a/spec/migrations/backfill_any_detector_passed_on_probe_results_spec.rb
+++ b/spec/migrations/backfill_any_detector_passed_on_probe_results_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+require Rails.root.join("db/migrate/20260412044226_backfill_any_detector_passed_on_probe_results")
+
+RSpec.describe BackfillAnyDetectorPassedOnProbeResults do
+  let(:migration) { described_class.new }
+
+  describe "#up" do
+    let(:report) { create(:report) }
+    let(:probe) { create(:probe) }
+    let(:detector) { create(:detector) }
+
+    before do
+      ProbeResult.reset_column_information
+    end
+
+    it "sets any_detector_passed=true for rows with passed > 0" do
+      pr = create(:probe_result, report: report, probe: probe, detector: detector,
+                  passed: 3, total: 10, any_detector_passed: false)
+
+      migration.up
+
+      expect(pr.reload.any_detector_passed).to be true
+    end
+
+    it "leaves any_detector_passed=false for rows with passed = 0" do
+      pr = create(:probe_result, report: report, probe: probe, detector: detector,
+                  passed: 0, total: 10, any_detector_passed: false)
+
+      migration.up
+
+      expect(pr.reload.any_detector_passed).to be false
+    end
+
+    it "does not overwrite already-true any_detector_passed" do
+      pr = create(:probe_result, report: report, probe: probe, detector: detector,
+                  passed: 5, total: 10, any_detector_passed: true)
+
+      migration.up
+
+      expect(pr.reload.any_detector_passed).to be true
+    end
+
+    it "handles batches across many records" do
+      results = 3.times.map do |i|
+        p = create(:probe, name: "Probe#{i}")
+        create(:probe_result, report: report, probe: p, detector: detector,
+               passed: i, total: 10, any_detector_passed: false)
+      end
+
+      migration.up
+
+      expect(results[0].reload.any_detector_passed).to be false
+      expect(results[1].reload.any_detector_passed).to be true
+      expect(results[2].reload.any_detector_passed).to be true
+    end
+  end
+end

--- a/spec/models/concerns/encryption_spec.rb
+++ b/spec/models/concerns/encryption_spec.rb
@@ -198,4 +198,148 @@ RSpec.describe "ActiveRecord Encryption", type: :model do
       expect(decrypted).to eq('{"key": "value"}')
     end
   end
+
+  describe "OutputServer encrypted fields" do
+    it "encrypts access_token at rest" do
+      server = create(:output_server, :with_credentials)
+      plaintext = server.access_token
+      raw = OutputServer.connection.select_value(
+        ActiveRecord::Base.sanitize_sql_array([ "SELECT access_token FROM output_servers WHERE id = ?", server.id ])
+      )
+      expect(raw).not_to eq(plaintext)
+    end
+
+    it "encrypts api_key at rest" do
+      server = create(:output_server, api_key: "sk-test-key-12345")
+      raw = OutputServer.connection.select_value(
+        ActiveRecord::Base.sanitize_sql_array([ "SELECT api_key FROM output_servers WHERE id = ?", server.id ])
+      )
+      expect(raw).not_to eq("sk-test-key-12345")
+    end
+
+    it "encrypts password at rest" do
+      server = create(:output_server, :with_credentials)
+      raw = OutputServer.connection.select_value(
+        ActiveRecord::Base.sanitize_sql_array([ "SELECT password FROM output_servers WHERE id = ?", server.id ])
+      )
+      expect(raw).not_to eq("password")
+    end
+
+    it "decrypts access_token transparently" do
+      server = create(:output_server, access_token: "my_token_value")
+      server.reload
+      expect(server.access_token).to eq("my_token_value")
+    end
+
+    it "decrypts api_key transparently" do
+      server = create(:output_server, api_key: "my_api_key_value")
+      server.reload
+      expect(server.api_key).to eq("my_api_key_value")
+    end
+
+    it "decrypts password transparently" do
+      server = create(:output_server, password: "my_password_value")
+      server.reload
+      expect(server.password).to eq("my_password_value")
+    end
+
+    it "handles nil credential fields" do
+      server = create(:output_server, access_token: nil, api_key: nil, password: nil)
+      server.reload
+      expect(server.access_token).to be_nil
+      expect(server.api_key).to be_nil
+      expect(server.password).to be_nil
+    end
+  end
+
+  describe "OutputServer per-tenant key isolation" do
+    let(:company_a) { create(:company) }
+    let(:company_b) { create(:company) }
+
+    it "produces different ciphertext for different tenants" do
+      server_a = ActsAsTenant.with_tenant(company_a) { create(:output_server, access_token: "same_token") }
+      server_b = ActsAsTenant.with_tenant(company_b) { create(:output_server, access_token: "same_token") }
+
+      raw_a = OutputServer.connection.select_value(
+        ActiveRecord::Base.sanitize_sql_array([ "SELECT access_token FROM output_servers WHERE id = ?", server_a.id ])
+      )
+      raw_b = OutputServer.connection.select_value(
+        ActiveRecord::Base.sanitize_sql_array([ "SELECT access_token FROM output_servers WHERE id = ?", server_b.id ])
+      )
+
+      expect(raw_a).not_to eq(raw_b)
+    end
+
+    it "decrypts correctly with the right tenant context" do
+      server = ActsAsTenant.with_tenant(company_a) { create(:output_server, api_key: "tenant_a_key") }
+
+      decrypted = ActsAsTenant.with_tenant(company_a) do
+        OutputServer.find(server.id).api_key
+      end
+
+      expect(decrypted).to eq("tenant_a_key")
+    end
+  end
+
+  describe "OutputServer migration re-encryption with encrypt method" do
+    it "re-encrypts output server secrets when using encrypt instead of save!" do
+      server = create(:output_server, :with_credentials)
+      original_token = server.access_token
+      raw_before = OutputServer.connection.select_value(
+        ActiveRecord::Base.sanitize_sql_array([ "SELECT access_token FROM output_servers WHERE id = ?", server.id ])
+      )
+
+      ActsAsTenant.with_tenant(server.company) do
+        server.encrypt
+      end
+
+      raw_after = OutputServer.connection.select_value(
+        ActiveRecord::Base.sanitize_sql_array([ "SELECT access_token FROM output_servers WHERE id = ?", server.id ])
+      )
+
+      expect(raw_after).not_to eq(raw_before)
+
+      decrypted = ActsAsTenant.with_tenant(server.company) do
+        OutputServer.find(server.id).access_token
+      end
+      expect(decrypted).to eq(original_token)
+    end
+
+    it "save! is a no-op for already-encrypted records (proving the migration bug)" do
+      server = create(:output_server, :with_credentials)
+      raw_before = OutputServer.connection.select_value(
+        ActiveRecord::Base.sanitize_sql_array([ "SELECT access_token FROM output_servers WHERE id = ?", server.id ])
+      )
+
+      ActsAsTenant.with_tenant(server.company) do
+        server.save!
+      end
+
+      raw_after = OutputServer.connection.select_value(
+        ActiveRecord::Base.sanitize_sql_array([ "SELECT access_token FROM output_servers WHERE id = ?", server.id ])
+      )
+
+      expect(raw_after).to eq(raw_before)
+    end
+  end
+
+  describe "OutputServer authentication works with encrypted credentials" do
+    it "authentication_method returns :token with encrypted access_token" do
+      server = create(:output_server, access_token: "encrypted_token")
+      server.reload
+      expect(server.authentication_method).to eq(:token)
+    end
+
+    it "authentication_method returns :api_key with encrypted api_key" do
+      server = create(:output_server, api_key: "encrypted_api_key")
+      server.reload
+      expect(server.authentication_method).to eq(:api_key)
+    end
+
+    it "authentication_method returns :basic with encrypted username and password" do
+      server = create(:output_server, username: "user", password: "pass")
+      server.reload
+      expect(server.authentication_method).to eq(:basic)
+    end
+  end
 end

--- a/spec/models/target_spec.rb
+++ b/spec/models/target_spec.rb
@@ -16,6 +16,89 @@ RSpec.describe Target, type: :model do
     it { is_expected.to validate_presence_of(:model) }
   end
 
+  describe "model format validation" do
+    context "for API targets" do
+      it "accepts valid model identifiers" do
+        valid_models = [ "gpt-4", "gpt-3.5-turbo", "claude-2", "meta-llama/Llama-2-7b", "openai:gpt-4", "model_v2" ]
+        valid_models.each do |model_name|
+          target = build(:target, target_type: :api, model: model_name)
+          target.valid?
+          expect(target.errors[:model]).to be_empty, "Expected '#{model_name}' to be valid but got: #{target.errors[:model]}"
+        end
+      end
+
+      it "rejects models with shell injection characters" do
+        dangerous_models = [
+          "'; rm -rf /; echo '",
+          "gpt-4; whoami",
+          "model$(id)",
+          "model`id`",
+          "model | cat /etc/passwd",
+          "model && echo pwned",
+          "model > /tmp/evil"
+        ]
+        dangerous_models.each do |model_name|
+          target = build(:target, target_type: :api, model: model_name)
+          expect(target).not_to be_valid, "Expected '#{model_name}' to be rejected"
+          expect(target.errors[:model].first).to include("contains invalid characters")
+        end
+      end
+
+      it "allows blank model (handled by presence validation)" do
+        target = build(:target, target_type: :api, model: nil)
+        target.valid?
+        expect(target.errors[:model]).to include("can't be blank")
+        expect(target.errors[:model]).not_to include(/contains invalid characters/)
+      end
+    end
+
+    context "for webchat targets" do
+      it "does not validate model format" do
+        target = build(:target, target_type: :webchat, model: "WebChatbotGenerator",
+                      web_config: {
+                        "url" => "https://example.com/chat",
+                        "selectors" => { "input_field" => "#input", "response_container" => "#response" }
+                      })
+        expect(target).to be_valid
+      end
+    end
+  end
+
+  describe "model_type validation" do
+    context "for API targets" do
+      it "accepts known generator types from INVERTED_MODEL_TYPES" do
+        valid_types = [ "OpenAIGenerator", "AzureOpenAIGenerator", "LiteLLMGenerator", "OllamaGenerator" ]
+        valid_types.each do |type|
+          target = build(:target, target_type: :api, model_type: type)
+          target.valid?
+          expect(target.errors[:model_type]).to be_empty, "Expected '#{type}' to be valid but got: #{target.errors[:model_type]}"
+        end
+      end
+
+      it "rejects unrecognized generator types" do
+        target = build(:target, target_type: :api, model_type: "FakeGenerator")
+        expect(target).not_to be_valid
+        expect(target.errors[:model_type].first).to include("is not a recognized generator type")
+      end
+
+      it "rejects model_type with injection characters" do
+        target = build(:target, target_type: :api, model_type: "openai; rm -rf /")
+        expect(target).not_to be_valid
+      end
+    end
+
+    context "for webchat targets" do
+      it "does not validate model_type against the allowlist" do
+        target = build(:target, target_type: :webchat, model_type: "web_chatbot",
+                      web_config: {
+                        "url" => "https://example.com/chat",
+                        "selectors" => { "input_field" => "#input", "response_container" => "#response" }
+                      })
+        expect(target).to be_valid
+      end
+    end
+  end
+
   describe "json_config validation" do
     context "for API targets" do
       it "accepts valid JSON when json_config is present" do
@@ -227,6 +310,7 @@ RSpec.describe Target, type: :model do
     end
 
     it "triggers validation when web_config changes" do
+      allow(UrlSafetyValidator).to receive(:resolve_addresses).and_return([ "93.184.216.34" ])
       target = create(:target, :good, target_type: :webchat,
                       web_config: {
                         "url" => "https://old.example.com/chat",
@@ -387,6 +471,12 @@ RSpec.describe Target, type: :model do
         target = build(:target, web_config: "{invalid json}")
         expect(target.parsed_web_config).to be_nil
       end
+
+      it "logs a warning for invalid JSON" do
+        target = build(:target, web_config: "{invalid json}")
+        expect(Rails.logger).to receive(:warn).with(/Target#parsed_web_config: invalid JSON/)
+        target.parsed_web_config
+      end
     end
 
     describe "#display_model_info" do
@@ -448,6 +538,7 @@ RSpec.describe Target, type: :model do
       end
 
       it "accepts config with HTTPS URL" do
+        allow(UrlSafetyValidator).to receive(:resolve_addresses).and_return([ "93.184.216.34" ])
         target = build(:target, target_type: :webchat, web_config: {
           "url" => "https://secure.example.com/chat",
           "selectors" => { "input_field" => "#input", "response_container" => "#response" }
@@ -554,6 +645,47 @@ RSpec.describe Target, type: :model do
 
         expect(target).not_to be_valid
         expect(target.errors[:web_config]).to include(/response_container/)
+      end
+    end
+
+    context "with SSRF protection" do
+      it "rejects URLs pointing to localhost" do
+        target = build(:target, target_type: :webchat, web_config: {
+          "url" => "http://127.0.0.1/chat",
+          "selectors" => { "input_field" => "#input", "response_container" => "#response" }
+        })
+        allow(UrlSafetyValidator).to receive(:safe_url?).and_return(
+          UrlSafetyValidator::Result.new("safe?": false, error: "blocked")
+        )
+
+        expect(target).not_to be_valid
+        expect(target.errors[:web_config]).to include("must include a valid URL")
+      end
+
+      it "rejects URLs pointing to cloud metadata endpoint" do
+        target = build(:target, target_type: :webchat, web_config: {
+          "url" => "http://169.254.169.254/latest/meta-data",
+          "selectors" => { "input_field" => "#input", "response_container" => "#response" }
+        })
+        allow(UrlSafetyValidator).to receive(:safe_url?).and_return(
+          UrlSafetyValidator::Result.new("safe?": false, error: "blocked")
+        )
+
+        expect(target).not_to be_valid
+      end
+
+      it "rejects URLs pointing to private networks" do
+        %w[http://10.0.0.1 http://172.16.0.1 http://192.168.1.1].each do |url|
+          target = build(:target, target_type: :webchat, web_config: {
+            "url" => url,
+            "selectors" => { "input_field" => "#input", "response_container" => "#response" }
+          })
+          allow(UrlSafetyValidator).to receive(:safe_url?).and_return(
+            UrlSafetyValidator::Result.new("safe?": false, error: "blocked")
+          )
+
+          expect(target).not_to be_valid, "Expected #{url} to be rejected"
+        end
       end
     end
 

--- a/spec/models/tenant_isolation_spec.rb
+++ b/spec/models/tenant_isolation_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Tenant Isolation", type: :model do
 
     it "automatically assigns current tenant on create" do
       ActsAsTenant.with_tenant(company_a) do
-        new_target = Target.create!(name: "New Target", model_type: "test", model: "test")
+        new_target = Target.create!(name: "New Target", model_type: "OpenAIGenerator", model: "gpt-4")
         expect(new_target.company).to eq(company_a)
       end
     end

--- a/spec/policies/tenant_scoped_policy_spec.rb
+++ b/spec/policies/tenant_scoped_policy_spec.rb
@@ -93,21 +93,35 @@ RSpec.describe TenantScopedPolicy do
     end
   end
 
-  describe 'security note' do
-    # This test documents the security model
+  describe 'authorization model' do
+    it 'grants all CRUD actions to any authenticated tenant user (intentional flat-permission design)' do
+      policy = described_class.new(user, target)
+      expect(policy.index?).to be true
+      expect(policy.show?).to be true
+      expect(policy.create?).to be true
+      expect(policy.update?).to be true
+      expect(policy.destroy?).to be true
+    end
+
+    it 'grants identical permissions to super_admin and regular user within the same tenant' do
+      regular_policy = described_class.new(user, target)
+      admin_policy = described_class.new(super_admin, target)
+
+      %i[index? show? create? update? destroy?].each do |action|
+        expect(regular_policy.public_send(action)).to eq(admin_policy.public_send(action)),
+          "Expected #{action} to be the same for regular user and super_admin"
+      end
+    end
+
     it 'relies on ActsAsTenant for tenant isolation' do
-      # When ActsAsTenant.current_tenant is set, queries are automatically scoped
       ActsAsTenant.with_tenant(company) do
         expect(ActsAsTenant.current_tenant).to eq(company)
-        # All Target queries in this block are scoped to company
       end
     end
 
     it 'exposes all tenants when ActsAsTenant is bypassed' do
-      # This is intentional for super_admin contexts
       ActsAsTenant.without_tenant do
         expect(ActsAsTenant.current_tenant).to be_nil
-        # Queries here return all records - only use for super_admin!
       end
     end
   end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -58,8 +58,12 @@ RSpec.describe UserPolicy do
       expect(described_class.new(super_admin, other_super_admin).update?).to be true
     end
 
-    it "allows user to update same company user" do
-      expect(described_class.new(regular_user, same_company_user).update?).to be true
+    it "allows user to update their own record" do
+      expect(described_class.new(regular_user, regular_user).update?).to be true
+    end
+
+    it "denies non-super-admin from updating a same-company peer" do
+      expect(described_class.new(regular_user, same_company_user).update?).to be false
     end
 
     it "denies user from updating other company user" do
@@ -84,15 +88,19 @@ RSpec.describe UserPolicy do
       expect(described_class.new(super_admin, regular_user).destroy?).to be true
     end
 
+    it "allows super admin to delete other company user" do
+      expect(described_class.new(super_admin, other_company_user).destroy?).to be true
+    end
+
     it "denies super admin from deleting another super admin" do
       expect(described_class.new(super_admin, other_super_admin).destroy?).to be false
     end
 
-    it "allows user to delete same company user" do
-      expect(described_class.new(regular_user, same_company_user).destroy?).to be true
+    it "denies regular user from deleting same company user" do
+      expect(described_class.new(regular_user, same_company_user).destroy?).to be false
     end
 
-    it "denies user from deleting other company user" do
+    it "denies regular user from deleting other company user" do
       expect(described_class.new(regular_user, other_company_user).destroy?).to be false
     end
 

--- a/spec/requests/report_details_spec.rb
+++ b/spec/requests/report_details_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe "ReportDetails", type: :request do
+  let(:company) { create(:company) }
+  let(:report) { create(:report, :completed, company: company) }
+
+  describe "GET /report_details/:id (cross-tenant isolation)" do
+    let(:company_a) { create(:company) }
+    let(:company_b) { create(:company) }
+    let(:user_a) { create(:user, company: company_a) }
+    let(:report_b) { create(:report, :completed, company: company_b) }
+
+    it "prevents Company-A user from viewing Company-B report" do
+      sign_in user_a
+      get report_detail_path(report_b)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "allows a user to view their own company report when detector results are present" do
+      report_a = create(:report, :completed, company: company_a)
+      create(:detector_result, report: report_a, passed: 3, total: 10)
+
+      sign_in user_a
+      get report_detail_path(report_a)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /report_details/:id (anonymous)" do
+    context "without any token" do
+      it "redirects to sign in instead of returning 500" do
+        get report_detail_path(report)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "with pdf=true and a valid pdf_token" do
+      let!(:detector_result) { create(:detector_result, report: report, passed: 3, total: 10) }
+
+      let(:pdf_token) do
+        Rails.application.message_verifier("pdf").generate(
+          report.id,
+          expires_in: 5.minutes,
+          purpose: :pdf_render
+        )
+      end
+
+      it "renders the show page successfully" do
+        get report_detail_path(report, pdf: "true", pdf_token: pdf_token)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with pdf=true but an invalid pdf_token" do
+      it "redirects to sign in" do
+        get report_detail_path(report, pdf: "true", pdf_token: "invalid-token")
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "with pdf=true and an expired pdf_token" do
+      let(:expired_token) do
+        Rails.application.message_verifier("pdf").generate(
+          report.id,
+          expires_at: 1.minute.ago,
+          purpose: :pdf_render
+        )
+      end
+
+      it "redirects to sign in" do
+        get report_detail_path(report, pdf: "true", pdf_token: expired_token)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/services/browser_automation/playwright_service_spec.rb
+++ b/spec/services/browser_automation/playwright_service_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe BrowserAutomation::PlaywrightService do
   let(:service) { described_class.instance }
 
   before do
-    # Reset singleton state between tests
     service.instance_variable_set(:@browser_process, nil)
     service.instance_variable_set(:@browser_ready, false)
   end
@@ -51,7 +50,7 @@ RSpec.describe BrowserAutomation::PlaywrightService do
 
     it "executes playwright script with correct parameters" do
       expect(Open3).to receive(:capture3).with(
-        hash_including("NODE_PATH" => Rails.root.join("node_modules").to_s),
+        hash_including("NODE_PATH" => Rails.root.join("node_modules").to_s, "PLAYWRIGHT_DATA_PATH" => anything),
         "node",
         anything
       ).and_return([ success_response, "", double(success?: true) ])
@@ -82,10 +81,109 @@ RSpec.describe BrowserAutomation::PlaywrightService do
 
       service.screenshot(url, output_path, options)
 
-      # Verify that the options were used in the generated script
       expect(script_content).to include("width: 1024")
       expect(script_content).to include("height: 768")
       expect(script_content).to include("fullPage: true")
+    end
+
+    it "passes URL via JSON data file instead of interpolating into script" do
+      script_content = nil
+      data_content = nil
+
+      allow(Open3).to receive(:capture3) do |env, _command, script_path|
+        script_content = File.read(script_path)
+        data_content = JSON.parse(File.read(env["PLAYWRIGHT_DATA_PATH"]))
+        [ success_response, "", double(success?: true) ]
+      end
+
+      service.screenshot(url, output_path)
+
+      expect(script_content).to include("__data.url")
+      expect(script_content).not_to include("'https://example.com'")
+      expect(data_content["url"]).to eq("https://example.com")
+    end
+
+    it "coerces numeric options to integers" do
+      options = { width: "1024", height: "768", timeout: "5000" }
+      script_content = nil
+
+      allow(Open3).to receive(:capture3) do |_env, _command, script_path|
+        script_content = File.read(script_path)
+        [ success_response, "", double(success?: true) ]
+      end
+
+      service.screenshot(url, output_path, options)
+
+      expect(script_content).to include("width: 1024")
+      expect(script_content).to include("height: 768")
+      expect(script_content).to include("timeout: 5000")
+    end
+
+    it "coerces full_page to strict boolean" do
+      script_content = nil
+
+      allow(Open3).to receive(:capture3) do |_env, _command, script_path|
+        script_content = File.read(script_path)
+        [ success_response, "", double(success?: true) ]
+      end
+
+      service.screenshot(url, output_path, { full_page: "yes" })
+      expect(script_content).to include("fullPage: false")
+    end
+  end
+
+  describe "#generate_pdf" do
+    let(:url) { "https://example.com/report" }
+    let(:output_path) { "/tmp/report.pdf" }
+    let(:success_response) { { "success" => true, "path" => output_path }.to_json }
+
+    before do
+      allow(Open3).to receive(:capture3).and_return([ success_response, "", double(success?: true) ])
+    end
+
+    it "passes URL via JSON data file instead of interpolating into script" do
+      script_content = nil
+      data_content = nil
+
+      allow(Open3).to receive(:capture3) do |env, _command, script_path|
+        script_content = File.read(script_path)
+        data_content = JSON.parse(File.read(env["PLAYWRIGHT_DATA_PATH"]))
+        [ success_response, "", double(success?: true) ]
+      end
+
+      service.generate_pdf(url, output_path)
+
+      expect(script_content).to include("__data.url")
+      expect(script_content).not_to include("'https://example.com/report'")
+      expect(data_content["url"]).to eq("https://example.com/report")
+    end
+
+    it "coerces boolean PDF options strictly" do
+      script_content = nil
+
+      allow(Open3).to receive(:capture3) do |_env, _command, script_path|
+        script_content = File.read(script_path)
+        [ success_response, "", double(success?: true) ]
+      end
+
+      service.generate_pdf(url, output_path, { print_background: "yes", prefer_css_page_size: 1 })
+
+      expect(script_content).to include("printBackground: false")
+      expect(script_content).to include("preferCSSPageSize: false")
+    end
+
+    it "defaults boolean PDF options to true" do
+      script_content = nil
+
+      allow(Open3).to receive(:capture3) do |_env, _command, script_path|
+        script_content = File.read(script_path)
+        [ success_response, "", double(success?: true) ]
+      end
+
+      service.generate_pdf(url, output_path)
+
+      expect(script_content).to include("printBackground: true")
+      expect(script_content).to include("preferCSSPageSize: true")
     end
   end
 
@@ -212,6 +310,31 @@ RSpec.describe BrowserAutomation::PlaywrightService do
       expect(script_content).to include("timeout: 60000")
       expect(script_content).to include("waitForTimeout(10000)")
     end
+
+    it "passes selectors via JSON data file instead of interpolating into script" do
+      script_content = nil
+      data_content = nil
+
+      allow(Open3).to receive(:capture3) do |env, _command, script_path|
+        script_content = File.read(script_path)
+        data_content = JSON.parse(File.read(env["PLAYWRIGHT_DATA_PATH"]))
+        [
+          { "success" => true, "errors" => [], "response_detected" => true }.to_json,
+          "",
+          double(success?: true)
+        ]
+      end
+
+      service.validate_webchat_config(url, config)
+
+      expect(script_content).to include("__data.input_selector")
+      expect(script_content).to include("__data.container_selector")
+      expect(script_content).not_to include("'#chat-input'")
+      expect(script_content).not_to include("'.chat-messages'")
+      expect(data_content["input_selector"]).to eq("#chat-input")
+      expect(data_content["container_selector"]).to eq(".chat-messages")
+      expect(data_content["send_selector"]).to eq("#send-btn")
+    end
   end
 
   describe "#extract_page_structure" do
@@ -293,6 +416,25 @@ RSpec.describe BrowserAutomation::PlaywrightService do
       expect(script_content).to include("height: 768")
       expect(script_content).to include("timeout: 20000")
     end
+
+    it "passes URL and user agent via JSON data file" do
+      script_content = nil
+      data_content = nil
+
+      allow(Open3).to receive(:capture3) do |env, _command, script_path|
+        script_content = File.read(script_path)
+        data_content = JSON.parse(File.read(env["PLAYWRIGHT_DATA_PATH"]))
+        [ success_response, "", double(success?: true) ]
+      end
+
+      service.extract_page_structure(url, { user_agent: "CustomAgent/1.0" })
+
+      expect(script_content).to include("__data.url")
+      expect(script_content).to include("__data.user_agent")
+      expect(script_content).not_to include("'https://example.com/chat'")
+      expect(data_content["url"]).to eq("https://example.com/chat")
+      expect(data_content["user_agent"]).to eq("CustomAgent/1.0")
+    end
   end
 
   describe "#stop_browser" do
@@ -313,14 +455,29 @@ RSpec.describe BrowserAutomation::PlaywrightService do
       expect(Process).to have_received(:wait).with(pid)
     end
 
-    it "handles process kill errors gracefully" do
+    it "handles process kill errors gracefully and logs warning" do
       pid = 12345
       service.instance_variable_set(:@browser_process, pid)
 
       allow(Process).to receive(:kill).and_raise(Errno::ESRCH)
-      allow(Process).to receive(:wait)
+      allow(Process).to receive(:wait).and_raise(Errno::ECHILD)
+      allow(Rails.logger).to receive(:warn)
 
       expect { service.stop_browser }.not_to raise_error
+      expect(Rails.logger).to have_received(:warn).with(/failed to kill process/).once
+      expect(Rails.logger).to have_received(:warn).with(/failed to wait on process/).once
+    end
+
+    it "logs warning when temp script unlink fails" do
+      temp_script = instance_double(Tempfile)
+      allow(temp_script).to receive(:unlink).and_raise(Errno::ENOENT.new("no such file"))
+      service.instance_variable_set(:@temp_script, temp_script)
+      allow(Rails.logger).to receive(:warn)
+
+      service.stop_browser
+
+      expect(Rails.logger).to have_received(:warn).with(/failed to unlink temp script/)
+      expect(service.instance_variable_get(:@temp_script)).to be_nil
     end
 
     it "resets browser_ready flag" do
@@ -352,7 +509,7 @@ RSpec.describe BrowserAutomation::PlaywrightService do
         expect(Open3).to have_received(:capture3) do |env, command, script_path|
           expect(env["NODE_PATH"]).to eq(Rails.root.join("node_modules").to_s)
           expect(command).to eq("node")
-          expect(File.exist?(script_path)).to be false # Temp file should be cleaned up
+          expect(File.exist?(script_path)).to be false
         end
       end
 
@@ -384,7 +541,6 @@ RSpec.describe BrowserAutomation::PlaywrightService do
 
         result = service.send(:execute_playwright_script, script)
 
-        # Now treated as a generic no-JSON case with stdout/stderr attached
         expect(result["error"]).to include("No JSON found in output")
       end
 
@@ -401,6 +557,43 @@ RSpec.describe BrowserAutomation::PlaywrightService do
 
         expect { service.send(:execute_playwright_script, script) }.to raise_error(StandardError)
         expect(temp_file).to have_received(:unlink)
+      end
+
+      it "writes data to a JSON temp file when data is provided" do
+        script = "console.log('test');"
+        test_data = { url: "https://example.com", selector: "#input" }
+
+        allow(Open3).to receive(:capture3) do |env, _command, _script_path|
+          data_path = env["PLAYWRIGHT_DATA_PATH"]
+          expect(data_path).to be_present
+          parsed = JSON.parse(File.read(data_path))
+          expect(parsed["url"]).to eq("https://example.com")
+          expect(parsed["selector"]).to eq("#input")
+          [ { "success" => true }.to_json, "", double(success?: true) ]
+        end
+
+        service.send(:execute_playwright_script, script, data: test_data)
+      end
+
+      it "cleans up data file even on error" do
+        script = "console.log('test');"
+        test_data = { url: "https://example.com" }
+        temp_paths = []
+
+        allow(Tempfile).to receive(:new).and_wrap_original do |original, *args|
+          file = original.call(*args)
+          temp_paths << file.path
+          file
+        end
+
+        allow(Open3).to receive(:capture3).and_raise(StandardError)
+
+        expect { service.send(:execute_playwright_script, script, data: test_data) }.to raise_error(StandardError)
+
+        expect(temp_paths.length).to eq(2)
+        temp_paths.each do |path|
+          expect(File.exist?(path)).to be false
+        end
       end
     end
 
@@ -424,36 +617,45 @@ RSpec.describe BrowserAutomation::PlaywrightService do
     end
 
     describe "#build_page_script" do
-      it "includes URL when provided" do
-        script = service.send(:build_page_script, "https://example.com", {})
+      it "includes conditional URL navigation using data" do
+        script, data = service.send(:build_page_script, "https://example.com", {})
 
-        expect(script).to include("await page.goto('https://example.com'")
+        expect(script).to include("if (__data.url)")
+        expect(script).to include("__data.url")
+        expect(script).not_to include("'https://example.com'")
+        expect(data[:url]).to eq("https://example.com")
       end
 
-      it "omits goto when URL is nil" do
-        script = service.send(:build_page_script, nil, {})
+      it "sets url to nil in data when URL is nil" do
+        script, data = service.send(:build_page_script, nil, {})
 
-        expect(script).to include("// No URL provided")
-        expect(script).not_to include("await page.goto")
+        expect(script).to include("if (__data.url)")
+        expect(data[:url]).to be_nil
+      end
+
+      it "does not include firefoxUserPrefs in chromium launch config" do
+        script, _data = service.send(:build_page_script, "https://example.com", {})
+
+        expect(script).not_to include("firefoxUserPrefs")
       end
 
       it "respects headless option" do
-        script = service.send(:build_page_script, "https://example.com", { headless: false })
+        script, _data = service.send(:build_page_script, "https://example.com", { headless: false })
 
         expect(script).to include("headless: false")
       end
 
       it "uses custom viewport dimensions" do
-        script = service.send(:build_page_script, "https://example.com", { width: 800, height: 600 })
+        script, _data = service.send(:build_page_script, "https://example.com", { width: 800, height: 600 })
 
         expect(script).to include("width: 800")
         expect(script).to include("height: 600")
       end
 
-      it "uses custom wait_until strategy" do
-        script = service.send(:build_page_script, "https://example.com", { wait_until: "load" })
+      it "passes wait_until via data hash" do
+        _script, data = service.send(:build_page_script, "https://example.com", { wait_until: "load" })
 
-        expect(script).to include("waitUntil: 'load'")
+        expect(data[:wait_until]).to eq("load")
       end
     end
   end
@@ -472,6 +674,224 @@ RSpec.describe BrowserAutomation::PlaywrightService do
       expect(mutex).to receive(:synchronize).and_call_original
 
       service.send(:execute_playwright_script, "test script")
+    end
+  end
+
+  describe "script injection prevention" do
+    before do
+      allow(service).to receive(:validate_url_safety!)
+    end
+
+    it "prevents URL injection in screenshot" do
+      malicious_url = "https://example.com'); process.exit(1); //"
+      script_content = nil
+      data_content = nil
+
+      allow(Open3).to receive(:capture3) do |env, _command, script_path|
+        script_content = File.read(script_path)
+        data_content = JSON.parse(File.read(env["PLAYWRIGHT_DATA_PATH"]))
+        [ { "success" => true, "path" => "/tmp/test.png" }.to_json, "", double(success?: true) ]
+      end
+
+      service.screenshot(malicious_url, "/tmp/test.png")
+
+      expect(script_content).not_to include("process.exit(1)")
+      expect(script_content).not_to include(malicious_url)
+      expect(data_content["url"]).to eq(malicious_url)
+    end
+
+    it "prevents URL injection in generate_pdf" do
+      malicious_url = "https://example.com'); require('child_process').exec('id'); //"
+      script_content = nil
+      data_content = nil
+
+      allow(Open3).to receive(:capture3) do |env, _command, script_path|
+        script_content = File.read(script_path)
+        data_content = JSON.parse(File.read(env["PLAYWRIGHT_DATA_PATH"]))
+        [ { "success" => true, "path" => "/tmp/test.pdf" }.to_json, "", double(success?: true) ]
+      end
+
+      service.generate_pdf(malicious_url, "/tmp/test.pdf")
+
+      expect(script_content).not_to include("child_process")
+      expect(script_content).not_to include(malicious_url)
+      expect(data_content["url"]).to eq(malicious_url)
+    end
+
+    it "prevents selector injection in validate_webchat_config" do
+      malicious_selector = "'); process.exit(1); //"
+      config = {
+        selectors: {
+          input_field: malicious_selector,
+          send_button: "#send",
+          response_container: "'); require('fs').writeFileSync('/tmp/pwned',''); //"
+        }
+      }
+
+      script_content = nil
+      data_content = nil
+
+      allow(Open3).to receive(:capture3) do |env, _command, script_path|
+        script_content = File.read(script_path)
+        data_content = JSON.parse(File.read(env["PLAYWRIGHT_DATA_PATH"]))
+        [
+          { "success" => true, "errors" => [], "response_detected" => true }.to_json,
+          "",
+          double(success?: true)
+        ]
+      end
+
+      service.validate_webchat_config("https://example.com", config)
+
+      expect(script_content).not_to include("process.exit(1)")
+      expect(script_content).not_to include("writeFileSync")
+      expect(data_content["input_selector"]).to eq(malicious_selector)
+      expect(data_content["container_selector"]).to eq(config[:selectors][:response_container])
+    end
+
+    it "prevents user agent injection in extract_page_structure" do
+      malicious_agent = "Mozilla'); process.exit(1); //"
+      script_content = nil
+
+      allow(Open3).to receive(:capture3) do |_env, _command, script_path|
+        script_content = File.read(script_path)
+        [
+          { "success" => true, "data" => { "html" => {}, "metadata" => {}, "screenshot" => "" } }.to_json,
+          "",
+          double(success?: true)
+        ]
+      end
+
+      service.extract_page_structure("https://example.com", { user_agent: malicious_agent })
+
+      expect(script_content).not_to include("process.exit(1)")
+      expect(script_content).not_to include(malicious_agent)
+    end
+
+    it "prevents URL injection in build_page_script" do
+      malicious_url = "https://example.com'); process.exit(1); //"
+      script, data = service.send(:build_page_script, malicious_url, {})
+
+      expect(script).not_to include("process.exit(1)")
+      expect(script).not_to include(malicious_url)
+      expect(data[:url]).to eq(malicious_url)
+    end
+
+    it "handles selectors containing quotes safely" do
+      config = {
+        selectors: {
+          input_field: "input[name='message']",
+          send_button: "button[aria-label=\"send\"]",
+          response_container: ".chat-container"
+        }
+      }
+
+      script_content = nil
+      data_content = nil
+
+      allow(Open3).to receive(:capture3) do |env, _command, script_path|
+        script_content = File.read(script_path)
+        data_content = JSON.parse(File.read(env["PLAYWRIGHT_DATA_PATH"]))
+        [
+          { "success" => true, "errors" => [], "response_detected" => true }.to_json,
+          "",
+          double(success?: true)
+        ]
+      end
+
+      service.validate_webchat_config("https://example.com", config)
+
+      expect(script_content).not_to include("input[name='message']")
+      expect(data_content["input_selector"]).to eq("input[name='message']")
+    end
+
+    it "no untrusted string values appear in generated scripts" do
+      test_url = "https://example.com/unique-marker-page"
+      test_selector = "#unique-marker-selector"
+      test_agent = "UniqueMarkerAgent/1.0"
+
+      script_contents = []
+      all_pass = true
+
+      capture_script = lambda do |env, _command, script_path|
+        script_contents << File.read(script_path)
+        [ { "success" => true, "path" => "/tmp/x", "errors" => [], "response_detected" => true,
+            "data" => { "html" => {}, "metadata" => {}, "screenshot" => "" } }.to_json, "", double(success?: true) ]
+      end
+
+      allow(Open3).to receive(:capture3, &capture_script)
+
+      service.screenshot(test_url, "/tmp/test.png")
+      service.generate_pdf(test_url, "/tmp/test.pdf")
+      service.validate_webchat_config(test_url, {
+        selectors: { input_field: test_selector, response_container: test_selector }
+      })
+      service.extract_page_structure(test_url, { user_agent: test_agent })
+
+      script_contents.each do |content|
+        all_pass &&= !content.include?(test_url)
+      end
+      expect(all_pass).to be true
+
+      expect(script_contents[2]).not_to include(test_selector)
+      expect(script_contents[3]).not_to include(test_agent)
+
+      script_contents.each do |content|
+        expect(content).not_to include("unique-marker-page")
+      end
+    end
+  end
+
+  describe "SSRF protection" do
+    let(:blocked_urls) { %w[http://169.254.169.254 http://10.0.0.1 http://192.168.1.1 http://172.16.0.1] }
+
+    it "blocks private/internal URLs in screenshot" do
+      blocked_urls.each do |url|
+        expect { service.screenshot(url) }.to raise_error(ArgumentError, /SSRF protection/), "Expected #{url} to be blocked"
+      end
+    end
+
+    it "blocks private/internal URLs in generate_pdf" do
+      blocked_urls.each do |url|
+        expect { service.generate_pdf(url) }.to raise_error(ArgumentError, /SSRF protection/), "Expected #{url} to be blocked"
+      end
+    end
+
+    it "blocks private/internal URLs in validate_webchat_config" do
+      config = { selectors: { input_field: "#input", response_container: "#response" } }
+      blocked_urls.each do |url|
+        expect { service.validate_webchat_config(url, config) }.to raise_error(ArgumentError, /SSRF protection/), "Expected #{url} to be blocked"
+      end
+    end
+
+    it "blocks private/internal URLs in extract_page_structure" do
+      blocked_urls.each do |url|
+        expect { service.extract_page_structure(url) }.to raise_error(ArgumentError, /SSRF protection/), "Expected #{url} to be blocked"
+      end
+    end
+
+    it "blocks private/internal URLs in with_page" do
+      blocked_urls.each do |url|
+        expect { service.with_page(url) }.to raise_error(ArgumentError, /SSRF protection/), "Expected #{url} to be blocked"
+      end
+    end
+
+    it "allows external URLs" do
+      allow(Open3).to receive(:capture3).and_return([
+        { "success" => true, "path" => "/tmp/test.png" }.to_json, "", double(success?: true)
+      ])
+      expect { service.screenshot("https://example.com", "/tmp/test.png") }.not_to raise_error
+    end
+
+    it "allows localhost in dev/test mode" do
+      allow(Open3).to receive(:capture3).and_return([
+        { "success" => true, "path" => "/tmp/test.png" }.to_json, "", double(success?: true)
+      ])
+      expect { service.screenshot("http://127.0.0.1:3000", "/tmp/test.png") }.not_to raise_error
+    end
+
+    it "raises ArgumentError with SSRF message on blocked URLs" do
+      expect { service.screenshot("http://10.0.0.1") }.to raise_error(ArgumentError, /SSRF protection.*blocked internal address/)
     end
   end
 end

--- a/spec/services/output_servers/connection_test_spec.rb
+++ b/spec/services/output_servers/connection_test_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OutputServers::ConnectionTest do
+  describe "SSRF protection" do
+    context "in production (localhost not allowed)" do
+      before do
+        allow(Rails.env).to receive(:development?).and_return(false)
+        allow(Rails.env).to receive(:test?).and_return(false)
+      end
+
+      it "blocks connections to localhost" do
+        server = build(:output_server, host: "127.0.0.1", enabled: true)
+        result = described_class.new(server).call
+
+        expect(result[:success]).to be false
+        expect(result[:message]).to include("Connection blocked")
+      end
+
+      it "blocks connections to IPv6 loopback" do
+        server = build(:output_server, host: "::1", enabled: true)
+        result = described_class.new(server).call
+
+        expect(result[:success]).to be false
+        expect(result[:message]).to include("Connection blocked")
+      end
+    end
+
+    it "blocks connections to private RFC1918 addresses" do
+      %w[10.0.0.1 172.16.0.1 192.168.1.1].each do |ip|
+        server = build(:output_server, host: ip, enabled: true)
+        result = described_class.new(server).call
+
+        expect(result[:success]).to be false
+        expect(result[:message]).to include("Connection blocked"), "Expected #{ip} to be blocked"
+      end
+    end
+
+    it "blocks connections to cloud metadata endpoint" do
+      server = build(:output_server, host: "169.254.169.254", enabled: true)
+      result = described_class.new(server).call
+
+      expect(result[:success]).to be false
+      expect(result[:message]).to include("Connection blocked")
+    end
+
+    it "blocks hostnames that resolve to internal IPs" do
+      allow(UrlSafetyValidator).to receive(:resolve_addresses).with("evil.internal").and_return([ "10.0.0.1" ])
+      server = build(:output_server, host: "evil.internal", enabled: true)
+      result = described_class.new(server).call
+
+      expect(result[:success]).to be false
+      expect(result[:message]).to include("Connection blocked")
+    end
+
+    it "returns not-enabled message before SSRF check when disabled" do
+      server = build(:output_server, host: "127.0.0.1", enabled: false)
+      result = described_class.new(server).call
+
+      expect(result[:success]).to be false
+      expect(result[:message]).to include("not enabled")
+    end
+
+    it "blocks connections when endpoint_path redirects to a different host via @ in URI" do
+      server = build(:output_server, host: "safe.example.com", endpoint_path: "@evil.com/ssrf", enabled: true)
+      allow(UrlSafetyValidator).to receive(:safe_host?).and_call_original
+      allow(UrlSafetyValidator).to receive(:resolve_addresses).with("safe.example.com").and_return([ "93.184.216.34" ])
+      allow(UrlSafetyValidator).to receive(:resolve_addresses).with("evil.com").and_return([ "10.0.0.1" ])
+
+      result = described_class.new(server).call
+
+      expect(result[:success]).to be false
+      expect(result[:message]).to include("Connection blocked")
+    end
+
+    it "blocks connections when endpoint_path makes constructed URL resolve to internal host" do
+      server = build(:output_server, host: "safe.example.com", endpoint_path: "@169.254.169.254/metadata", enabled: true)
+      allow(UrlSafetyValidator).to receive(:safe_host?).and_call_original
+      allow(UrlSafetyValidator).to receive(:resolve_addresses).with("safe.example.com").and_return([ "93.184.216.34" ])
+
+      result = described_class.new(server).call
+
+      expect(result[:success]).to be false
+      expect(result[:message]).to include("Connection blocked")
+    end
+
+    it "treats URI parse failure as unsafe instead of passing" do
+      server = build(:output_server, host: "safe.example.com", enabled: true)
+      allow(UrlSafetyValidator).to receive(:safe_host?).and_return(
+        UrlSafetyValidator::Result.new("safe?": true, error: nil)
+      )
+      allow(server).to receive(:connection_string).and_return("http://[invalid uri")
+
+      result = described_class.new(server).call
+
+      expect(result[:success]).to be false
+      expect(result[:message]).to include("Connection blocked")
+      expect(result[:message]).to include("invalid")
+    end
+  end
+
+  describe "TLS certificate verification" do
+    let(:server) { build(:output_server, server_type: "rsyslog", protocol: "tls", host: "example.com", port: 6514, enabled: true) }
+    let(:tcp_socket) { instance_double(TCPSocket) }
+    let(:ssl_context) { instance_double(OpenSSL::SSL::SSLContext) }
+    let(:ssl_socket) { instance_double(OpenSSL::SSL::SSLSocket) }
+    let(:cert_store) { instance_double(OpenSSL::X509::Store) }
+
+    before do
+      allow(UrlSafetyValidator).to receive(:safe_host?).and_return(
+        UrlSafetyValidator::Result.new("safe?": true, error: nil)
+      )
+      allow(TCPSocket).to receive(:new).and_return(tcp_socket)
+      allow(OpenSSL::SSL::SSLContext).to receive(:new).and_return(ssl_context)
+      allow(OpenSSL::X509::Store).to receive(:new).and_return(cert_store)
+      allow(cert_store).to receive(:set_default_paths).and_return(cert_store)
+      allow(ssl_context).to receive(:verify_mode=)
+      allow(ssl_context).to receive(:cert_store=)
+      allow(OpenSSL::SSL::SSLSocket).to receive(:new).and_return(ssl_socket)
+      allow(ssl_socket).to receive(:hostname=)
+      allow(ssl_socket).to receive(:connect)
+      allow(ssl_socket).to receive(:puts)
+      allow(ssl_socket).to receive(:close)
+      allow(tcp_socket).to receive(:close)
+    end
+
+    it "sets verify_mode to VERIFY_PEER" do
+      described_class.new(server).call
+      expect(ssl_context).to have_received(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
+    end
+
+    it "sets the certificate store with default paths" do
+      described_class.new(server).call
+      expect(cert_store).to have_received(:set_default_paths)
+    end
+
+    it "sets SNI hostname" do
+      described_class.new(server).call
+      expect(ssl_socket).to have_received(:hostname=).with("example.com")
+    end
+
+    it "connects to the pinned IP from DNS resolution instead of re-resolving hostname" do
+      allow(UrlSafetyValidator).to receive(:safe_host?).and_return(
+        UrlSafetyValidator::Result.new("safe?": true, error: nil, resolved_ips: [ "93.184.216.34" ])
+      )
+      described_class.new(server).call
+      expect(TCPSocket).to have_received(:new).with("93.184.216.34", 6514)
+      expect(ssl_socket).to have_received(:hostname=).with("example.com")
+    end
+  end
+
+  describe "DNS rebinding prevention" do
+    it "pins resolved IP for Splunk HTTP connections" do
+      server = build(:output_server, server_type: "splunk", host: "example.com", port: 8088, enabled: true)
+      allow(UrlSafetyValidator).to receive(:safe_host?).and_return(
+        UrlSafetyValidator::Result.new("safe?": true, error: nil, resolved_ips: [ "93.184.216.34" ])
+      )
+
+      http_double = instance_double(Net::HTTP)
+      allow(Net::HTTP).to receive(:new).and_return(http_double)
+      allow(http_double).to receive(:use_ssl=)
+      allow(http_double).to receive(:open_timeout=)
+      allow(http_double).to receive(:read_timeout=)
+
+      response = instance_double(Net::HTTPResponse, code: "200", body: "OK")
+      allow(http_double).to receive(:request).and_return(response)
+
+      described_class.new(server).call
+      expect(Net::HTTP).to have_received(:new).with("93.184.216.34", anything)
+    end
+
+    it "pins resolved IP for TCP syslog connections" do
+      server = build(:output_server, server_type: "rsyslog", protocol: "tcp", host: "example.com", port: 514, enabled: true)
+      allow(UrlSafetyValidator).to receive(:safe_host?).and_return(
+        UrlSafetyValidator::Result.new("safe?": true, error: nil, resolved_ips: [ "93.184.216.34" ])
+      )
+
+      socket = instance_double(TCPSocket)
+      allow(TCPSocket).to receive(:new).and_return(socket)
+      allow(socket).to receive(:puts)
+      allow(socket).to receive(:close)
+
+      described_class.new(server).call
+      expect(TCPSocket).to have_received(:new).with("93.184.216.34", 514)
+    end
+
+    it "pins resolved IP for UDP syslog connections" do
+      server = build(:output_server, server_type: "rsyslog", protocol: "udp", host: "example.com", port: 514, enabled: true)
+      allow(UrlSafetyValidator).to receive(:safe_host?).and_return(
+        UrlSafetyValidator::Result.new("safe?": true, error: nil, resolved_ips: [ "93.184.216.34" ])
+      )
+
+      socket = instance_double(UDPSocket)
+      allow(UDPSocket).to receive(:new).and_return(socket)
+      allow(socket).to receive(:send)
+      allow(socket).to receive(:close)
+
+      described_class.new(server).call
+      expect(socket).to have_received(:send).with(anything, 0, "93.184.216.34", 514)
+    end
+  end
+end

--- a/spec/services/reports/pdf_generator_spec.rb
+++ b/spec/services/reports/pdf_generator_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe Reports::PdfGenerator do
           format: "A4",
           print_background: true,
           prefer_css_page_size: true,
-          timeout: 20000
+          timeout: 20000,
+          allow_localhost: true
         }
       )
 

--- a/spec/services/reports/process_spec.rb
+++ b/spec/services/reports/process_spec.rb
@@ -179,6 +179,311 @@ RSpec.describe Reports::Process, type: :service do
       end
     end
 
+    context 'when entry_type is unknown' do
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let(:unknown_entry_jsonl) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test prompt', outputs: [ 'Test output' ], notes: { score_percentage: 70 } }.to_json,
+          { entry_type: 'evil_method', payload: 'should be ignored' }.to_json,
+          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din.TestProbe', passed: 3, total: 10 }.to_json,
+          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
+        ].join("\n")
+      end
+      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: unknown_entry_jsonl, logs_data: nil) }
+
+      it 'ignores the unknown entry_type and processes the rest normally' do
+        expect { service.call }.to change { ProbeResult.count }.by(1)
+        expect(report.status).to eq('completed')
+      end
+
+      it 'does not dispatch to arbitrary private methods' do
+        expect(service).not_to receive(:send).with('process_evil_method', anything)
+        service.call
+      end
+    end
+
+    context 'when start_time is invalid' do
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let(:bad_start_time_jsonl) do
+        [
+          { entry_type: 'init', start_time: 'not-a-date' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test prompt', outputs: [ 'Test output' ], notes: { score_percentage: 70 } }.to_json,
+          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din.TestProbe', passed: 3, total: 10 }.to_json,
+          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
+        ].join("\n")
+      end
+      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: bad_start_time_jsonl, logs_data: nil) }
+
+      it 'logs a warning and leaves start_time nil' do
+        allow(Rails.logger).to receive(:warn).and_call_original
+        service.call
+        report.reload
+        expect(report.start_time).to be_nil
+        expect(Rails.logger).to have_received(:warn).with(/invalid start_time/i)
+      end
+    end
+
+    context 'when end_time is invalid' do
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let(:bad_end_time_jsonl) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test prompt', outputs: [ 'Test output' ], notes: { score_percentage: 70 } }.to_json,
+          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din.TestProbe', passed: 3, total: 10 }.to_json,
+          { entry_type: 'completion', end_time: 'garbage-time' }.to_json
+        ].join("\n")
+      end
+      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: bad_end_time_jsonl, logs_data: nil) }
+
+      it 'logs a warning and leaves end_time nil' do
+        allow(Rails.logger).to receive(:warn).and_call_original
+        service.call
+        report.reload
+        expect(report.end_time).to be_nil
+        expect(Rails.logger).to have_received(:warn).with(/invalid end_time/i)
+      end
+    end
+
+    context 'when processing a probe with multiple detectors' do
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let(:multi_detector_jsonl) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test prompt', outputs: [ 'Test output' ], notes: { score_percentage: 85 } }.to_json,
+          # First detector eval - has attempts and max_score in report_data
+          { entry_type: 'eval', detector: 'detector.0din.CrystalMethScore', probe: '0din.TestProbe', passed: 1, total: 4 }.to_json,
+          # Second detector eval - report_data already consumed by first eval
+          { entry_type: 'eval', detector: 'detector.0din.MitigationBypass', probe: '0din.TestProbe', passed: 3, total: 4 }.to_json,
+          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
+        ].join("\n")
+      end
+      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: multi_detector_jsonl, logs_data: nil) }
+
+      it 'preserves attempts from the first detector eval' do
+        service.call
+
+        probe_result = report.probe_results.find_by(probe: probe)
+        expect(probe_result.attempts).to be_present
+        expect(probe_result.attempts.first['uuid']).to eq('attempt-1')
+      end
+
+      it 'preserves max_score from the first detector eval' do
+        service.call
+
+        probe_result = report.probe_results.find_by(probe: probe)
+        expect(probe_result.max_score).to eq(85)
+      end
+
+      it 'keeps the max passed across detectors and associates the detector that produced it' do
+        service.call
+
+        probe_result = report.probe_results.find_by(probe: probe)
+        # First eval: inverted passed=3, detector=CrystalMethScore → new max
+        # Second eval: inverted passed=1, detector=MitigationBypass → not a new max, retained
+        expect(probe_result.passed).to eq(3)
+        expect(probe_result.total).to eq(4)
+        expect(probe_result.detector.name).to eq('0din.CrystalMethScore')
+      end
+
+      it 'creates detector results for both detectors' do
+        expect { service.call }.to change { DetectorResult.count }.by(2)
+
+        detector_names = report.detector_results.includes(:detector).map { |dr| dr.detector.name }
+        expect(detector_names).to contain_exactly('0din.CrystalMethScore', '0din.MitigationBypass')
+      end
+
+      it 'does not double-count tokens across detector evals' do
+        service.call
+
+        probe_result = report.probe_results.find_by(probe: probe)
+        first_eval_input = probe_result.input_tokens
+        first_eval_output = probe_result.output_tokens
+
+        # Re-run the same jsonl via a second pass should not inflate token counts —
+        # tokens are only recomputed when fresh attempts arrive on an eval.
+        expect(first_eval_input).to be > 0
+        expect(probe_result.attempts.size).to eq(1)
+        # The second detector eval had attempts_data blank, so input/output tokens
+        # come from the first eval only, not additively summed.
+        expect(first_eval_input).to eq(TokenEstimator.estimate_from_attempts(probe_result.attempts)[:input_tokens])
+        expect(first_eval_output).to eq(TokenEstimator.estimate_from_attempts(probe_result.attempts)[:output_tokens])
+      end
+
+      it 'sets any_detector_passed when any eval had successful attacks' do
+        service.call
+
+        probe_result = report.probe_results.find_by(probe: probe)
+        # First eval inverted passed=3; second inverted passed=1. any detector > 0 → true.
+        expect(probe_result.any_detector_passed).to be true
+      end
+    end
+
+    context 'when first detector is bypassed and last detector fully defends' do
+      # Regression guard for the "red vulnerable with 0/N numerator" contradiction.
+      # Without max-merge on probe_result.passed, the last detector's passed=0
+      # would overwrite the earlier detector's passed=4, producing a self-
+      # contradictory display (any_detector_passed=true but passed=0).
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let(:first_bypassed_then_defended_jsonl) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test', outputs: [ 'Test' ], notes: { score_percentage: 90 } }.to_json,
+          # First detector: 0 defenses out of 4 → inverted passed=4 (fully bypassed)
+          { entry_type: 'eval', detector: 'detector.0din.CrystalMethScore', probe: '0din.TestProbe', passed: 0, total: 4 }.to_json,
+          # Second detector: 4 defenses out of 4 → inverted passed=0 (fully defended)
+          { entry_type: 'eval', detector: 'detector.0din.MitigationBypass', probe: '0din.TestProbe', passed: 4, total: 4 }.to_json,
+          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
+        ].join("\n")
+      end
+      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: first_bypassed_then_defended_jsonl, logs_data: nil) }
+
+      it 'preserves the max passed so display and signal stay consistent' do
+        service.call
+
+        probe_result = report.probe_results.find_by(probe: probe)
+        expect(probe_result.passed).to eq(4)
+        expect(probe_result.any_detector_passed).to be true
+        expect(probe_result.detector.name).to eq('0din.CrystalMethScore')
+      end
+    end
+
+    context 'when two detectors tie on passed' do
+      # Regression guard: strict `>` tie-break keeps the first detector's
+      # attribution so detector_id is stable against eval re-ordering.
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let(:tie_jsonl) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test', outputs: [ 'Test' ], notes: {} }.to_json,
+          { entry_type: 'eval', detector: 'detector.0din.CrystalMethScore', probe: '0din.TestProbe', passed: 2, total: 4 }.to_json,
+          { entry_type: 'eval', detector: 'detector.0din.MitigationBypass', probe: '0din.TestProbe', passed: 2, total: 4 }.to_json,
+          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
+        ].join("\n")
+      end
+      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: tie_jsonl, logs_data: nil) }
+
+      it 'keeps the first detector to reach the max' do
+        service.call
+
+        probe_result = report.probe_results.find_by(probe: probe)
+        expect(probe_result.passed).to eq(2)
+        expect(probe_result.detector.name).to eq('0din.CrystalMethScore')
+      end
+    end
+
+    context 'when detectors report different totals' do
+      # Regression guard: passed/total/detector_id must stay tied to the
+      # winning detector so we never produce `passed > total` or inconsistent
+      # ASR derivations.
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let(:divergent_totals_jsonl) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test', outputs: [ 'Test' ], notes: {} }.to_json,
+          # Winning detector: 1 defense out of 5 → inverted passed=4, total=5
+          { entry_type: 'eval', detector: 'detector.0din.CrystalMethScore', probe: '0din.TestProbe', passed: 1, total: 5 }.to_json,
+          # Later detector: 2 defenses out of 3 → inverted passed=1, total=3 (must not bleed total=3 in)
+          { entry_type: 'eval', detector: 'detector.0din.MitigationBypass', probe: '0din.TestProbe', passed: 2, total: 3 }.to_json,
+          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
+        ].join("\n")
+      end
+      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: divergent_totals_jsonl, logs_data: nil) }
+
+      it 'keeps passed and total tied to the winning detector' do
+        service.call
+
+        probe_result = report.probe_results.find_by(probe: probe)
+        expect(probe_result.passed).to eq(4)
+        expect(probe_result.total).to eq(5)
+        expect(probe_result.detector.name).to eq('0din.CrystalMethScore')
+        expect(probe_result.passed).to be <= probe_result.total
+      end
+    end
+
+    context 'when an existing probe_result has null detector_id but non-zero passed' do
+      # Regression guard: the new_record? fallback must not regress an existing
+      # max. A persisted row with detector_id=nil (data anomaly) and passed=5
+      # should not be overwritten by a later, lower-scoring eval just because
+      # the detector is unset.
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let!(:existing_detector) { create(:detector, name: 'legacy_detector') }
+      let!(:existing_probe_result) do
+        report.probe_results.create!(
+          probe: probe,
+          detector: existing_detector,
+          passed: 5,
+          total: 10,
+          any_detector_passed: true
+        ).tap { |pr| pr.update_column(:detector_id, nil) }
+      end
+      let(:lower_eval_jsonl) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test', outputs: [ 'Test' ], notes: {} }.to_json,
+          # Lower passed than the persisted max: 7 defenses out of 10 → inverted passed=3
+          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din.TestProbe', passed: 7, total: 10 }.to_json,
+          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
+        ].join("\n")
+      end
+      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: lower_eval_jsonl, logs_data: nil) }
+
+      it 'preserves the persisted max instead of overwriting it' do
+        service.call
+
+        existing_probe_result.reload
+        expect(existing_probe_result.passed).to eq(5)
+        expect(existing_probe_result.total).to eq(10)
+      end
+    end
+
+    context 'when probe classname is a dotted name that falls back to last segment' do
+      # The runtime may emit classnames like "dan.DAN_Jailbreak" where the Probe row
+      # was persisted under just "DAN_Jailbreak". The resolver must fall back.
+      let!(:probe) { create(:probe, name: 'DAN_Jailbreak') }
+      let(:dotted_jsonl) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: 'dan.DAN_Jailbreak', uuid: 'attempt-1', prompt: 'Test', outputs: [ 'Test' ], notes: { score_percentage: 50 } }.to_json,
+          { entry_type: 'eval', detector: 'detector.test_detector', probe: 'dan.DAN_Jailbreak', passed: 2, total: 5 }.to_json,
+          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
+        ].join("\n")
+      end
+      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: dotted_jsonl, logs_data: nil) }
+
+      it 'resolves the probe via last-segment fallback' do
+        expect { service.call }.to change { ProbeResult.count }.by(1)
+        expect(ProbeResult.last.probe).to eq(probe)
+      end
+    end
+
+    context 'when probe classname is not found in database' do
+      let(:unknown_probe_jsonl) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din.NonExistentProbe', uuid: 'attempt-1', prompt: 'Test prompt', outputs: [ 'Test output' ], notes: {} }.to_json,
+          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din.NonExistentProbe', passed: 3, total: 10 }.to_json,
+          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
+        ].join("\n")
+      end
+      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: unknown_probe_jsonl, logs_data: nil) }
+
+      it 'does not create a probe result' do
+        expect { service.call }.not_to change { ProbeResult.count }
+      end
+
+      it 'logs a warning for the unknown probe' do
+        allow(Rails.logger).to receive(:warn)
+        service.call
+        expect(Rails.logger).to have_received(:warn).with(/Unknown probe classname: 0din.NonExistentProbe/)
+      end
+
+      it 'marks the report as failed when no probe results were created' do
+        service.call
+        expect(report.status).to eq('failed')
+      end
+    end
+
     context 'when processing garak 0.14.0 format with total_evaluated' do
       let(:logs_content) { 'Garak 0.14.0 log content' }
       let!(:probe) { create(:probe, name: 'dan.DAN_Jailbreak') }
@@ -207,6 +512,93 @@ RSpec.describe Reports::Process, type: :service do
         detector_result = DetectorResult.last
         expect(detector_result.total).to eq(5)
         expect(detector_result.passed).to eq(0)
+      end
+    end
+
+    context 'when processing variant report' do
+      let(:probe) { create(:probe, name: 'TestProbe') }
+      let(:industry) { create(:threat_variant_industry) }
+      let(:subindustry) { create(:threat_variant_subindustry, threat_variant_industry: industry) }
+      let!(:threat_variant) { create(:threat_variant, probe: probe, threat_variant_subindustry: subindustry, prompt: 'Variant_TEST_001') }
+
+      let(:variant_scan) do
+        s = build(:complete_scan)
+        s.threat_variant_subindustries << subindustry
+        s.save!(validate: false)
+        s
+      end
+
+      let(:parent_report) { create(:report, target: target, scan: variant_scan) }
+      let(:child_report) { create(:report, :running, target: target, scan: variant_scan, parent_report: parent_report, uuid: 'variant-test-uuid') }
+      let(:variant_service) { described_class.new(child_report.id) }
+
+      let(:variant_jsonl_content) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din_variants.Variant_TEST_001', uuid: 'attempt-1', prompt: 'Test prompt', outputs: [ 'Test output' ], notes: { score_percentage: 70 } }.to_json,
+          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din_variants.Variant_TEST_001', passed: 3, total: 10 }.to_json,
+          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
+        ].join("\n")
+      end
+
+      let!(:variant_raw_data) { create(:raw_report_data, report: child_report, jsonl_data: variant_jsonl_content, logs_data: 'Variant logs') }
+
+      before do
+        child_report.variant_probes << probe
+      end
+
+      it 'creates probe results with threat_variant_id' do
+        expect { variant_service.call }.to change { ProbeResult.count }.by(1)
+
+        probe_result = ProbeResult.last
+        expect(probe_result.threat_variant_id).to eq(threat_variant.id)
+        expect(probe_result.threat_variant).to eq(threat_variant)
+      end
+
+      it 'looks up variant from probe classname' do
+        variant_service.call
+
+        probe_result = ProbeResult.last
+        expect(probe_result.probe).to eq(probe)
+        expect(probe_result.threat_variant.prompt).to eq('Variant_TEST_001')
+      end
+
+      it 'handles unknown variant prompt gracefully' do
+        bad_content = [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din_variants.Variant_NONEXISTENT', uuid: 'attempt-1', prompt: 'Test', outputs: [ 'Test' ], notes: { score_percentage: 70 } }.to_json,
+          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din_variants.Variant_NONEXISTENT', passed: 3, total: 10 }.to_json,
+          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
+        ].join("\n")
+
+        variant_raw_data.update!(jsonl_data: bad_content)
+
+        allow(Rails.logger).to receive(:warn)
+        expect { variant_service.call }.not_to change { ProbeResult.count }
+        expect(Rails.logger).to have_received(:warn).with(/Unknown variant probe: Variant_NONEXISTENT/)
+      end
+
+      it 'scopes variant lookup to report.variant_probes when present' do
+        # A ThreatVariant with the same prompt but tied to a different probe
+        # must not be selected when variant_probes constrains the search.
+        other_probe = create(:probe, name: 'OtherProbe')
+        create(:threat_variant, probe: other_probe, threat_variant_subindustry: subindustry, prompt: 'Variant_TEST_001')
+
+        variant_service.call
+
+        probe_result = ProbeResult.last
+        expect(probe_result.probe).to eq(probe)
+        expect(probe_result.threat_variant).to eq(threat_variant)
+      end
+
+      it 'associates correct variant with probe result' do
+        variant_service.call
+
+        probe_result = ProbeResult.last
+        expect(probe_result.attempts.first['uuid']).to eq('attempt-1')
+        expect(probe_result.threat_variant.threat_variant_subindustry).to eq(subindustry)
+        expect(probe_result.passed).to eq(7) # 10 - 3
+        expect(probe_result.total).to eq(10)
       end
     end
 
@@ -311,89 +703,6 @@ RSpec.describe Reports::Process, type: :service do
       end
     end
 
-    context 'when processing variant probe results' do
-      let!(:probe) { create(:probe, name: 'TestProbe') }
-      let(:industry) { create(:threat_variant_industry, name: 'Automotive') }
-      let(:subindustry) { create(:threat_variant_subindustry, name: 'Autonomous Driving', threat_variant_industry: industry) }
-      let!(:variant) { create(:threat_variant, prompt: 'Variant_TAG_Automotive_Autonomous_Driving', probe: probe, threat_variant_subindustry: subindustry) }
-
-      let(:variant_jsonl_content) do
-        [
-          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
-          { entry_type: 'attempt', probe_classname: '0din_variants.Variant_TAG_Automotive_Autonomous_Driving', uuid: 'attempt-v1', prompt: 'Variant prompt', outputs: [ 'Variant output' ], notes: { score_percentage: 85 } }.to_json,
-          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din_variants.Variant_TAG_Automotive_Autonomous_Driving', passed: 2, total: 10 }.to_json,
-          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
-        ].join("\n")
-      end
-
-      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: variant_jsonl_content) }
-
-      it 'creates probe results linked to the variant' do
-        expect { service.call }.to change { ProbeResult.count }.by(1)
-
-        probe_result = ProbeResult.last
-        expect(probe_result.probe).to eq(probe)
-        expect(probe_result.threat_variant).to eq(variant)
-        expect(probe_result.passed).to eq(8) # 10 - 2
-        expect(probe_result.total).to eq(10)
-        expect(probe_result.max_score).to eq(85)
-      end
-
-      it 'completes the report successfully' do
-        service.call
-        expect(report.status).to eq('completed')
-      end
-
-      context 'with shared class names across base and CM probes' do
-        let(:cm_probe) { create(:probe, name: 'TestProbeCM') }
-        let!(:cm_variant) do
-          create(:threat_variant, prompt: 'Variant_TAG_Automotive_Autonomous_Driving',
-                 probe: cm_probe, threat_variant_subindustry: subindustry)
-        end
-
-        it 'assigns tokens only once to avoid inflating totals' do
-          expect { service.call }.to change { ProbeResult.count }.by(2)
-
-          results = report.probe_results.where.not(threat_variant_id: nil).order(:id)
-          expect(results.size).to eq(2)
-
-          # First result gets the tokens
-          expect(results.first.input_tokens).to be >= 0
-          expect(results.first.output_tokens).to be >= 0
-
-          # Second result gets zero tokens (shared classname, single execution)
-          expect(results.second.input_tokens).to eq(0)
-          expect(results.second.output_tokens).to eq(0)
-        end
-      end
-    end
-
-    context 'when processing unknown variant probe results' do
-      let(:unknown_variant_jsonl) do
-        [
-          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
-          { entry_type: 'attempt', probe_classname: '0din_variants.Variant_TAG_Unknown_Missing', uuid: 'attempt-v2', prompt: 'Unknown variant', outputs: [ 'Output' ], notes: {} }.to_json,
-          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din_variants.Variant_TAG_Unknown_Missing', passed: 5, total: 5 }.to_json,
-          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
-        ].join("\n")
-      end
-
-      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: unknown_variant_jsonl) }
-
-      before do
-        allow(Rails.logger).to receive(:warn)
-      end
-
-      it 'skips unknown variant probes without creating probe results' do
-        expect { service.call }.not_to change { ProbeResult.count }
-      end
-
-      it 'marks report as failed when no valid probes processed' do
-        service.call
-        expect(report.status).to eq('failed')
-      end
-    end
-
     context 'when updating target token rate' do
       let!(:probe) { create(:probe, name: 'TestProbe') }
       let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: jsonl_content, logs_data: 'Test logs') }
@@ -410,85 +719,6 @@ RSpec.describe Reports::Process, type: :service do
       it 'calls update_target_token_rate after processing' do
         expect(service).to receive(:update_target_token_rate)
         service.call
-      end
-    end
-  end
-
-  describe '#resolve_probe' do
-    let(:target) { create(:target) }
-    let(:scan) { create(:complete_scan) }
-    let(:report) { create(:report, target: target, scan: scan) }
-    let(:service) { described_class.new(report.id) }
-
-    context 'with a variant probe classname' do
-      let(:probe) { create(:probe, name: 'TestProbe') }
-      let(:industry) { create(:threat_variant_industry, name: 'Automotive') }
-      let(:subindustry) { create(:threat_variant_subindustry, name: 'Autonomous Driving', threat_variant_industry: industry) }
-      let!(:variant) { create(:threat_variant, prompt: 'Variant_TAG_Automotive_Autonomous_Driving', probe: probe, threat_variant_subindustry: subindustry) }
-
-      it 'resolves to the correct probe and variant' do
-        results = service.send(:resolve_probe, '0din_variants.Variant_TAG_Automotive_Autonomous_Driving')
-        expect(results).to be_an(Array)
-        expect(results.length).to eq(1)
-        expect(results.first[:probe_id]).to eq(probe.id)
-        expect(results.first[:variant]).to eq(variant)
-        expect(results.first[:skip]).to be_nil
-      end
-
-      it 'returns skip when variant is not found' do
-        results = service.send(:resolve_probe, '0din_variants.Variant_TAG_Unknown_Missing')
-        expect(results.first[:skip]).to be true
-        expect(results.first[:probe_id]).to be_nil
-      end
-
-      it 'logs a warning for unknown variant probes' do
-        allow(Rails.logger).to receive(:warn)
-        service.send(:resolve_probe, '0din_variants.Variant_TAG_Unknown_Missing')
-        expect(Rails.logger).to have_received(:warn).with(/Unknown variant probe: Variant_TAG_Unknown_Missing/)
-      end
-
-      context 'with shared class names across base and CM probes' do
-        let(:base_detector) { create(:detector, name: '0din.MitigationBypass') }
-        let(:cm_detector) { create(:detector, name: '0din.CrystalMethScore') }
-        let(:probe) { create(:probe, name: 'TestProbe', detector: base_detector) }
-        let(:cm_probe) { create(:probe, name: 'TestProbeCM', detector: cm_detector) }
-        let!(:variant) { create(:threat_variant, prompt: 'Variant_TAG_Automotive_Autonomous_Driving', probe: probe, threat_variant_subindustry: subindustry) }
-        let!(:cm_variant) { create(:threat_variant, prompt: 'Variant_TAG_Automotive_Autonomous_Driving', probe: cm_probe, threat_variant_subindustry: subindustry) }
-
-        it 'returns all matching probes when no detector is provided' do
-          results = service.send(:resolve_probe, '0din_variants.Variant_TAG_Automotive_Autonomous_Driving')
-          expect(results.length).to eq(2)
-          probe_ids = results.map { |r| r[:probe_id] }
-          expect(probe_ids).to contain_exactly(probe.id, cm_probe.id)
-        end
-
-        it 'filters to matching detector when detector_name is provided' do
-          results = service.send(:resolve_probe, '0din_variants.Variant_TAG_Automotive_Autonomous_Driving', '0din.MitigationBypass')
-          expect(results.length).to eq(1)
-          expect(results.first[:probe_id]).to eq(probe.id)
-        end
-
-        it 'filters to CM probe when CM detector is provided' do
-          results = service.send(:resolve_probe, '0din_variants.Variant_TAG_Automotive_Autonomous_Driving', '0din.CrystalMethScore')
-          expect(results.length).to eq(1)
-          expect(results.first[:probe_id]).to eq(cm_probe.id)
-        end
-      end
-    end
-
-    context 'with a standard probe classname' do
-      let!(:probe) { create(:probe, name: 'TestProbe') }
-
-      it 'resolves by full classname' do
-        results = service.send(:resolve_probe, '0din.TestProbe')
-        expect(results).to be_an(Array)
-        expect(results.first[:probe_id]).to eq(probe.id)
-        expect(results.first[:variant]).to be_nil
-      end
-
-      it 'returns skip for unknown probes' do
-        results = service.send(:resolve_probe, '0din.UnknownProbe')
-        expect(results.first[:skip]).to be true
       end
     end
   end

--- a/spec/services/run_command_spec.rb
+++ b/spec/services/run_command_spec.rb
@@ -3,22 +3,417 @@ require 'rails_helper'
 RSpec.describe RunCommand do
   describe '#call' do
     it 'returns the stdout when command is successful' do
-      command_service = RunCommand.new('echo "hello"')
+      command_service = RunCommand.new([ "echo", "hello" ])
       result = command_service.call
       expect(result).to eq("hello\n")
     end
 
     it 'raises an error when command fails' do
-      command_service = RunCommand.new('exit 1')
+      command_service = RunCommand.new([ "false" ])
       expect { command_service.call }.to raise_error(/Command failed with error/)
+    end
+
+    it 'passes environment variables to the command' do
+      command_service = RunCommand.new(
+        [ "/bin/sh", "-c", "echo $TEST_VAR" ],
+        env: { "TEST_VAR" => "hello_from_env" }
+      )
+      result = command_service.call
+      expect(result.strip).to eq("hello_from_env")
+    end
+
+    it 'writes output to log file when specified' do
+      Dir.mktmpdir do |dir|
+        log_path = File.join(dir, "test.log")
+        command_service = RunCommand.new([ "echo", "logged output" ])
+        command_service.call(log_file: log_path)
+        expect(File.read(log_path)).to include("logged output")
+      end
+    end
+
+    it 'sanitizes stderr in error messages to redact secrets' do
+      command_service = RunCommand.new(
+        [ "/bin/sh", "-c", "echo 'Error: invalid api_key=sk_live_abc123xyz' >&2; exit 1" ]
+      )
+      expect { command_service.call }.to raise_error do |error|
+        expect(error.message).not_to include("sk_live_abc123xyz")
+        expect(error.message).to include("[REDACTED]")
+      end
+    end
+
+    it 'sanitizes stderr containing token values in error messages' do
+      command_service = RunCommand.new(
+        [ "/bin/sh", "-c", "echo 'auth failed: token=my_secret_token_123' >&2; exit 1" ]
+      )
+      expect { command_service.call }.to raise_error do |error|
+        expect(error.message).not_to include("my_secret_token_123")
+        expect(error.message).to include("[REDACTED]")
+      end
+    end
+
+    it 'sanitizes stderr containing password values in error messages' do
+      command_service = RunCommand.new(
+        [ "/bin/sh", "-c", "echo 'connection failed: password=hunter2' >&2; exit 1" ]
+      )
+      expect { command_service.call }.to raise_error do |error|
+        expect(error.message).not_to include("hunter2")
+        expect(error.message).to include("[REDACTED]")
+      end
     end
   end
 
   describe '#call_async' do
     it 'returns a process object' do
-      command_service = RunCommand.new('echo "async test"')
+      command_service = RunCommand.new([ "echo", "async test" ])
       result = command_service.call_async
       expect(result).to be_a(Process::Waiter)
+    end
+
+    it 'passes environment variables to the async command' do
+      Dir.mktmpdir do |dir|
+        log_path = File.join(dir, "async.log")
+        command_service = RunCommand.new(
+          [ "/bin/sh", "-c", "echo $ASYNC_VAR" ],
+          env: { "ASYNC_VAR" => "async_value" }
+        )
+        wait_thr = command_service.call_async(log_file: log_path)
+        wait_thr.join
+        # Wait for IO threads to flush after process exits
+        sleep 1.0
+        expect(File.read(log_path)).to include("async_value")
+      end
+    end
+
+    it 'raises ImmediateExitError when process exits immediately with non-zero status' do
+      command_service = RunCommand.new([ "/bin/sh", "-c", "exit 1" ])
+      expect { command_service.call_async }.to raise_error(RunCommand::ImmediateExitError) do |error|
+        expect(error.exit_status).to eq(1)
+        expect(error.message).to include("exited immediately with status 1")
+      end
+    end
+
+    it 'returns wait_thr when process exits immediately with zero status' do
+      command_service = RunCommand.new([ "/bin/sh", "-c", "exit 0" ])
+      result = command_service.call_async
+      expect(result).to be_a(Process::Waiter)
+    end
+
+    it 'logs sanitized command and raises on immediate failure' do
+      command_service = RunCommand.new(
+        [ "/bin/sh", "-c", "exit 1", "--token", "super_secret_123" ],
+      )
+      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:error)
+      expect { command_service.call_async }.to raise_error(RunCommand::ImmediateExitError)
+      expect(Rails.logger).to have_received(:error).with(/Command was:/).at_least(:once)
+      expect(Rails.logger).not_to have_received(:error).with(/super_secret_123/)
+    end
+  end
+
+  describe 'shell injection prevention' do
+    it 'treats injection payloads as literal arguments, not shell commands' do
+      payload = "'; rm -rf /; echo '"
+      command_service = RunCommand.new([ "echo", payload ])
+      result = command_service.call
+      lines = result.strip.split("\n")
+      expect(lines.length).to eq(1)
+      expect(lines.first).to eq(payload)
+    end
+
+    it 'does not expand shell variables in arguments' do
+      command_service = RunCommand.new([ "echo", "$HOME" ])
+      result = command_service.call
+      expect(result.strip).to eq("$HOME")
+    end
+
+    it 'does not interpret backticks in arguments' do
+      command_service = RunCommand.new([ "echo", "`whoami`" ])
+      result = command_service.call
+      expect(result.strip).to eq("`whoami`")
+    end
+
+    it 'does not interpret subshell syntax in arguments' do
+      command_service = RunCommand.new([ "echo", "$(whoami)" ])
+      result = command_service.call
+      expect(result.strip).to eq("$(whoami)")
+    end
+
+    it 'keeps secrets in env hash separate from logged command' do
+      command_service = RunCommand.new(
+        [ "echo", "test" ],
+        env: { "SECRET_API_KEY" => "super_secret_value" }
+      )
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("super_secret_value")
+      expect(log_output).to include("echo test")
+    end
+  end
+
+  describe 'sensitive argument redaction' do
+    it 'redacts values following --token flag' do
+      command_service = RunCommand.new([ "cmd", "--token", "sk_live_abc123" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("sk_live_abc123")
+      expect(log_output).to include("--token [REDACTED]")
+    end
+
+    it 'redacts values following --password flag' do
+      command_service = RunCommand.new([ "cmd", "--password", "hunter2" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("hunter2")
+      expect(log_output).to include("--password [REDACTED]")
+    end
+
+    it 'redacts values following --api-key flag' do
+      command_service = RunCommand.new([ "cmd", "--api-key", "key_abc123" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("key_abc123")
+      expect(log_output).to include("--api-key [REDACTED]")
+    end
+
+    it 'redacts values following --secret flag' do
+      command_service = RunCommand.new([ "cmd", "--secret", "mysecret" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("mysecret")
+      expect(log_output).to include("--secret [REDACTED]")
+    end
+
+    it 'redacts values following --access-token flag' do
+      command_service = RunCommand.new([ "cmd", "--access-token", "at_123" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("at_123")
+      expect(log_output).to include("--access-token [REDACTED]")
+    end
+
+    it 'redacts values following --authorization flag' do
+      command_service = RunCommand.new([ "cmd", "--authorization", "Bearer xyz" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("Bearer xyz")
+      expect(log_output).to include("--authorization [REDACTED]")
+    end
+
+    it 'redacts --token=value inline format' do
+      command_service = RunCommand.new([ "cmd", "--token=sk_live_abc123" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("sk_live_abc123")
+      expect(log_output).to include("--token=[REDACTED]")
+    end
+
+    it 'redacts --api-key=value inline format' do
+      command_service = RunCommand.new([ "cmd", "--api-key=key_abc123" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("key_abc123")
+      expect(log_output).to include("--api-key=[REDACTED]")
+    end
+
+    it 'redacts --password=value inline format' do
+      command_service = RunCommand.new([ "cmd", "--password=hunter2" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("hunter2")
+      expect(log_output).to include("--password=[REDACTED]")
+    end
+
+    it 'does not redact non-sensitive flags' do
+      command_service = RunCommand.new([ "cmd", "--verbose", "--output", "file.txt" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).to eq("cmd --verbose --output file.txt")
+    end
+
+    it 'handles single-dash sensitive flags' do
+      command_service = RunCommand.new([ "cmd", "-token", "mysecret" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("mysecret")
+      expect(log_output).to include("-token [REDACTED]")
+    end
+
+    it 'is case-insensitive for flag names' do
+      command_service = RunCommand.new([ "cmd", "--TOKEN", "mysecret" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("mysecret")
+      expect(log_output).to include("--TOKEN [REDACTED]")
+    end
+
+    it 'redacts values following --openai-api-key (partial match)' do
+      command_service = RunCommand.new([ "cmd", "--openai-api-key", "sk-abc123" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("sk-abc123")
+      expect(log_output).to include("--openai-api-key [REDACTED]")
+    end
+
+    it 'redacts values following --bearer-token (partial match)' do
+      command_service = RunCommand.new([ "cmd", "--bearer-token", "bt_xyz" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("bt_xyz")
+      expect(log_output).to include("--bearer-token [REDACTED]")
+    end
+
+    it 'redacts --openai-api-key=value inline format (partial match)' do
+      command_service = RunCommand.new([ "cmd", "--openai-api-key=sk-abc123" ])
+      log_output = command_service.send(:sanitize_for_logging)
+      expect(log_output).not_to include("sk-abc123")
+      expect(log_output).to include("--openai-api-key=[REDACTED]")
+    end
+  end
+
+  describe 'output sanitization' do
+    it 'redacts api_key values in output' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "Error: api_key=sk_live_abc123 is invalid")
+      expect(result).not_to include("sk_live_abc123")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'redacts token values in output' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "failed: token=abc123xyz")
+      expect(result).not_to include("abc123xyz")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'redacts password values in output' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "auth failed: password=hunter2")
+      expect(result).not_to include("hunter2")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'redacts bearer token values in output' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9")
+      expect(result).not_to include("eyJhbGciOiJSUzI1NiJ9")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'redacts secret values with colon separator' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "secret: my_super_secret_value")
+      expect(result).not_to include("my_super_secret_value")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'redacts credential values in output' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "credential=abc_def_123")
+      expect(result).not_to include("abc_def_123")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'returns empty string for nil input' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      expect(command_service.send(:sanitize_output, nil)).to eq("")
+    end
+
+    it 'returns empty string for empty input' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      expect(command_service.send(:sanitize_output, "")).to eq("")
+    end
+
+    it 'truncates very long output' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      long_text = "error: " + "x" * 600
+      result = command_service.send(:sanitize_output, long_text)
+      expect(result.length).to be <= 503
+      expect(result).to end_with("...")
+    end
+
+    it 'preserves non-sensitive content in output' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "Error: file not found at /tmp/data.csv")
+      expect(result).to eq("Error: file not found at /tmp/data.csv")
+    end
+
+    it 'handles multiple sensitive values in same output' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "api_key=abc123 token=xyz789")
+      expect(result).not_to include("abc123")
+      expect(result).not_to include("xyz789")
+    end
+
+    it 'redacts secrets in spaced equals format (key = value)' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "password = hunter2")
+      expect(result).not_to include("hunter2")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'does not redact non-sensitive uses of token keyword' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "token estimation completed for 500 samples")
+      expect(result).to eq("token estimation completed for 500 samples")
+    end
+
+    it 'skips truncation when truncate: false' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      long_text = "info: " + "x" * 600
+      result = command_service.send(:sanitize_output, long_text, truncate: false)
+      expect(result.length).to eq(long_text.length)
+      expect(result).not_to end_with("...")
+    end
+
+    it 'redacts JSON-quoted secret keys' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, '{"token":"abc123"}')
+      expect(result).not_to include("abc123")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'redacts JSON-quoted secret keys with spaces' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, '{"api_key": "sk_live_abc123"}')
+      expect(result).not_to include("sk_live_abc123")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'preserves JSON structure after redacting secrets' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, '{"token":"abc","error":"timeout"}')
+      expect(result).not_to include("abc")
+      expect(result).to include("timeout")
+      expect(result).to include('"error"')
+    end
+
+    it 'redacts DATABASE_URL values in output' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "DATABASE_URL=postgresql://user:pass@host/db")
+      expect(result).not_to include("postgresql://user:pass@host/db")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'redacts REDIS_URL values in output' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "REDIS_URL=redis://:secret@redis:6379/0")
+      expect(result).not_to include("redis://:secret@redis:6379/0")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'redacts SECRET_KEY_BASE values in output' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "SECRET_KEY_BASE=abc123def456")
+      expect(result).not_to include("abc123def456")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'redacts non-Bearer authorization schemes' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "Authorization: Splunk abc123def")
+      expect(result).not_to include("abc123def")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it 'preserves ampersand-delimited context after secret values' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "token=abc123&code=401")
+      expect(result).not_to include("abc123")
+      expect(result).to include("[REDACTED]")
+      expect(result).to include("&code=401")
+    end
+
+    it 'preserves semicolon-delimited context after secret values' do
+      command_service = RunCommand.new([ "echo", "test" ])
+      result = command_service.send(:sanitize_output, "access_token=abc123;error=timeout")
+      expect(result).not_to include("abc123")
+      expect(result).to include("[REDACTED]")
+      expect(result).to include(";error=timeout")
     end
   end
 end

--- a/spec/services/run_garak_scan_spec.rb
+++ b/spec/services/run_garak_scan_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RunGarakScan, type: :service do
   end
 
   describe '#call' do
-    let(:target) { create(:target, model_type: 'openai', model: 'gpt-4') }
+    let(:target) { create(:target, :good, model_type: 'OpenAIGenerator', model: 'gpt-4') }
     let(:scan) { create(:complete_scan) }
     let(:report) { create(:report, target: target, scan: scan) }
 
@@ -19,37 +19,23 @@ RSpec.describe RunGarakScan, type: :service do
     end
 
     it 'updates the report status to starting' do
-      expect(report).to receive(:update).with(status: :starting)
-
       service = described_class.new(report)
-      allow(service).to receive(:command).and_return("mock command")
+      allow(service).to receive(:call).and_call_original
+      allow(service).to receive(:execute_scan)
 
-      run_command_double = double("RunCommand")
-      allow(run_command_double).to receive(:call_async)
-      allow(RunCommand).to receive(:new).and_return(run_command_double)
+      expect(report).to receive(:update).with(status: :starting)
 
       service.call
     end
 
-    it 'processes the report and prevents actual command execution' do
-      original_run_command_new = RunCommand.method(:new)
-      fake_run_command = double("FakeRunCommand", call_async: nil)
+    it 'calls execute_scan for valid targets' do
+      service = described_class.new(report)
+      allow(service).to receive(:call).and_call_original
 
-      begin
-        RunCommand.singleton_class.define_method(:new) do |*args|
-          fake_run_command
-        end
+      expect(service).to receive(:execute_scan)
+      expect(report).to receive(:update).with(status: :starting)
 
-        service = described_class.new(report)
-
-        expect(report).to receive(:update).with(status: :starting)
-        service.call
-
-        expect(true).to be true
-      ensure
-        RunCommand.singleton_class.send(:remove_method, :new)
-        RunCommand.define_singleton_method(:new, original_run_command_new)
-      end
+      service.call
     end
 
     it 'fails the report if target has bad status' do
@@ -98,12 +84,10 @@ RSpec.describe RunGarakScan, type: :service do
 
       service = described_class.new(good_report)
 
-      expect(good_report).to receive(:update).with(status: :starting)
+      allow(service).to receive(:call).and_call_original
+      allow(service).to receive(:execute_scan)
 
-      run_command_double = double("RunCommand")
-      allow(run_command_double).to receive(:call_async)
-      allow(RunCommand).to receive(:new).and_return(run_command_double)
-      allow(service).to receive(:command).and_return("mock command")
+      expect(good_report).to receive(:update).with(status: :starting)
 
       service.call
     end
@@ -150,9 +134,9 @@ RSpec.describe RunGarakScan, type: :service do
     end
   end
 
-  describe 'tenant context for command construction' do
+  describe 'argv-based command construction' do
     let(:json_config) { '{"temperature": 0.7}' }
-    let(:target) { create(:target, :good, model_type: 'openai', model: 'gpt-4', json_config: json_config) }
+    let(:target) { create(:target, :good, model_type: 'OpenAIGenerator', model: 'gpt-4', json_config: json_config) }
     let(:scan) { create(:complete_scan, company: target.company) }
     let(:report) { create(:report, target: target, scan: scan, company: target.company) }
 
@@ -162,22 +146,66 @@ RSpec.describe RunGarakScan, type: :service do
       allow(Dir).to receive(:exist?).and_return(true)
     end
 
-    it 'builds the command string within tenant context' do
-      service = described_class.new(report)
+    describe '#build_argv' do
+      it 'returns an array with python, script path, uuid, followed by individual params' do
+        service = described_class.new(report)
+        argv = service.send(:build_argv)
 
-      allow(service).to receive(:env_vars_string).and_return("HOME=/home/rails")
-      allow(service).to receive(:log_file).and_return(" 2>&1 | tee /dev/null ")
+        expect(argv).to be_an(Array)
+        expect(argv[0]).to eq("/opt/venv/bin/python3")
+        expect(argv[1]).to include("run_garak.py")
+        expect(argv[2]).to eq(report.uuid)
+        expect(argv.length).to be > 3
+        expect(argv.all? { |e| e.is_a?(String) }).to be true
+      end
 
-      # command method wraps in ActsAsTenant.with_tenant(report.company) internally
-      command = service.send(:command)
-      expect(command).to be_a(String)
-      expect(command).not_to be_empty
+      it 'passes each flag and value as separate argv elements' do
+        service = described_class.new(report)
+        argv = service.send(:build_argv)
+
+        expect(argv).to include("--skip_unknown")
+        expect(argv).to include("--target_type")
+        expect(argv).to include("--target_name")
+      end
+
+      it 'does not contain shell metacharacters in the argv structure' do
+        service = described_class.new(report)
+        argv = service.send(:build_argv)
+
+        expect(argv[0]).not_to include("|")
+        expect(argv[0]).not_to include(";")
+        expect(argv[0]).not_to include("&&")
+      end
+    end
+
+    describe '#build_env' do
+      it 'returns a hash of environment variables' do
+        service = described_class.new(report)
+
+        ActsAsTenant.with_tenant(report.company) do
+          env = service.send(:build_env)
+
+          expect(env).to be_a(Hash)
+          expect(env["HOME"]).to eq("/home/rails")
+          expect(env["REPORT_UUID"]).to eq(report.uuid)
+          expect(env["SCAN_ID"]).to eq(report.scan.id.to_s)
+          expect(env["TARGET_ID"]).to eq(target.id.to_s)
+        end
+      end
+
+      it 'includes DATABASE_URL' do
+        service = described_class.new(report)
+
+        ActsAsTenant.with_tenant(report.company) do
+          env = service.send(:build_env)
+          expect(env["DATABASE_URL"]).to be_present
+        end
+      end
     end
 
     it 'decrypts json_config within tenant context for generator options' do
       service = described_class.new(report)
 
-      # The command method wraps in with_tenant, so json_config should be accessible
       allow(RunCommand).to receive(:new).and_return(double(call_async: nil))
 
       expect {
@@ -185,6 +213,41 @@ RSpec.describe RunGarakScan, type: :service do
           service.send(:generator_options)
         end
       }.not_to raise_error
+    end
+  end
+
+  describe 'injection prevention' do
+    let(:target) { create(:target, :good, model_type: 'OpenAIGenerator', model: 'gpt-4') }
+    let(:scan) { create(:complete_scan) }
+    let(:report) { create(:report, target: target, scan: scan) }
+
+    before do
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(File).to receive(:write)
+      allow(Dir).to receive(:exist?).and_return(true)
+    end
+
+    it 'constructs argv array that does not pass through shell' do
+      service = described_class.new(report)
+      argv = service.send(:build_argv)
+
+      expect(argv).to be_an(Array)
+      expect(argv.length).to be > 3
+      expect(argv.all? { |e| e.is_a?(String) }).to be true
+    end
+
+    it 'passes env vars as a hash, not as shell-prefixed strings' do
+      service = described_class.new(report)
+
+      ActsAsTenant.with_tenant(report.company) do
+        env = service.send(:build_env)
+
+        expect(env).to be_a(Hash)
+        env.each do |key, value|
+          expect(key).to be_a(String)
+          expect(value).to be_a(String)
+        end
+      end
     end
   end
 
@@ -228,7 +291,7 @@ RSpec.describe RunGarakScan, type: :service do
       end
 
       it 'calls api_params for API targets' do
-        api_target = create(:target, target_type: :api, model_type: 'openai', model: 'gpt-4')
+        api_target = create(:target, target_type: :api, model_type: 'OpenAIGenerator', model: 'gpt-4')
         api_report = create(:report, target: api_target, scan: scan)
         api_service = described_class.new(api_report)
 
@@ -240,36 +303,42 @@ RSpec.describe RunGarakScan, type: :service do
     describe '#web_chat_params' do
       it 'includes web_chatbot target type' do
         params = service.send(:web_chat_params)
-        expect(params).to include('--target_type web_chatbot.WebChatbotGenerator')
+        expect(params).to include('--target_type', 'web_chatbot.WebChatbotGenerator')
       end
 
       it 'includes web_chatbot target name' do
         params = service.send(:web_chat_params)
-        expect(params).to include('--target_name web_chatbot')
+        expect(params).to include('--target_name', 'web_chatbot')
       end
 
       it 'includes generator options file' do
         allow(service).to receive(:temp_web_config_file_path).and_return('/tmp/test_web.json')
         params = service.send(:web_chat_params)
-        expect(params).to include('--generator_option_file /tmp/test_web.json')
+        expect(params).to include('--generator_option_file', '/tmp/test_web.json')
       end
 
       it 'includes skip_unknown flag' do
         params = service.send(:web_chat_params)
         expect(params).to include('--skip_unknown')
       end
+
+      it 'returns a flat array of strings' do
+        params = service.send(:web_chat_params)
+        expect(params).to be_an(Array)
+        expect(params.all? { |e| e.is_a?(String) }).to be true
+      end
     end
 
     describe '#web_chat_target_name' do
-      it 'returns web_chatbot target name' do
-        expect(service.send(:web_chat_target_name)).to eq('--target_name web_chatbot')
+      it 'returns web_chatbot target name as array' do
+        expect(service.send(:web_chat_target_name)).to eq([ '--target_name', 'web_chatbot' ])
       end
     end
 
     describe '#web_chat_generator_options' do
-      it 'returns generator option file path when web_config is present' do
+      it 'returns generator option file path as array when web_config is present' do
         allow(service).to receive(:temp_web_config_file_path).and_return('/tmp/test_web.json')
-        expect(service.send(:web_chat_generator_options)).to eq('--generator_option_file /tmp/test_web.json')
+        expect(service.send(:web_chat_generator_options)).to eq([ '--generator_option_file', '/tmp/test_web.json' ])
       end
 
       it 'returns nil when web_config is blank' do
@@ -407,7 +476,7 @@ RSpec.describe RunGarakScan, type: :service do
         service = described_class.new(report)
 
         expect(ProcessReportJob).to receive(:perform_later).with(report.id)
-        expect(service).not_to receive(:command)
+        expect(service).not_to receive(:execute_scan)
 
         service.call
       end
@@ -471,6 +540,60 @@ RSpec.describe RunGarakScan, type: :service do
         remaining = service.send(:remaining_probes)
         expect(remaining).to contain_exactly('test.ProbeA', 'test.ProbeB')
       end
+    end
+  end
+
+  describe 'immediate process death handling' do
+    let(:target) { create(:target, :good, model_type: 'OpenAIGenerator', model: 'gpt-4') }
+    let(:scan) { create(:complete_scan, company: target.company) }
+    let(:report) { create(:report, target: target, scan: scan, company: target.company) }
+
+    before do
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(File).to receive(:write)
+      allow(Dir).to receive(:exist?).and_return(true)
+      allow_any_instance_of(RunGarakScan).to receive(:call).and_call_original
+    end
+
+    it 'marks report as failed when process exits immediately' do
+      service = described_class.new(report)
+
+      run_command = instance_double(RunCommand)
+      allow(RunCommand).to receive(:new).and_return(run_command)
+      allow(run_command).to receive(:call_async).and_raise(
+        RunCommand::ImmediateExitError.new(1, "/opt/venv/bin/python3 script/run_garak.py")
+      )
+      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:error)
+
+      service.call
+
+      report.reload
+      expect(report.status).to eq("failed")
+      expect(report.logs).to include("Scan process failed to start (exit status 1)")
+    end
+
+    it 'includes log tail in failure message when log file exists' do
+      service = described_class.new(report)
+
+      run_command = instance_double(RunCommand)
+      allow(RunCommand).to receive(:new).and_return(run_command)
+      allow(run_command).to receive(:call_async).and_raise(
+        RunCommand::ImmediateExitError.new(127, "/opt/venv/bin/python3 script/run_garak.py")
+      )
+      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:error)
+
+      log_path = LogPathManager.scan_log_file_for_report(report)
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(log_path.to_s).and_return(true)
+      allow(File).to receive(:read).with(log_path.to_s).and_return("python3: command not found\n")
+
+      service.call
+
+      report.reload
+      expect(report.status).to eq("failed")
+      expect(report.logs).to include("Output: python3: command not found")
     end
   end
 end

--- a/spec/services/scans/stats_serializer_spec.rb
+++ b/spec/services/scans/stats_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Scans::StatsSerializer, type: :service do
-  let(:target) { create(:target, :good, name: "Test Target", model_type: "OpenAI", model: "gpt-4") }
+  let(:target) { create(:target, :good, name: "Test Target", model_type: "OpenAIGenerator", model: "gpt-4") }
   let(:default_probe) { create(:probe) }
   let(:scan) { create(:scan, name: "Test Scan", targets: [ target ], probes: [ default_probe ]) }
   let(:serializer) { described_class.new(scan) }
@@ -84,7 +84,7 @@ RSpec.describe Scans::StatsSerializer, type: :service do
       expect(result.first).to include(
         target_id: target.id,
         target_name: "Test Target",
-        model_type: "OpenAI",
+        model_type: "OpenAIGenerator",
         model: "gpt-4"
       )
     end
@@ -102,6 +102,58 @@ RSpec.describe Scans::StatsSerializer, type: :service do
 
         expect(result.length).to eq(2)
         expect(result.map { |t| t[:target_name] }).to contain_exactly("Test Target", "Target 2")
+      end
+    end
+  end
+
+  describe '#attacks_info' do
+    context 'with multiple targets' do
+      let(:target2) { create(:target, :good, name: "Target 2", model: "claude-3") }
+      let(:detector) { create(:detector) }
+      let(:probe) { create(:probe, detector: detector) }
+
+      before do
+        scan.targets << target2
+        scan.probes << probe
+
+        report1 = create(:report, :completed, scan: scan, target: target)
+        report2 = create(:report, :completed, scan: scan, target: target2)
+
+        create(:detector_result, report: report1, detector: detector, passed: 10, total: 50)
+        create(:detector_result, report: report2, detector: detector, passed: 20, total: 80)
+      end
+
+      it 'returns correct per-target totals from a single grouped query' do
+        result = serializer.send(:attacks_info)
+
+        expect(result[:total_passed]).to eq(30)
+        expect(result[:total_tests]).to eq(130)
+
+        by_target = result[:by_target]
+        expect(by_target.length).to eq(2)
+
+        t1 = by_target.find { |t| t[:target_name] == "Test Target" }
+        t2 = by_target.find { |t| t[:target_name] == "Target 2" }
+
+        expect(t1[:passed]).to eq(10)
+        expect(t1[:total]).to eq(50)
+        expect(t1[:asr]).to eq(20.0)
+
+        expect(t2[:passed]).to eq(20)
+        expect(t2[:total]).to eq(80)
+        expect(t2[:asr]).to eq(25.0)
+      end
+
+      it 'includes targets with no completed reports as zero' do
+        target3 = create(:target, :good, name: "Target 3")
+        scan.targets << target3
+
+        result = serializer.send(:attacks_info)
+        t3 = result[:by_target].find { |t| t[:target_name] == "Target 3" }
+
+        expect(t3[:passed]).to eq(0)
+        expect(t3[:total]).to eq(0)
+        expect(t3[:asr]).to eq(0)
       end
     end
   end

--- a/spec/services/stats/attack_fails_by_target_data_spec.rb
+++ b/spec/services/stats/attack_fails_by_target_data_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Stats::AttackFailsByTargetData do
     end
 
     context 'when data exists for multiple targets' do
-      let!(:target1) { create(:target, name: 'Target 1', model_type: 'openai', model: 'gpt-3.5-turbo') }
-      let!(:target2) { create(:target, name: 'Target 2', model_type: 'anthropic', model: 'claude-2') }
+      let!(:target1) { create(:target, name: 'Target 1', model_type: 'OpenAIGenerator', model: 'gpt-3.5-turbo') }
+      let!(:target2) { create(:target, name: 'Target 2', model_type: 'OpenAIGenerator', model: 'claude-2') }
 
       before do
         # Create reports and detector results for Target 1
@@ -60,7 +60,7 @@ RSpec.describe Stats::AttackFailsByTargetData do
 
         # Check target 1 data
         target1_data = result[:targets].find { |t| t[:name] == 'Target 1' }
-        expect(target1_data[:model_info]).to eq('openai - gpt-3.5-turbo')
+        expect(target1_data[:model_info]).to eq('OpenAIGenerator - gpt-3.5-turbo')
         expect(target1_data[:summary][:total_reports]).to eq(2)
         expect(target1_data[:summary][:total_tests]).to eq(30) # 10+10+10
         expect(target1_data[:summary][:total_passed]).to eq(19) # 8+5+6
@@ -69,7 +69,7 @@ RSpec.describe Stats::AttackFailsByTargetData do
 
         # Check target 2 data
         target2_data = result[:targets].find { |t| t[:name] == 'Target 2' }
-        expect(target2_data[:model_info]).to eq('anthropic - claude-2')
+        expect(target2_data[:model_info]).to eq('OpenAIGenerator - claude-2')
         expect(target2_data[:summary][:total_reports]).to eq(1)
         expect(target2_data[:summary][:total_tests]).to eq(20) # 10+10
         expect(target2_data[:summary][:total_passed]).to eq(10) # 3+7

--- a/spec/services/validate_target_spec.rb
+++ b/spec/services/validate_target_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe ValidateTarget, type: :service do
 
     context 'with API target' do
       it 'uses RunCommand for API targets' do
-        expect(RunCommand).to receive(:new).with(kind_of(String)).and_return(mock_run_command)
-        expect(mock_run_command).to receive(:call)
+        expect(RunCommand).to receive(:new).with(kind_of(Array), env: kind_of(Hash)).and_return(mock_run_command)
+        expect(mock_run_command).to receive(:call).with(log_file: kind_of(String))
 
         service.call
       end
@@ -89,9 +89,9 @@ RSpec.describe ValidateTarget, type: :service do
       service.call
     end
 
-    it 'creates and calls RunCommand with the correct command' do
-      expect(RunCommand).to receive(:new).with(kind_of(String)).and_return(mock_run_command)
-      expect(mock_run_command).to receive(:call)
+    it 'creates and calls RunCommand with argv array and env hash' do
+      expect(RunCommand).to receive(:new).with(kind_of(Array), env: kind_of(Hash)).and_return(mock_run_command)
+      expect(mock_run_command).to receive(:call).with(log_file: kind_of(String))
 
       service.call
     end
@@ -141,92 +141,88 @@ RSpec.describe ValidateTarget, type: :service do
       allow(service).to receive(:validation_uuid).and_return(validation_uuid)
     end
 
-    describe '#command' do
-      let(:expected_script_path) { Rails.root.join("script", "run_garak.py") }
+    describe '#build_argv' do
+      it 'returns a flat array with python, script path, uuid, and individual params' do
+        argv = service.send(:build_argv)
 
-      before do
-        allow(service).to receive(:env_vars).and_return('ENV_VAR=value')
-        allow(service).to receive(:params).and_return('--model_type test --model_name gpt-4')
-        allow(service).to receive(:log_file).and_return(' 2>&1 | tee -a /path/to/log ')
-      end
-
-      it 'constructs the correct command' do
-        command = service.send(:command)
-
-        expect(command).to include('ENV_VAR=value')
-        expect(command).to include('HOME=/home/rails')
-        expect(command).to include("python3 #{expected_script_path}")
-        expect(command).to include("'#{validation_uuid}'")
-        expect(command).to include("'--model_type test --model_name gpt-4'")
-        expect(command).to include('2>&1 | tee -a /path/to/log')
+        expect(argv).to be_an(Array)
+        expect(argv[0]).to eq("/opt/venv/bin/python3")
+        expect(argv[1]).to include("run_garak.py")
+        expect(argv[2]).to eq(validation_uuid)
+        expect(argv[3]).to eq("--target_type")
+        expect(argv[4]).to include("OpenAIGenerator")
+        expect(argv[5]).to eq("--target_name")
+        expect(argv[6]).to eq("gpt-4")
       end
     end
 
-    describe '#env_vars' do
+    describe '#build_env' do
       let!(:global_env_var) { create(:environment_variable, target: nil, env_name: 'API_KEY', env_value: 'secret') }
       let!(:excluded_env_var) { create(:environment_variable, target: nil, env_name: 'EVALUATION_THRESHOLD', env_value: '0.5') }
 
+      it 'returns a hash of environment variables' do
+        env = service.send(:build_env)
+
+        expect(env).to be_a(Hash)
+        expect(env["HOME"]).to eq("/home/rails")
+      end
+
       it 'includes global environment variables' do
-        env_vars = service.send(:env_vars)
-        expect(env_vars).to include('API_KEY=secret')
+        env = service.send(:build_env)
+        expect(env["API_KEY"]).to eq("secret")
       end
 
       it 'excludes EVALUATION_THRESHOLD' do
-        env_vars = service.send(:env_vars)
-        expect(env_vars).not_to include('EVALUATION_THRESHOLD=0.5')
+        env = service.send(:build_env)
+        expect(env).not_to have_key("EVALUATION_THRESHOLD")
       end
 
-      it 'escapes values with Shellwords to prevent command injection' do
+      it 'preserves values verbatim without shell escaping' do
         create(:environment_variable, target: nil, env_name: 'INJECTION_TEST', env_value: 'value; rm -rf /')
 
-        env_vars = service.send(:env_vars)
-        expect(env_vars).to include('INJECTION_TEST=value\\;\ rm\ -rf\ /')
-        expect(env_vars).not_to include('INJECTION_TEST=value; rm -rf /')
+        env = service.send(:build_env)
+        expect(env["INJECTION_TEST"]).to eq('value; rm -rf /')
       end
 
-      it 'escapes values containing special shell characters' do
+      it 'preserves values with special shell characters' do
         create(:environment_variable, target: nil, env_name: 'SPECIAL_CHARS', env_value: "val'ue $(whoami)")
 
-        env_vars = service.send(:env_vars)
-        # Shellwords.escape wraps or escapes special characters
-        expect(env_vars).not_to include("$(whoami)")
-        expect(env_vars).to include("SPECIAL_CHARS=")
+        env = service.send(:build_env)
+        expect(env["SPECIAL_CHARS"]).to eq("val'ue $(whoami)")
       end
     end
 
     describe '#params' do
-      before do
-        allow(service).to receive(:target_type_arg).and_return('--target_type openai.gpt-4')
-        allow(service).to receive(:target_name_arg).and_return('--target_name gpt-4')
-        allow(service).to receive(:probe).and_return("--probes \"#{Scanner.configuration.validation_probe}\"")
-        allow(service).to receive(:report_prefix).and_return('--report_prefix validation_123')
-        allow(service).to receive(:generator_options).and_return('--generator_option_file /path/to/config.json')
-      end
+      it 'returns a flat array of individual arguments' do
+        allow(service).to receive(:temp_json_file_path).and_return('/path/to/config.json')
 
-      it 'combines all parameters' do
         params = service.send(:params)
-        expect(params).to eq("--target_type openai.gpt-4 --target_name gpt-4 --probes \"#{Scanner.configuration.validation_probe}\" --report_prefix validation_123 --generator_option_file /path/to/config.json")
+
+        expect(params).to be_an(Array)
+        expect(params).to include("--target_type", "--target_name", "--probes", "--report_prefix", "--generator_option_file")
+        expect(params).not_to include(nil)
+        params.each { |p| expect(p).to be_a(String) }
       end
     end
 
     describe '#target_type_arg' do
-      it 'constructs correct target type parameter' do
+      it 'returns a two-element array with flag and value' do
         target_type = service.send(:target_type_arg)
-        expect(target_type).to eq('--target_type openai.OpenAIGenerator')
+        expect(target_type).to eq([ "--target_type", "openai.OpenAIGenerator" ])
       end
     end
 
     describe '#target_name_arg' do
-      it 'constructs correct target name parameter' do
+      it 'returns a two-element array with flag and value' do
         target_name = service.send(:target_name_arg)
-        expect(target_name).to eq('--target_name gpt-4')
+        expect(target_name).to eq([ "--target_name", "gpt-4" ])
       end
     end
 
     describe '#probe' do
-      it 'returns the configured validation probe parameter' do
+      it 'returns a two-element array with flag and value' do
         probe = service.send(:probe)
-        expect(probe).to eq("--probes \"#{Scanner.configuration.validation_probe}\"")
+        expect(probe).to eq([ "--probes", Scanner.configuration.validation_probe ])
       end
     end
 
@@ -236,9 +232,9 @@ RSpec.describe ValidateTarget, type: :service do
           allow(service).to receive(:temp_json_file_path).and_return('/path/to/config.json')
         end
 
-        it 'returns generator option file parameter' do
+        it 'returns a two-element array with flag and path' do
           generator_options = service.send(:generator_options)
-          expect(generator_options).to eq('--generator_option_file /path/to/config.json')
+          expect(generator_options).to eq([ "--generator_option_file", "/path/to/config.json" ])
         end
       end
 

--- a/spec/services/validate_web_chat_target_spec.rb
+++ b/spec/services/validate_web_chat_target_spec.rb
@@ -168,12 +168,14 @@ RSpec.describe ValidateWebChatTarget do
 
   describe "#valid_url?" do
     it "returns true for valid HTTPS URLs" do
+      allow(UrlSafetyValidator).to receive(:resolve_addresses).and_return([ "93.184.216.34" ])
       expect(service.send(:valid_url?, "https://example.com")).to be true
       expect(service.send(:valid_url?, "https://example.com/chat")).to be true
       expect(service.send(:valid_url?, "https://subdomain.example.com")).to be true
     end
 
     it "returns true for valid HTTP URLs" do
+      allow(UrlSafetyValidator).to receive(:resolve_addresses).and_return([ "93.184.216.34" ])
       expect(service.send(:valid_url?, "http://example.com")).to be true
       expect(service.send(:valid_url?, "http://localhost:3000")).to be true
     end
@@ -186,7 +188,21 @@ RSpec.describe ValidateWebChatTarget do
     end
 
     it "returns false for nil" do
-      expect { service.send(:valid_url?, nil) }.not_to raise_error
+      expect(service.send(:valid_url?, nil)).to be false
+    end
+
+    context "SSRF protection" do
+      it "rejects internal IP addresses" do
+        allow(UrlSafetyValidator).to receive(:safe_url?).and_return(
+          UrlSafetyValidator::Result.new("safe?": false, error: "blocked")
+        )
+        expect(service.send(:valid_url?, "http://127.0.0.1")).to be false
+      end
+
+      it "delegates to UrlSafetyValidator" do
+        expect(UrlSafetyValidator).to receive(:safe_url?).with("https://example.com", allow_localhost: true).and_call_original
+        service.send(:valid_url?, "https://example.com")
+      end
     end
   end
 end

--- a/spec/support/run_garak_scan_stub.rb
+++ b/spec/support/run_garak_scan_stub.rb
@@ -1,9 +1,5 @@
 RSpec.configure do |config|
   config.before(:each) do
-    allow_any_instance_of(RunGarakScan).to receive(:command).and_return(
-      "echo 'Stubbed garak scan command for test environment'"
-    )
-
     allow_any_instance_of(RunGarakScan).to receive(:call) do |instance|
       instance.report.update(status: :starting)
     end

--- a/spec/validators/url_safety_validator_spec.rb
+++ b/spec/validators/url_safety_validator_spec.rb
@@ -1,0 +1,355 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UrlSafetyValidator do
+  describe ".safe_url?" do
+    context "with safe external URLs" do
+      it "allows standard HTTPS URLs" do
+        result = described_class.safe_url?("https://example.com")
+        expect(result.safe?).to be true
+      end
+
+      it "allows standard HTTP URLs" do
+        result = described_class.safe_url?("http://example.com/path")
+        expect(result.safe?).to be true
+      end
+
+      it "allows URLs with ports" do
+        result = described_class.safe_url?("https://example.com:8443/api")
+        expect(result.safe?).to be true
+      end
+    end
+
+    context "with loopback addresses" do
+      it "blocks http://127.0.0.1" do
+        result = described_class.safe_url?("http://127.0.0.1")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+
+      it "blocks http://127.0.0.2" do
+        result = described_class.safe_url?("http://127.0.0.2")
+        expect(result.safe?).to be false
+      end
+
+      it "blocks http://[::1]" do
+        result = described_class.safe_url?("http://[::1]")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+    end
+
+    context "with RFC1918 private addresses" do
+      it "blocks http://10.0.0.1" do
+        result = described_class.safe_url?("http://10.0.0.1")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+
+      it "blocks http://172.16.0.1" do
+        result = described_class.safe_url?("http://172.16.0.1")
+        expect(result.safe?).to be false
+      end
+
+      it "blocks http://192.168.1.1" do
+        result = described_class.safe_url?("http://192.168.1.1")
+        expect(result.safe?).to be false
+      end
+
+      it "allows http://172.32.0.1 (outside /12 range)" do
+        allow(UrlSafetyValidator).to receive(:resolve_addresses).with("172.32.0.1").and_return([ "172.32.0.1" ])
+        result = described_class.safe_url?("http://172.32.0.1")
+        expect(result.safe?).to be true
+      end
+    end
+
+    context "with cloud metadata endpoints" do
+      it "blocks http://169.254.169.254" do
+        result = described_class.safe_url?("http://169.254.169.254")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+
+      it "blocks http://169.254.169.254/latest/meta-data" do
+        result = described_class.safe_url?("http://169.254.169.254/latest/meta-data")
+        expect(result.safe?).to be false
+      end
+    end
+
+    context "with non-HTTP schemes" do
+      it "blocks FTP URLs" do
+        result = described_class.safe_url?("ftp://example.com")
+        expect(result.safe?).to be false
+        expect(result.error).to include("Only HTTP and HTTPS")
+      end
+
+      it "blocks javascript URIs" do
+        result = described_class.safe_url?("javascript:alert(1)")
+        expect(result.safe?).to be false
+      end
+    end
+
+    context "with invalid input" do
+      it "rejects nil" do
+        result = described_class.safe_url?(nil)
+        expect(result.safe?).to be false
+      end
+
+      it "rejects empty string" do
+        result = described_class.safe_url?("")
+        expect(result.safe?).to be false
+      end
+
+      it "rejects malformed URLs" do
+        result = described_class.safe_url?("not a url at all")
+        expect(result.safe?).to be false
+      end
+    end
+
+    context "with allow_localhost option" do
+      it "allows localhost IP when allow_localhost is true" do
+        result = described_class.safe_url?("http://127.0.0.1:3000", allow_localhost: true)
+        expect(result.safe?).to be true
+      end
+
+      it "allows localhost hostname when allow_localhost is true" do
+        result = described_class.safe_url?("http://localhost:3000", allow_localhost: true)
+        expect(result.safe?).to be true
+      end
+
+      it "still blocks private ranges when allow_localhost is true" do
+        result = described_class.safe_url?("http://10.0.0.1", allow_localhost: true)
+        expect(result.safe?).to be false
+      end
+
+      it "still blocks metadata endpoint when allow_localhost is true" do
+        result = described_class.safe_url?("http://169.254.169.254", allow_localhost: true)
+        expect(result.safe?).to be false
+      end
+    end
+
+    context "with DNS resolution" do
+      it "blocks hostnames that resolve to internal IPs" do
+        allow(UrlSafetyValidator).to receive(:resolve_addresses).with("evil.example.com").and_return([ "127.0.0.1" ])
+        result = described_class.safe_url?("http://evil.example.com")
+        expect(result.safe?).to be false
+      end
+
+      it "blocks hostnames that resolve to private IPs" do
+        allow(UrlSafetyValidator).to receive(:resolve_addresses).with("internal.example.com").and_return([ "192.168.1.100" ])
+        result = described_class.safe_url?("http://internal.example.com")
+        expect(result.safe?).to be false
+      end
+
+      it "blocks hostnames that cannot be resolved" do
+        allow(UrlSafetyValidator).to receive(:resolve_addresses).with("nonexistent.invalid").and_return([])
+        result = described_class.safe_url?("http://nonexistent.invalid")
+        expect(result.safe?).to be false
+        expect(result.error).to eq("Could not resolve hostname")
+      end
+    end
+
+    context "with IPv6 addresses" do
+      it "blocks IPv6 unique local addresses" do
+        result = described_class.safe_url?("http://[fd00::1]")
+        expect(result.safe?).to be false
+      end
+
+      it "blocks IPv6 link-local addresses" do
+        result = described_class.safe_url?("http://[fe80::1]")
+        expect(result.safe?).to be false
+      end
+    end
+
+    context "with IPv4-mapped IPv6 addresses" do
+      it "blocks ::ffff:127.0.0.1 (mapped loopback)" do
+        result = described_class.safe_url?("http://[::ffff:127.0.0.1]")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+
+      it "blocks ::ffff:169.254.169.254 (mapped metadata)" do
+        result = described_class.safe_url?("http://[::ffff:169.254.169.254]")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+
+      it "blocks ::ffff:10.0.0.1 (mapped RFC1918)" do
+        result = described_class.safe_url?("http://[::ffff:10.0.0.1]")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+
+      it "blocks ::ffff:192.168.1.1 (mapped RFC1918)" do
+        result = described_class.safe_url?("http://[::ffff:192.168.1.1]")
+        expect(result.safe?).to be false
+      end
+
+      it "blocks hostnames resolving to IPv4-mapped addresses" do
+        allow(UrlSafetyValidator).to receive(:resolve_addresses).with("mapped.evil.com").and_return([ "::ffff:127.0.0.1" ])
+        result = described_class.safe_url?("http://mapped.evil.com")
+        expect(result.safe?).to be false
+      end
+
+      it "allows ::ffff:127.0.0.1 when allow_localhost is true" do
+        result = described_class.safe_url?("http://[::ffff:127.0.0.1]:3000", allow_localhost: true)
+        expect(result.safe?).to be true
+      end
+    end
+
+    context "with zero address" do
+      it "blocks http://0.0.0.0" do
+        result = described_class.safe_url?("http://0.0.0.0")
+        expect(result.safe?).to be false
+      end
+    end
+
+    context "with additional blocked ranges" do
+      it "blocks CGN shared address space (100.64.0.1)" do
+        result = described_class.safe_url?("http://100.64.0.1")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+
+      it "blocks reserved-for-future (240.0.0.1)" do
+        result = described_class.safe_url?("http://240.0.0.1")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+
+      it "blocks multicast (224.0.0.1)" do
+        result = described_class.safe_url?("http://224.0.0.1")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+
+      it "blocks broadcast (255.255.255.255)" do
+        result = described_class.safe_url?("http://255.255.255.255")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+
+      it "blocks IPv6 unspecified ([::])" do
+        result = described_class.safe_url?("http://[::]")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+
+      it "blocks IPv6 multicast ([ff02::1])" do
+        result = described_class.safe_url?("http://[ff02::1]")
+        expect(result.safe?).to be false
+        expect(result.error).to include("blocked internal address")
+      end
+    end
+
+    context "with URI userinfo" do
+      it "rejects URLs with user credentials" do
+        allow(UrlSafetyValidator).to receive(:resolve_addresses).with("example.com").and_return([ "93.184.216.34" ])
+        result = described_class.safe_url?("http://user@example.com/")
+        expect(result.safe?).to be false
+        expect(result.error).to include("credentials")
+      end
+
+      it "rejects URLs with user:password credentials" do
+        allow(UrlSafetyValidator).to receive(:resolve_addresses).with("example.com").and_return([ "93.184.216.34" ])
+        result = described_class.safe_url?("http://user:pass@example.com/")
+        expect(result.safe?).to be false
+        expect(result.error).to include("credentials")
+      end
+    end
+
+    context "with IPv6 zone IDs" do
+      it "rejects URLs with percent-encoded zone IDs" do
+        result = described_class.safe_url?("http://[fe80::1%25eth0]/")
+        expect(result.safe?).to be false
+      end
+
+      it "rejects URLs with unencoded zone IDs" do
+        result = described_class.safe_url?("http://[fe80::1%eth0]/")
+        expect(result.safe?).to be false
+      end
+    end
+
+    context "with DNS resolution timeout" do
+      it "configures DNS resolver with timeouts" do
+        resolver = instance_double(Resolv::DNS)
+        allow(Resolv::DNS).to receive(:new).and_return(resolver)
+        allow(resolver).to receive(:timeouts=)
+        allow(resolver).to receive(:getaddresses).with("slow.example.com").and_return([])
+        allow(resolver).to receive(:close)
+
+        described_class.resolve_addresses("slow.example.com")
+
+        expect(resolver).to have_received(:timeouts=).with([ 2, 2 ])
+      end
+
+      it "returns empty array on DNS resolution error" do
+        resolver = instance_double(Resolv::DNS)
+        allow(Resolv::DNS).to receive(:new).and_return(resolver)
+        allow(resolver).to receive(:timeouts=)
+        allow(resolver).to receive(:getaddresses).and_raise(Resolv::ResolvError)
+        allow(resolver).to receive(:close)
+
+        expect(described_class.resolve_addresses("bad.example.com")).to eq([])
+      end
+
+      it "returns empty array on DNS timeout" do
+        resolver = instance_double(Resolv::DNS)
+        allow(Resolv::DNS).to receive(:new).and_return(resolver)
+        allow(resolver).to receive(:timeouts=)
+        allow(resolver).to receive(:getaddresses).and_raise(Resolv::ResolvTimeout)
+        allow(resolver).to receive(:close)
+
+        expect(described_class.resolve_addresses("timeout.example.com")).to eq([])
+      end
+    end
+
+    context "with resolved_ips in result" do
+      it "returns resolved IPs on successful validation" do
+        allow(UrlSafetyValidator).to receive(:resolve_addresses).with("safe.example.com").and_return([ "93.184.216.34" ])
+        result = described_class.safe_url?("http://safe.example.com")
+        expect(result.safe?).to be true
+        expect(result.resolved_ips).to eq([ "93.184.216.34" ])
+      end
+    end
+  end
+
+  describe ".safe_host?" do
+    it "allows safe external hostnames" do
+      result = described_class.safe_host?("example.com")
+      expect(result.safe?).to be true
+    end
+
+    it "blocks localhost" do
+      result = described_class.safe_host?("127.0.0.1")
+      expect(result.safe?).to be false
+    end
+
+    it "blocks private IPs" do
+      result = described_class.safe_host?("10.0.0.1")
+      expect(result.safe?).to be false
+    end
+
+    it "blocks metadata IP" do
+      result = described_class.safe_host?("169.254.169.254")
+      expect(result.safe?).to be false
+    end
+
+    it "rejects blank host" do
+      result = described_class.safe_host?(nil)
+      expect(result.safe?).to be false
+      expect(result.error).to include("Host is blank")
+    end
+
+    it "rejects empty host" do
+      result = described_class.safe_host?("")
+      expect(result.safe?).to be false
+    end
+
+    it "allows localhost when allow_localhost is true" do
+      result = described_class.safe_host?("127.0.0.1", allow_localhost: true)
+      expect(result.safe?).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR hardens several trust boundaries in the scanner while preserving the end-to-end scan flow, including variant report generation. It also fixes a queue-enqueue issue in the Python notifier that could create malformed running-stats jobs.

## What changed

- add URL safety validation and strengthen outbound target/output-server checks to reject unsafe internal destinations
- replace shell-string subprocess execution with argv-based execution in scan/runtime paths
- harden Playwright/browser automation by passing untrusted values through structured inputs instead of interpolation
- encrypt output server secrets at rest
- tighten authorization/tenant-scoping behavior and prevent unsafe target attribute updates
- improve report processing and report-details rendering, including variant and multi-detector result handling
- add schema/data updates for variant uniqueness, passed-flag backfill, and supporting indexes
- fix `BroadcastRunningStatsJob` enqueue payloads in `script/db_notifier.py` so jobs include the required arguments and concurrency key

## Why

These changes close security gaps around outbound requests, subprocess execution, browser automation, and secret storage while keeping core scanner workflows working correctly.
