### PR TITLE
fix(reports): normalize nil probe_result attempts

### DIFF
--- a/app/models/probe_result.rb
+++ b/app/models/probe_result.rb
@@ -8,6 +8,8 @@ class ProbeResult < ApplicationRecord
 
   validates :report_id, uniqueness: { scope: [ :probe_id, :threat_variant_id ] }
 
+  before_validation :normalize_attempts
+
   def asr_percentage
     return 0 if total.nil? || total.zero?
 
@@ -21,6 +23,10 @@ class ProbeResult < ApplicationRecord
   after_destroy_commit :decrement_probe_stats
 
   private
+
+  def normalize_attempts
+    self.attempts = [] if attempts.nil?
+  end
 
   # Thread-safe atomic increment using SQL expressions
   def increment_probe_stats

--- a/app/views/report_details/show.html.erb
+++ b/app/views/report_details/show.html.erb
@@ -376,7 +376,7 @@
 
         <div class="<%= pdf_mode ? 'px-6 pb-4 page-break-inside-avoid' : 'px-8 pb-6' %>">
           <div class="<%= pdf_mode ? 'pl-4 border-l-2 border-gray-200 space-y-3' : 'pl-6 border-l-2 border-gray-200 space-y-4' %>">
-            <% result.attempts.each do |attempt| %>
+            <% (result.attempts || []).each do |attempt| %>
               <div id="<%= attempt["uuid"] %>" class="<%= pdf_mode ? 'bg-gray-50/50 rounded p-4 border border-gray-100 break-inside-avoid' : 'bg-gray-50/50 rounded-lg p-5 shadow-sm border border-gray-100' %>">
                 <div class="<%= pdf_mode ? 'flex items-center justify-end mb-3' : 'flex items-center justify-end mb-4' %>">
                   <% if attempt.dig('notes', 'score_percentage').present? %>

--- a/db/migrate/20260415120000_backfill_and_enforce_not_null_on_probe_result_attempts.rb
+++ b/db/migrate/20260415120000_backfill_and_enforce_not_null_on_probe_result_attempts.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class BackfillAndEnforceNotNullOnProbeResultAttempts < ActiveRecord::Migration[8.0]
+  CONSTRAINT_NAME = "chk_probe_results_attempts_not_null"
+
+  def up
+    add_check_constraint :probe_results,
+      "attempts IS NOT NULL",
+      name: CONSTRAINT_NAME,
+      validate: false
+
+    execute "UPDATE probe_results SET attempts = '[]'::json WHERE attempts IS NULL"
+
+    validate_check_constraint :probe_results, name: CONSTRAINT_NAME
+    change_column_null :probe_results, :attempts, false
+    remove_check_constraint :probe_results, name: CONSTRAINT_NAME
+  end
+
+  def down
+    change_column_null :probe_results, :attempts, true
+    remove_check_constraint :probe_results, name: CONSTRAINT_NAME, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_060000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -146,7 +146,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_060000) do
 
   create_table "probe_results", force: :cascade do |t|
     t.boolean "any_detector_passed", default: false, null: false
-    t.json "attempts", default: []
+    t.json "attempts", default: [], null: false
     t.datetime "created_at", null: false
     t.integer "detector_id"
     t.integer "input_tokens", default: 0, null: false

--- a/spec/factories/probe_results.rb
+++ b/spec/factories/probe_results.rb
@@ -21,5 +21,9 @@ FactoryBot.define do
       passed { 0 }
       total { 10 }
     end
+
+    trait :nil_attempts do
+      attempts { nil }
+    end
   end
 end

--- a/spec/migrations/backfill_and_enforce_not_null_on_probe_result_attempts_spec.rb
+++ b/spec/migrations/backfill_and_enforce_not_null_on_probe_result_attempts_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+require Rails.root.join("db/migrate/20260415120000_backfill_and_enforce_not_null_on_probe_result_attempts")
+
+RSpec.describe BackfillAndEnforceNotNullOnProbeResultAttempts do
+  let(:migration) { described_class.new }
+
+  describe "#up" do
+    let(:report) { create(:report) }
+    let(:probe) { create(:probe) }
+    let(:detector) { create(:detector) }
+
+    before do
+      migration.down
+      ProbeResult.reset_column_information
+    end
+
+    after do
+      migration.up
+      ProbeResult.reset_column_information
+    end
+
+    it "backfills NULL attempts to empty array" do
+      pr = create(:probe_result, report: report, probe: probe, detector: detector)
+      pr.update_column(:attempts, nil)
+
+      migration.up
+
+      expect(pr.reload.attempts).to eq([])
+    end
+
+    it "preserves existing non-nil attempts" do
+      data = [ { "prompt" => "hello", "response" => "world" } ]
+      pr = create(:probe_result, report: report, probe: probe, detector: detector, attempts: data)
+
+      migration.up
+
+      expect(pr.reload.attempts).to eq(data)
+    end
+
+    it "enforces NOT NULL after migration" do
+      migration.up
+
+      expect {
+        ActiveRecord::Base.transaction(requires_new: true) do
+          ActiveRecord::Base.connection.execute(
+            "INSERT INTO probe_results (report_id, probe_id, detector_id, attempts, created_at, updated_at) " \
+            "VALUES (#{report.id}, #{probe.id}, #{detector.id}, NULL, NOW(), NOW())"
+          )
+        end
+      }.to raise_error(ActiveRecord::NotNullViolation)
+    end
+  end
+
+  describe "#down" do
+    it "allows NULL attempts again" do
+      migration.down
+
+      expect {
+        create(:probe_result).tap { |pr| pr.update_column(:attempts, nil) }
+      }.not_to raise_error
+
+      migration.up
+    end
+  end
+end

--- a/spec/models/probe_result_spec.rb
+++ b/spec/models/probe_result_spec.rb
@@ -9,6 +9,32 @@ RSpec.describe ProbeResult, type: :model do
   describe 'validations' do
   end
 
+  describe 'attempts normalization' do
+    it 'normalizes nil attempts to empty array before validation' do
+      result = build(:probe_result, :nil_attempts)
+      result.valid?
+      expect(result.attempts).to eq([])
+    end
+
+    it 'preserves existing attempts array' do
+      result = build(:probe_result, attempts: [ { "prompt" => "hello" } ])
+      result.valid?
+      expect(result.attempts).to eq([ { "prompt" => "hello" } ])
+    end
+
+    it 'saves with empty array when attempts is nil' do
+      result = create(:probe_result, :nil_attempts)
+      expect(result.reload.attempts).to eq([])
+    end
+
+    it 'normalizes nil attempts on update' do
+      result = create(:probe_result)
+      result.attempts = nil
+      result.save!
+      expect(result.reload.attempts).to eq([])
+    end
+  end
+
   describe 'factory' do
     it 'has a valid structure' do
       expect(build_stubbed(:probe_result)).to be_valid

--- a/spec/requests/report_details_spec.rb
+++ b/spec/requests/report_details_spec.rb
@@ -78,4 +78,36 @@ RSpec.describe "ReportDetails", type: :request do
       end
     end
   end
+
+  describe "GET /report_details/:id with nil probe_result attempts" do
+    let!(:probe_result) do
+      create(:probe_result, report: report, passed: 3, total: 10)
+    end
+
+    let(:pdf_token) do
+      Rails.application.message_verifier("pdf").generate(
+        report.id,
+        expires_in: 5.minutes,
+        purpose: :pdf_render
+      )
+    end
+
+    before do
+      ActiveRecord::Base.connection.execute("ALTER TABLE probe_results ALTER COLUMN attempts DROP NOT NULL")
+      probe_result.update_column(:attempts, nil)
+    end
+
+    after do
+      ActiveRecord::Base.connection.execute(
+        "UPDATE probe_results SET attempts = '[]' WHERE attempts IS NULL"
+      )
+      ActiveRecord::Base.connection.execute("ALTER TABLE probe_results ALTER COLUMN attempts SET NOT NULL")
+    end
+
+    it "renders successfully even when probe_result.attempts is NULL in the database" do
+      get report_detail_path(report, pdf: "true", pdf_token: pdf_token)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- normalize `ProbeResult.attempts` to `[]` before validation so nil values are not persisted
- guard the report details view against historical rows with nil `attempts`
- backfill existing null `probe_results.attempts` values and enforce `NOT NULL`
- add regression coverage for model normalization, report-details rendering, and the migration behavior
