### PR TITLE
fix: harden PDF download flow

### DIFF
--- a/app/controllers/report_details_controller.rb
+++ b/app/controllers/report_details_controller.rb
@@ -11,56 +11,123 @@ class ReportDetailsController < ApplicationController
   end
 
   def pdf
+    if params[:pdf_token].present?
+      serve_downloadable_pdf
+    else
+      serve_status_or_enqueue
+    end
+  end
+
+  def pdf_retry
     report_pdf = @report.report_pdf
 
-    # If PDF is ready, serve it
-    if report_pdf&.ready?
-      # file_path is set by GeneratePdfJob, not user input
-      # the file_path is something like storage/pdfs/report_{report.id}.pdf
-      # the filename is based on the target, target name_yyyy-mm-dd.pdf, which is
-      # legacy behavior
-      return send_file report_pdf.file_path,
-                       filename: pdf_filename,
-                       type: "application/pdf",
-                       disposition: "attachment"
+    # Already-downloadable or already-running requests don't need a reset.
+    # Respond with the normal status so the client can just poll or download.
+    return if report_pdf && render_report_pdf_status_for_retry(report_pdf)
+
+    report_pdf&.destroy!
+
+    begin
+      @report.create_report_pdf!(status: :pending)
+    rescue ActiveRecord::RecordNotUnique
+      @report.reload
+      existing = @report.report_pdf
+      return if existing && render_report_pdf_status_for_retry(existing)
+      raise
     end
 
-    # If PDF is being generated, return current status
-    if report_pdf&.status_processing? || report_pdf&.status_pending?
-      return render json: {
-        status: report_pdf.status,
-        message: "PDF is being generated. Please wait..."
-      }, status: :accepted
-    end
+    GeneratePdfJob.perform_later(@report.id, current_user.id)
 
-    # Create ReportPdf record here to prevent race condition
-    # Use find_or_create_by with uniqueness constraint to ensure only one exists
-    report_pdf = @report.build_report_pdf(status: :pending) unless report_pdf
-    report_pdf.save!
-
-    # Start PDF generation job
-    GeneratePdfJob.perform_later(@report.id)
     render json: {
       status: "pending",
       message: "PDF generation started. Please wait..."
     }, status: :accepted
   end
 
-  def pdf_status
+  private
+
+  def serve_downloadable_pdf
     report_pdf = @report.report_pdf
+    return head :not_found unless report_pdf&.ready?
+    return head :not_found unless Reports::PdfDownloadToken.verify(params[:pdf_token], report_pdf)
+    return head :not_found unless report_pdf.downloadable?
 
-    return render json: { status: "not_found" } if report_pdf.nil?
+    safe_path = Reports::PdfStorage.safe_path(report_pdf.file_path)
+    return head :not_found unless safe_path
+    return head :not_found unless File.exist?(safe_path)
 
-    if report_pdf.ready?
-      render json: { status: "completed", download_url: pdf_report_detail_path(@report) }
-    elsif report_pdf.status_failed?
-      render json: { status: "failed", error: report_pdf.error_message }
-    else
-      render json: { status: report_pdf.status }
-    end
+    DeletePdfJob.set(wait: 2.minutes).perform_later(report_pdf.id) if report_pdf.claim_download!
+
+    send_file safe_path,
+              filename: pdf_filename,
+              type: "application/pdf",
+              disposition: "attachment"
   end
 
-  private
+  def serve_status_or_enqueue
+    report_pdf = @report.report_pdf
+
+    return if render_report_pdf_status(report_pdf)
+
+    report_pdf&.destroy!
+
+    begin
+      @report.create_report_pdf!(status: :pending)
+    rescue ActiveRecord::RecordNotUnique
+      @report.reload
+      existing = @report.report_pdf
+      return if existing && render_report_pdf_status(existing)
+      raise
+    end
+
+    GeneratePdfJob.perform_later(@report.id, current_user.id)
+
+    render json: {
+      status: "pending",
+      message: "PDF generation started. Please wait..."
+    }, status: :accepted
+  end
+
+  def render_report_pdf_status(report_pdf)
+    return false unless report_pdf
+
+    if report_pdf.downloadable?
+      token = Reports::PdfDownloadToken.generate(report_pdf)
+      render json: {
+        status: "ready",
+        download_url: pdf_report_detail_path(@report, pdf_token: token)
+      }, status: :ok
+      return true
+    end
+
+    if report_pdf.status_processing? || report_pdf.status_pending?
+      render json: {
+        status: report_pdf.status,
+        message: "PDF is being generated. Please wait..."
+      }, status: :accepted
+      return true
+    end
+
+    if report_pdf.status_failed?
+      render json: {
+        status: "failed",
+        message: report_pdf.error_message.presence || "PDF generation failed",
+        retryable: true,
+        retry_url: pdf_retry_report_detail_path(@report)
+      }, status: :unprocessable_entity
+      return true
+    end
+
+    false
+  end
+
+  # Retry should treat the failed state as "rerun this", so we only
+  # short-circuit for the already-good and in-flight states.
+  def render_report_pdf_status_for_retry(report_pdf)
+    return false if report_pdf.status_failed?
+
+    render_report_pdf_status(report_pdf)
+  end
 
   def set_report
     report = @_unscoped_report || Report.includes(*SHOW_INCLUDES).find(params[:id])
@@ -73,30 +140,32 @@ class ReportDetailsController < ApplicationController
 
   # Verify a short-lived signed token from the internal PDF renderer.
   # This allows the headless browser to access the report without a Devise session.
-  def valid_pdf_token?
-    return @_valid_pdf_token if defined?(@_valid_pdf_token)
+  def valid_pdf_render_token?
+    return @_valid_pdf_render_token if defined?(@_valid_pdf_render_token)
 
-    @_valid_pdf_token = if params[:pdf_token].present? && params[:pdf].present?
-      report_id = Rails.application.message_verifier("pdf").verify(
+    @_valid_pdf_render_token = if params[:pdf_token].present? && params[:pdf].present?
+      report_id = Rails.application.message_verifier(
+        Reports::PdfGenerator::RENDER_TOKEN_VERIFIER_KEY
+      ).verify(
         params[:pdf_token],
-        purpose: :pdf_render
+        purpose: Reports::PdfGenerator::RENDER_TOKEN_PURPOSE
       )
       report_id.to_s == params[:id].to_s
     else
       false
     end
   rescue ActiveSupport::MessageVerifier::InvalidSignature
-    @_valid_pdf_token = false
+    @_valid_pdf_render_token = false
   end
 
   def authenticate_show
-    return if valid_pdf_token?
+    return if valid_pdf_render_token?
 
     redirect_to new_user_session_path unless current_user
   end
 
   def set_show_tenant
-    if valid_pdf_token?
+    if valid_pdf_render_token?
       @_unscoped_report = Report.includes(*SHOW_INCLUDES).find(params[:id])
       ActsAsTenant.current_tenant = @_unscoped_report.company
     else

--- a/app/javascript/controllers/pdf_download_controller.js
+++ b/app/javascript/controllers/pdf_download_controller.js
@@ -1,26 +1,31 @@
 import { Controller } from "@hotwired/stimulus"
 import { showToast } from "utils"
 
+const POLL_INTERVAL_MS = 5000
+const POLL_TIMEOUT_MS = 3 * 60 * 1000
+
 export default class extends Controller {
-  static targets = ['button', 'text', 'icon']
+  static targets = ["button", "text", "icon"]
   static values = {
     reportId: String,
     url: String
   }
 
   connect() {
-    // Listen for Turbo stream updates to pdf-status div
-    // We need to observe the parent because Turbo's replace action removes and re-adds the element
+    this.downloadRequested = false
+    this.pollingTimer = null
+    this.pollingStartedAt = null
+    this.autoRetryConsumed = false
+    this.statusUrl = null
+
     const statusDiv = document.getElementById(`pdf-status-${this.reportIdValue}`)
     if (statusDiv && statusDiv.parentElement) {
-      this.observer = new MutationObserver((mutations) => {
-        // Check if the status div was replaced
+      this.observer = new MutationObserver(() => {
         const updatedStatusDiv = document.getElementById(`pdf-status-${this.reportIdValue}`)
         if (updatedStatusDiv) {
           this.checkPdfStatus(updatedStatusDiv)
         }
       })
-      // Observe the parent element for childList changes
       this.observer.observe(statusDiv.parentElement, {
         childList: true,
         subtree: true
@@ -32,100 +37,217 @@ export default class extends Controller {
     if (this.observer) {
       this.observer.disconnect()
     }
+    this.stopPollingFallback()
   }
 
   async downloadPdf(event) {
     event.preventDefault()
-    
-    // Get URL from button's data attribute, controller value, or href
+
     const button = event.currentTarget
-    const url = button.dataset.pdfDownloadUrlValue || this.urlValue || button.href
-    
-    if (!url) {
-      console.error('No PDF URL found')
-      this.showError('PDF URL not configured')
+    const statusUrl = button.dataset.pdfDownloadUrlValue || this.urlValue || button.href
+
+    if (!statusUrl) {
+      console.error("No PDF URL found")
+      this.showError("PDF URL not configured")
       return
     }
-    
-    // Show loading state
+
+    this.downloadRequested = true
+    this.autoRetryConsumed = false
+    this.statusUrl = statusUrl
     this.setLoading(true)
-    
+
     try {
-      const response = await fetch(url, {
-        method: 'HEAD',
-        headers: {
-          'Accept': 'application/pdf,application/json'
-        }
-      })
-      
-      if (response.status === 200 && response.headers.get('Content-Type')?.includes('application/pdf')) {
-        // PDF is ready, trigger download via direct navigation
-        window.location.href = url
-        this.setLoading(false)
-      } else if (response.status === 202) {
-        // PDF generation in progress - need to GET to read JSON body
-        const getResponse = await fetch(url, {
-          headers: {
-            'Accept': 'application/json'
-          }
-        })
-        const data = await getResponse.json()
-        this.showGenerating(data.message || 'Generating PDF...')
-      } else {
-        // Error - need to GET to read error message
-        const getResponse = await fetch(url, {
-          headers: {
-            'Accept': 'application/json'
-          }
-        })
-        const data = await getResponse.json()
-        this.showError(data.message || 'Failed to generate PDF')
-      }
+      await this.requestPdf(statusUrl)
     } catch (error) {
-      console.error('PDF download error:', error)
-      this.showError('Failed to download PDF')
+      console.error("PDF download error:", error)
+      this.downloadRequested = false
+      this.showError("Failed to download PDF")
     }
   }
 
+  async requestPdf(statusUrl) {
+    const response = await fetch(statusUrl, {
+      headers: { "Accept": "application/json" }
+    })
+
+    if (response.status === 200) {
+      const data = await response.json()
+      if (data.status === "ready" && data.download_url) {
+        this.triggerDownload(data.download_url)
+      } else {
+        this.downloadRequested = false
+        this.showError(data.message || "PDF is not ready")
+      }
+      return
+    }
+
+    if (response.status === 202) {
+      const data = await response.json().catch(() => ({}))
+      this.showGenerating(data.message || "Generating PDF...")
+      this.startPollingFallback(statusUrl)
+      return
+    }
+
+    const data = await response.json().catch(() => ({}))
+
+    if (data && data.retryable && data.retry_url && !this.autoRetryConsumed) {
+      this.autoRetryConsumed = true
+      await this.retryPdf(data.retry_url, statusUrl)
+      return
+    }
+
+    this.downloadRequested = false
+    this.showError(data.message || data.error || "Failed to generate PDF")
+  }
+
+  async retryPdf(retryUrl, statusUrl) {
+    const response = await fetch(retryUrl, {
+      method: "POST",
+      headers: {
+        "Accept": "application/json",
+        "X-CSRF-Token": this.csrfToken(),
+        "X-Requested-With": "XMLHttpRequest"
+      },
+      credentials: "same-origin"
+    })
+
+    const data = await response.json().catch(() => ({}))
+
+    if (response.status === 202) {
+      this.showGenerating(data.message || "Retrying PDF generation...")
+      this.startPollingFallback(statusUrl)
+      return
+    }
+
+    if (response.status === 200 && data.status === "ready" && data.download_url) {
+      this.triggerDownload(data.download_url)
+      return
+    }
+
+    this.downloadRequested = false
+    this.showError(data.message || data.error || "Failed to retry PDF generation")
+  }
+
+  csrfToken() {
+    return document.querySelector('meta[name="csrf-token"]')?.content || ""
+  }
+
   checkPdfStatus(statusDiv) {
+    if (!this.downloadRequested) return
+
     const status = statusDiv.dataset.pdfStatus
     const downloadUrl = statusDiv.dataset.downloadUrl
-    
-    if (status === 'ready' && downloadUrl) {
-      // PDF is ready, trigger download
-      window.location.href = downloadUrl
-      this.setLoading(false)
+    const errorMessage = statusDiv.dataset.pdfError
+    const retryUrl = statusDiv.dataset.retryUrl
+    const retryable = statusDiv.dataset.pdfRetryable === "true"
+
+    if (status === "ready" && downloadUrl) {
+      this.triggerDownload(downloadUrl)
+    } else if (status === "failed") {
+      if (retryable && retryUrl && this.statusUrl && !this.autoRetryConsumed) {
+        this.autoRetryConsumed = true
+        this.stopPollingFallback()
+        this.retryPdf(retryUrl, this.statusUrl).catch((error) => {
+          console.error("PDF retry error:", error)
+          this.downloadRequested = false
+          this.showError("Failed to retry PDF generation")
+        })
+        return
+      }
+
+      this.stopPollingFallback()
+      this.downloadRequested = false
+      this.showError(errorMessage || "PDF generation failed")
     }
+  }
+
+  triggerDownload(url) {
+    this.stopPollingFallback()
+    this.downloadRequested = false
+    this.setLoading(false)
+    window.location.href = url
+  }
+
+  startPollingFallback(statusUrl) {
+    this.stopPollingFallback()
+    this.pollingStartedAt = Date.now()
+
+    this.pollingTimer = setInterval(async () => {
+      if (!this.downloadRequested) {
+        this.stopPollingFallback()
+        return
+      }
+
+      if (Date.now() - this.pollingStartedAt > POLL_TIMEOUT_MS) {
+        this.stopPollingFallback()
+        this.downloadRequested = false
+        this.showError("PDF generation timed out. Please try again.")
+        return
+      }
+
+      try {
+        const response = await fetch(statusUrl, {
+          headers: { "Accept": "application/json" }
+        })
+
+        if (response.status === 200) {
+          const data = await response.json()
+          if (data.status === "ready" && data.download_url) {
+            this.triggerDownload(data.download_url)
+          }
+        } else if (response.status !== 202) {
+          const data = await response.json().catch(() => ({}))
+
+          if (data && data.retryable && data.retry_url && !this.autoRetryConsumed) {
+            this.autoRetryConsumed = true
+            this.stopPollingFallback()
+            await this.retryPdf(data.retry_url, statusUrl)
+            return
+          }
+
+          this.stopPollingFallback()
+          this.downloadRequested = false
+          this.showError(data.message || data.error || "PDF generation failed")
+        }
+      } catch (error) {
+        console.error("PDF polling error:", error)
+      }
+    }, POLL_INTERVAL_MS)
+  }
+
+  stopPollingFallback() {
+    if (this.pollingTimer) {
+      clearInterval(this.pollingTimer)
+      this.pollingTimer = null
+    }
+    this.pollingStartedAt = null
   }
 
   setLoading(loading) {
     if (!this.hasButtonTarget) return
-    
+
     if (loading) {
-      this.buttonTarget.classList.add('opacity-50', 'pointer-events-none')
+      this.buttonTarget.classList.add("opacity-50", "pointer-events-none")
       if (this.hasTextTarget) {
         this.originalText = this.textTarget.textContent
-        this.textTarget.textContent = 'Preparing...'
+        this.textTarget.textContent = "Preparing..."
       } else {
-        // For links without text target, store original and update label
         this.originalText = this.buttonTarget.textContent.trim()
-        // Find text nodes (not icon spans) and update them
         Array.from(this.buttonTarget.childNodes).forEach(node => {
           if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
-            node.textContent = ' Preparing...'
+            node.textContent = " Preparing..."
           }
         })
       }
     } else {
-      this.buttonTarget.classList.remove('opacity-50', 'pointer-events-none')
+      this.buttonTarget.classList.remove("opacity-50", "pointer-events-none")
       if (this.hasTextTarget) {
-        this.textTarget.textContent = this.originalText || 'Download PDF'
+        this.textTarget.textContent = this.originalText || "Download PDF"
       } else {
-        // Restore original text for links
         Array.from(this.buttonTarget.childNodes).forEach(node => {
           if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
-            // Extract just the label part from originalText (remove icon text)
-            const labelOnly = this.originalText ? this.originalText.replace(/^\s+/, ' ') : ' Download PDF'
+            const labelOnly = this.originalText ? this.originalText.replace(/^\s+/, " ") : " Download PDF"
             node.textContent = labelOnly
           }
         })
@@ -137,16 +259,14 @@ export default class extends Controller {
     if (this.hasTextTarget) {
       this.textTarget.textContent = message
     }
-    // Keep loading state
   }
 
   showError(message) {
     if (this.hasTextTarget) {
-      this.textTarget.textContent = 'Download PDF'
+      this.textTarget.textContent = "Download PDF"
     }
     this.setLoading(false)
-    console.error('PDF download error:', message)
-    showToast(message, 'error')
+    console.error("PDF download error:", message)
+    showToast(message, "error")
   }
-
 }

--- a/app/jobs/cleanup_old_pdfs_job.rb
+++ b/app/jobs/cleanup_old_pdfs_job.rb
@@ -4,24 +4,24 @@ class CleanupOldPdfsJob < ApplicationJob
   queue_as :low_priority
 
   def perform
-    # Clean up PDF records older than 24 hours
     old_pdfs = ReportPdf.stale(24)
+    count = 0
 
     old_pdfs.find_each do |report_pdf|
       begin
-        # Delete the file if it exists
-        if report_pdf.file_path && File.exist?(report_pdf.file_path)
-          File.delete(report_pdf.file_path)
-          Rails.logger.info("Deleted old PDF file: #{report_pdf.file_path}")
+        safe_path = Reports::PdfStorage.safe_path(report_pdf.file_path)
+        if safe_path && File.exist?(safe_path)
+          File.delete(safe_path)
+          Rails.logger.info("Deleted old PDF file: #{safe_path}")
         end
 
-        # Delete the database record
         report_pdf.destroy
+        count += 1
       rescue => e
         Rails.logger.error("Failed to cleanup PDF #{report_pdf.id}: #{e.message}")
       end
     end
 
-    Rails.logger.info("Cleaned up #{old_pdfs.count} old PDF files")
+    Rails.logger.info("Cleaned up #{count} old PDF files")
   end
 end

--- a/app/jobs/delete_pdf_job.rb
+++ b/app/jobs/delete_pdf_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class DeletePdfJob < ApplicationJob
+  queue_as :low_priority
+
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(report_pdf_id)
+    report_pdf = ReportPdf.find(report_pdf_id)
+
+    safe_path = Reports::PdfStorage.safe_path(report_pdf.file_path)
+
+    if safe_path && File.exist?(safe_path)
+      File.delete(safe_path)
+      Rails.logger.info("Deleted PDF after download: report_pdf=#{report_pdf.id} path=#{safe_path}")
+    end
+
+    report_pdf.destroy
+  end
+end

--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -1,95 +1,115 @@
 # frozen_string_literal: true
 
 class GeneratePdfJob < ApplicationJob
+  MAX_ATTEMPTS = 3
+
   queue_as :default
 
-  # Ensure only one PDF generation job per report_id can be enqueued/running at a time
-  limits_concurrency to: 1, key: ->(report_id) { "generate_pdf_#{report_id}" }, on_conflict: :discard
+  limits_concurrency to: 1,
+    key: ->(report_id, _user_id = nil) { "generate_pdf_#{report_id}" },
+    on_conflict: :discard
 
-  # Retry with exponential backoff for transient failures
-  # Wait sequence: 3s, 18s, 83s, 258s, 627s (approximately)
-  retry_on StandardError, wait: :polynomially_longer, attempts: 3
+  # Mid-retry: retry_on re-enqueues without touching the ReportPdf row, so it stays
+  # in :processing across attempts (avoiding a rebuild loop on the client).
+  # Final attempt: the block runs, marking the record :failed and broadcasting.
+  retry_on StandardError, wait: :polynomially_longer, attempts: MAX_ATTEMPTS do |job, error|
+    job.send(:on_attempts_exceeded, error)
+  end
 
-  # Don't retry if report was deleted - it's a permanent failure
   discard_on ActiveRecord::RecordNotFound
 
-  def perform(report_id)
+  def perform(report_id, user_id)
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     report = Report.find(report_id)
-
-    # Get the ReportPdf record (created by controller)
     report_pdf = report.report_pdf
 
-    # If already completed and file exists, skip regeneration
-    return if report_pdf&.ready?
+    return if report_pdf.nil?
+    return if report_pdf.ready?
 
-    # Mark as processing
-    report_pdf.update!(status: :processing)
+    report_pdf.update!(status: :processing) unless report_pdf.status_processing?
 
-    begin
-      # Generate PDF using existing service
-      pdf_generator = Reports::PdfGenerator.new(ReportDecorator.new(report))
+    file_path = write_pdf(report)
 
-      # Create storage directory if it doesn't exist
-      storage_dir = Rails.root.join("storage", "pdfs")
-      FileUtils.mkdir_p(storage_dir)
+    duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round
 
-      # Simple filename without timestamp
-      filename = "report_#{report.id}.pdf"
-      file_path = storage_dir.join(filename).to_s
+    report_pdf.update!(status: :completed, file_path: file_path, error_message: nil)
 
-      # Generate and save PDF
-      pdf_content = pdf_generator.generate
-      File.binwrite(file_path, pdf_content)
+    Rails.logger.info(
+      "Successfully generated PDF for report #{report_id} at #{file_path} in #{duration_ms}ms"
+    )
 
-      # Calculate generation time
-      duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round
+    collect_metrics(report, duration_ms, File.size(file_path), success: true)
 
-      # Update record with success
-      report_pdf.update!(
-        status: :completed,
-        file_path: file_path,
-        error_message: nil
-      )
-
-      Rails.logger.info("Successfully generated PDF for report #{report_id} at #{file_path} in #{duration_ms}ms")
-
-      # Collect metrics
-      collect_metrics(report, duration_ms, pdf_content.bytesize, success: true)
-
-      # Broadcast completion to company-scoped stream
-      broadcast_pdf_ready(report)
-    rescue => e
-      # Calculate generation time even on failure
-      duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round
-
-      # Update record with failure
-      report_pdf.update!(
-        status: :failed,
-        error_message: "#{e.class}: #{e.message}"
-      )
-
-      Rails.logger.error("PDF generation failed for report #{report_id}: #{e.message}")
-      Rails.logger.error(e.backtrace.join("\n"))
-
-      # Collect failure metrics
-      collect_metrics(report, duration_ms, 0, success: false, error: e.class.name)
-
-      # Re-raise to trigger retry logic
-      raise
-    end
+    broadcast_pdf_ready(report, report_pdf.reload, user_id)
+  rescue ActiveRecord::RecordNotFound
+    raise
+  rescue => e
+    Rails.logger.error("PDF generation failed for report #{report_id}: #{e.message}")
+    Rails.logger.error(e.backtrace.join("\n"))
+    collect_metrics(report, 0, 0, success: false, error: e.class.name) if defined?(report) && report
+    raise
   end
 
   private
 
-  def broadcast_pdf_ready(report)
-    # Broadcast to company-scoped PDF stream using Turbo
-    # Replace the hidden status div with one that has the ready attributes
+  def on_attempts_exceeded(error)
+    report_id, user_id = arguments
+    report = Report.find_by(id: report_id)
+    return unless report
+
+    report_pdf = report.report_pdf
+    return unless report_pdf
+
+    report_pdf.update!(status: :failed, error_message: "#{error.class}: #{error.message}")
+    broadcast_pdf_failed(report, user_id, error)
+  end
+
+  def write_pdf(report)
+    storage_dir = Rails.root.join("storage", "pdfs")
+    FileUtils.mkdir_p(storage_dir)
+
+    file_path = storage_dir.join("report_#{report.id}.pdf").to_s
+    pdf_content = Reports::PdfGenerator.new(ReportDecorator.new(report)).generate
+    File.binwrite(file_path, pdf_content)
+    file_path
+  end
+
+  def broadcast_pdf_ready(report, report_pdf, user_id)
+    token = Reports::PdfDownloadToken.generate(report_pdf)
+    download_url = Rails.application.routes.url_helpers.pdf_report_detail_path(report, pdf_token: token)
+    escaped_url = ERB::Util.html_escape(download_url)
+
     Turbo::StreamsChannel.broadcast_replace_to(
-      "pdf_notifications:company_#{report.company_id}",
+      stream_name_for(report, user_id),
       target: "pdf-status-#{report.id}",
-      html: "<div id='pdf-status-#{report.id}' style='display: none;' data-pdf-status='ready' data-download-url='#{Rails.application.routes.url_helpers.pdf_report_detail_path(report)}'></div>"
+      html: <<~HTML.squish
+        <div id='pdf-status-#{report.id}' style='display: none;'
+             data-pdf-status='ready'
+             data-download-url='#{escaped_url}'></div>
+      HTML
     )
+  end
+
+  def broadcast_pdf_failed(report, user_id, error)
+    escaped_error = ERB::Util.html_escape("#{error.class}: #{error.message}")
+    retry_url = Rails.application.routes.url_helpers.pdf_retry_report_detail_path(report)
+    escaped_retry_url = ERB::Util.html_escape(retry_url)
+
+    Turbo::StreamsChannel.broadcast_replace_to(
+      stream_name_for(report, user_id),
+      target: "pdf-status-#{report.id}",
+      html: <<~HTML.squish
+        <div id='pdf-status-#{report.id}' style='display: none;'
+             data-pdf-status='failed'
+             data-pdf-error='#{escaped_error}'
+             data-pdf-retryable='true'
+             data-retry-url='#{escaped_retry_url}'></div>
+      HTML
+    )
+  end
+
+  def stream_name_for(report, user_id)
+    "pdf_notifications:user_#{user_id}:report_#{report.id}"
   end
 
   def collect_metrics(report, duration_ms, pdf_size_bytes, success:, error: nil)
@@ -109,6 +129,9 @@ class GeneratePdfJob < ApplicationJob
 
     MonitoringService.set_labels(labels)
 
-    Rails.logger.info("[Metrics] PDF generation: report=#{report.id} duration=#{duration_ms}ms size=#{pdf_size_bytes}bytes success=#{success}")
+    Rails.logger.info(
+      "[Metrics] PDF generation: report=#{report.id} duration=#{duration_ms}ms " \
+      "size=#{pdf_size_bytes}bytes success=#{success}"
+    )
   end
 end

--- a/app/models/report_pdf.rb
+++ b/app/models/report_pdf.rb
@@ -1,4 +1,6 @@
 class ReportPdf < ApplicationRecord
+  DOWNLOAD_GRACE_WINDOW = 2.minutes
+
   belongs_to :report
 
   enum :status, {
@@ -9,19 +11,47 @@ class ReportPdf < ApplicationRecord
   }, prefix: true
 
   validates :report, presence: true
+  validates :report_id, uniqueness: true
   validates :status, presence: true
 
   scope :recent, -> { order(created_at: :desc) }
   scope :stale, ->(hours = 24) { where("created_at < ?", hours.hours.ago) }
 
-  # Check if PDF is ready to serve
+  # Check if PDF is ready to serve. A record is only ready when the persisted
+  # file_path resolves inside the sandbox AND the file exists on disk — otherwise
+  # the status endpoint could hand out a "ready" URL for a path the downloader
+  # will reject with 404.
   def ready?
-    status_completed? && file_path.present? && File.exist?(file_path)
+    status_completed? && safe_file_path.present?
+  end
+
+  def downloadable?
+    ready? && (downloaded_at.nil? || downloaded_at > DOWNLOAD_GRACE_WINDOW.ago)
+  end
+
+  def claim_download!
+    updated_count = self.class
+      .where(id: id, downloaded_at: nil)
+      .update_all(downloaded_at: Time.current, updated_at: Time.current)
+    updated_count == 1
+  end
+
+  # Returns the sandbox-resolved absolute path when file_path points inside
+  # storage/pdfs and the file exists, or nil otherwise.
+  def safe_file_path
+    return nil if file_path.blank?
+
+    resolved = Reports::PdfStorage.safe_path(file_path)
+    return nil unless resolved && File.exist?(resolved)
+
+    resolved
   end
 
   # Get the file size in bytes
   def file_size
-    return nil unless file_path && File.exist?(file_path)
-    File.size(file_path)
+    path = safe_file_path
+    return nil unless path
+
+    File.size(path)
   end
 end

--- a/app/services/reports/pdf_download_token.rb
+++ b/app/services/reports/pdf_download_token.rb
@@ -1,0 +1,30 @@
+module Reports
+  module PdfDownloadToken
+    PURPOSE_PREFIX = "report_pdf_download"
+    TTL = 10.minutes
+
+    def self.generate(report_pdf)
+      verifier.generate(report_pdf.id,
+                        purpose: purpose_for(report_pdf),
+                        expires_in: TTL)
+    end
+
+    def self.verify(token, report_pdf)
+      return false if token.blank?
+
+      verifier.verify(token, purpose: purpose_for(report_pdf)) == report_pdf.id
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      false
+    end
+
+    def self.verifier
+      Rails.application.message_verifier(:pdf_download)
+    end
+
+    def self.purpose_for(report_pdf)
+      "#{PURPOSE_PREFIX}:#{report_pdf.id}"
+    end
+
+    private_class_method :verifier, :purpose_for
+  end
+end

--- a/app/services/reports/pdf_generator.rb
+++ b/app/services/reports/pdf_generator.rb
@@ -1,5 +1,9 @@
 module Reports
   class PdfGenerator
+    RENDER_TOKEN_VERIFIER_KEY = :report_pdf
+    RENDER_TOKEN_PURPOSE = :pdf_render
+    RENDER_TOKEN_TTL = 5.minutes
+
     attr_reader :report
 
     def initialize(report)
@@ -12,12 +16,12 @@ module Reports
         # Prefer ENV_PORT (entrypoint invariant) over PORT (which some servers mutate)
         port = ENV["ENV_PORT"].presence || ENV["PORT"].presence || "3000"
 
-        # Generate a short-lived signed token so the headless browser can access
-        # the report without a Devise session.
-        token = Rails.application.message_verifier("pdf").generate(
+        # Short-lived signed token so the headless browser can render the report
+        # without a Devise session.
+        token = Rails.application.message_verifier(RENDER_TOKEN_VERIFIER_KEY).generate(
           report.id,
-          expires_in: 5.minutes,
-          purpose: :pdf_render
+          expires_in: RENDER_TOKEN_TTL,
+          purpose: RENDER_TOKEN_PURPOSE
         )
 
         url = Rails.application.routes.url_helpers.report_detail_url(

--- a/app/services/reports/pdf_storage.rb
+++ b/app/services/reports/pdf_storage.rb
@@ -9,10 +9,11 @@ module Reports
       return nil if file_path.blank?
       return nil if file_path.include?("\u0000")
 
-      sandbox_real = File.realpath(Rails.root.join("storage", "pdfs").to_s)
+      sandbox_real = resolve_without_symlink_escape(File.expand_path(Rails.root.join("storage", "pdfs").to_s))
       resolved = resolve_without_symlink_escape(File.expand_path(file_path))
 
-      if resolved.nil? || (resolved != sandbox_real && !resolved.start_with?(sandbox_real + File::SEPARATOR))
+      if sandbox_real.nil? || resolved.nil? ||
+         (resolved != sandbox_real && !resolved.start_with?(sandbox_real + File::SEPARATOR))
         Rails.logger.warn("Rejected PDF path outside sandbox: #{file_path}")
         return nil
       end
@@ -23,19 +24,29 @@ module Reports
       nil
     end
 
-    # Resolve symlinks in every ancestor of the path. If the target file itself
-    # does not yet exist, resolve only its parent; reject broken symlinks since
-    # their targets could later materialise as sandbox escapes.
+    # Resolve symlinks in every ancestor of the path. If the target path or one
+    # of its parent directories does not exist yet, resolve the nearest existing
+    # ancestor and then rebuild the trailing relative path. Reject broken
+    # symlinks since their targets could later materialise as sandbox escapes.
     def self.resolve_without_symlink_escape(absolute)
-      File.realpath(absolute)
-    rescue Errno::ENOENT
-      return nil if File.symlink?(absolute)
+      missing_components = []
+      current = absolute
 
-      parent = File.dirname(absolute)
-      basename = File.basename(absolute)
-      return nil if basename.empty? || basename == "." || basename == ".."
+      loop do
+        begin
+          resolved = File.realpath(current)
+          return missing_components.empty? ? resolved : File.join(resolved, *missing_components.reverse)
+        rescue Errno::ENOENT
+          return nil if File.symlink?(current)
 
-      File.join(File.realpath(parent), basename)
+          parent = File.dirname(current)
+          basename = File.basename(current)
+          return nil if basename.empty? || basename == "." || basename == ".." || parent == current
+
+          missing_components << basename
+          current = parent
+        end
+      end
     end
     private_class_method :resolve_without_symlink_escape
   end

--- a/app/services/reports/pdf_storage.rb
+++ b/app/services/reports/pdf_storage.rb
@@ -1,0 +1,42 @@
+module Reports
+  module PdfStorage
+    # Canonicalize file_path and confirm it lives under storage/pdfs.
+    # Follows symlinks so an attacker-planted link inside the sandbox cannot
+    # redirect serving or deletion to files outside it. Tolerates a missing
+    # basename so callers may validate paths before the file is written.
+    # Returns the resolved absolute path on success, nil on any rejection.
+    def self.safe_path(file_path)
+      return nil if file_path.blank?
+      return nil if file_path.include?("\u0000")
+
+      sandbox_real = File.realpath(Rails.root.join("storage", "pdfs").to_s)
+      resolved = resolve_without_symlink_escape(File.expand_path(file_path))
+
+      if resolved.nil? || (resolved != sandbox_real && !resolved.start_with?(sandbox_real + File::SEPARATOR))
+        Rails.logger.warn("Rejected PDF path outside sandbox: #{file_path}")
+        return nil
+      end
+
+      resolved
+    rescue ArgumentError, SystemCallError => e
+      Rails.logger.warn("Invalid PDF path #{file_path.inspect}: #{e.message}")
+      nil
+    end
+
+    # Resolve symlinks in every ancestor of the path. If the target file itself
+    # does not yet exist, resolve only its parent; reject broken symlinks since
+    # their targets could later materialise as sandbox escapes.
+    def self.resolve_without_symlink_escape(absolute)
+      File.realpath(absolute)
+    rescue Errno::ENOENT
+      return nil if File.symlink?(absolute)
+
+      parent = File.dirname(absolute)
+      basename = File.basename(absolute)
+      return nil if basename.empty? || basename == "." || basename == ".."
+
+      File.join(File.realpath(parent), basename)
+    end
+    private_class_method :resolve_without_symlink_escape
+  end
+end

--- a/app/views/admin/reports/_show_v2.html.erb
+++ b/app/views/admin/reports/_show_v2.html.erb
@@ -1,4 +1,6 @@
-<%= turbo_stream_from "pdf_notifications:company_#{current_user.current_company_id}" %>
+<% if current_user %>
+  <%= turbo_stream_from "pdf_notifications:user_#{current_user.id}:report_#{report.id}" %>
+<% end %>
 <div id="pdf-status-<%= report.id %>" style="display: none;"></div>
 
 <div class="min-h-screen" data-controller="report-redesigned pdf-download" data-pdf-download-report-id-value="<%= report.id %>" data-report-redesigned-probes-tab-url-value="<%= probes_tab_report_path(report) %>">

--- a/app/views/report_details/show.html.erb
+++ b/app/views/report_details/show.html.erb
@@ -2,7 +2,7 @@
 
 <% unless pdf_mode %>
   <% if current_user %>
-    <%= turbo_stream_from "pdf_notifications:company_#{current_user.current_company_id}" %>
+    <%= turbo_stream_from "pdf_notifications:user_#{current_user.id}:report_#{@report.id}" %>
   <% end %>
   <div id="pdf-status-<%= @report.id %>" style="display: none;"></div>
 <% end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,27 +3,50 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "bf6481d9a583704c4e72449022387d49463c496a4b09852f91e87d21bb16c06b",
+      "fingerprint": "f3162d97301023ea7d2fd095ad35e699e3e4387c1de2495089b0c78cb2165449",
       "check_name": "SendFile",
       "message": "Model attribute used in file name",
       "file": "app/controllers/report_details_controller.rb",
-      "line": 22,
+      "line": 61,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(ReportDecorator.new((Report.includes(:target, :scan, :probe_results => ([:probe, :detector])).find(params[:id]) or Report.includes(:target, :scan, :probe_results => ([:probe, :detector])).find(params[:id]))).report_pdf.file_path, :filename => pdf_filename, :type => \"application/pdf\", :disposition => \"attachment\")",
+      "code": "send_file(Reports::PdfStorage.safe_path(ReportDecorator.new((Report.includes(:target, :scan, :probe_results => ([:probe, :detector])).find(params[:id]) or Report.includes(:target, :scan, :probe_results => ([:probe, :detector])).find(params[:id]))).report_pdf.file_path), :filename => pdf_filename, :type => \"application/pdf\", :disposition => \"attachment\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "ReportDetailsController",
-        "method": "pdf"
+        "method": "serve_downloadable_pdf"
       },
       "user_input": "Report.includes(:target, :scan, :probe_results => ([:probe, :detector])).find(params[:id])",
       "confidence": "Weak",
       "cwe_id": [
         22
       ],
-      "note": "file_path is set by GeneratePdfJob, not user input. The path format is storage/pdfs/report_{report.id}.pdf and cannot be manipulated by users."
+      "note": "file_path is set by GeneratePdfJob to storage/pdfs/report_{id}.pdf. Reports::PdfStorage.safe_path validates that the expanded path is inside Rails.root/storage/pdfs before serving; paths outside the sandbox return 404. The download is token-gated via Reports::PdfDownloadToken bound to the specific ReportPdf.id."
+    },
+    {
+      "warning_type": "File Access",
+      "warning_code": 16,
+      "fingerprint": "3a0905d2ae8d141c9966f2ceaa9a44edc4b67b0ce86b9688dc1b46da6f62dacb",
+      "check_name": "FileAccess",
+      "message": "Model attribute used in file name",
+      "file": "app/jobs/delete_pdf_job.rb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
+      "code": "File.delete(Reports::PdfStorage.safe_path(ReportPdf.find(report_pdf_id).file_path))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "DeletePdfJob",
+        "method": "perform"
+      },
+      "user_input": "ReportPdf.find(report_pdf_id).file_path",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ],
+      "note": "DeletePdfJob now routes file_path through Reports::PdfStorage.safe_path, which rejects anything outside Rails.root/storage/pdfs (returns nil) so only sandboxed paths reach File.delete. Covered by spec/jobs/delete_pdf_job_spec.rb sandbox rejection test."
     }
   ],
-  "updated": "2026-02-20 19:42:55 +0000",
-  "brakeman_version": "8.0.2"
+  "updated": "2026-04-20 04:16:00 -0500",
+  "brakeman_version": "8.0.4"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,7 +107,7 @@ Rails.application.routes.draw do
   resources :report_details, only: [ :show ] do
     member do
       get :pdf
-      get :pdf_status
+      post :pdf_retry
     end
   end
 

--- a/cypress/e2e/06_report_details.cy.js
+++ b/cypress/e2e/06_report_details.cy.js
@@ -150,64 +150,69 @@ describe('Report Details Page', () => {
     })
   })
   
-  it('verifies PDF download link and response', () => {
+  it('verifies PDF download flow and response', () => {
     cy.visit(`/report_details/${reportId}`)
-    
-    // Get PDF button/link
+
     const pdfTimeout = Number(Cypress.env('PDF_REQUEST_TIMEOUT_MS') || 240000) // default 240s for CI
-    cy.get('button[data-pdf-download-target="button"], a[href*="/pdf"]', { timeout: pdfTimeout })
-      .scrollIntoView()
-      .should('be.visible')
-      .invoke('attr', 'href')
-      .then((pdfUrl) => {
-        // Button might not have href, construct URL if needed
-        const url = pdfUrl || `/report_details/${reportId}/pdf`
-        expect(typeof url).to.eq('string')
-        cy.log(`Fetching PDF: ${url} (timeout ${pdfTimeout} ms)`)
+    const statusUrl = `/report_details/${reportId}/pdf`
 
-        const fetchPdf = (retries = 3) => cy.request({
-          url: url,
-          encoding: 'binary',
-          timeout: pdfTimeout,
-          followRedirect: true,
-          failOnStatusCode: false,
-          headers: {
-            Referer: `${Cypress.config('baseUrl')}/report_details/${reportId}`,
-            Accept: 'application/pdf,application/json'
-          }
-        }).then((resp) => {
-          const ct = (resp.headers && (resp.headers['content-type'] || resp.headers['Content-Type'])) || ''
-          const isPdf = (ct || '').toLowerCase().includes('application/pdf')
-          const isJson = (ct || '').toLowerCase().includes('application/json')
-          cy.log(`PDF response: status=${resp.status} content-type=${ct}`)
+    cy.log(`Polling PDF status: ${statusUrl} (timeout ${pdfTimeout} ms)`)
 
-          // Handle async PDF generation (202 status)
-          if (resp.status === 202 && isJson) {
-            cy.log('PDF generation in progress (202), waiting and retrying...')
-            if (retries > 0) {
-              cy.wait(10000) // Wait 10s for generation
-              return fetchPdf(retries - 1)
-            } else {
-              cy.log('PDF generation taking too long, but async flow is working')
-              // Don't fail - async generation is working, just taking time
-              return
-            }
-          }
+    const fetchStatus = (retries = 30) => cy.request({
+      url: statusUrl,
+      timeout: pdfTimeout,
+      followRedirect: true,
+      failOnStatusCode: false,
+      headers: {
+        Referer: `${Cypress.config('baseUrl')}/report_details/${reportId}`,
+        Accept: 'application/json'
+      }
+    }).then((resp) => {
+      const ct = (resp.headers && (resp.headers['content-type'] || resp.headers['Content-Type'])) || ''
+      cy.log(`Status response: status=${resp.status} content-type=${ct}`)
 
-          // Handle server errors gracefully
-          if (resp.status === 500) {
-            cy.log('PDF generation returned 500 - server-side issue')
-            return
-          }
+      if (resp.status === 500) {
+        cy.log('PDF generation returned 500 - server-side issue')
+        return
+      }
 
-          // PDF should be ready
-          expect(resp.status).to.eq(200)
-          expect(isPdf).to.eq(true)
-          expect(resp.body && resp.body.length).to.be.greaterThan(1000)
-        })
+      // 202 = generation in progress, body has {status: pending|processing}
+      if (resp.status === 202) {
+        if (retries > 0) {
+          cy.wait(5000)
+          return fetchStatus(retries - 1)
+        }
+        cy.log('PDF generation taking too long, but async flow is working')
+        return
+      }
 
-        fetchPdf()
+      // 200 = ready, body has {status: "ready", download_url: "...pdf_token=..."}
+      expect(resp.status).to.eq(200)
+      const body = typeof resp.body === 'string' ? JSON.parse(resp.body) : resp.body
+      expect(body.status).to.eq('ready')
+      expect(body.download_url).to.be.a('string')
+      expect(body.download_url).to.match(/pdf_token=/)
+
+      // Fetch the signed download URL and verify we get actual PDF bytes.
+      return cy.request({
+        url: body.download_url,
+        encoding: 'binary',
+        timeout: pdfTimeout,
+        followRedirect: true,
+        failOnStatusCode: false,
+        headers: {
+          Referer: `${Cypress.config('baseUrl')}/report_details/${reportId}`,
+          Accept: 'application/pdf'
+        }
+      }).then((fileResp) => {
+        const fct = (fileResp.headers && (fileResp.headers['content-type'] || fileResp.headers['Content-Type'])) || ''
+        expect(fileResp.status).to.eq(200)
+        expect((fct || '').toLowerCase()).to.include('application/pdf')
+        expect(fileResp.body && fileResp.body.length).to.be.greaterThan(1000)
       })
+    })
+
+    fetchStatus()
   })
   
   it('handles navigation correctly', () => {

--- a/db/migrate/20260418002147_add_downloaded_at_to_report_pdfs.rb
+++ b/db/migrate/20260418002147_add_downloaded_at_to_report_pdfs.rb
@@ -1,0 +1,6 @@
+class AddDownloadedAtToReportPdfs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :report_pdfs, :downloaded_at, :datetime
+    add_index :report_pdfs, :downloaded_at
+  end
+end

--- a/db/migrate/20260418193602_add_unique_index_to_report_pdfs_report_id.rb
+++ b/db/migrate/20260418193602_add_unique_index_to_report_pdfs_report_id.rb
@@ -1,0 +1,59 @@
+class AddUniqueIndexToReportPdfsReportId < ActiveRecord::Migration[8.1]
+  def up
+    return if index_exists?(:report_pdfs, :report_id,
+                            name: "index_report_pdfs_on_report_id", unique: true)
+
+    cleanup_duplicate_report_pdfs
+
+    remove_index :report_pdfs,
+                 name: "index_report_pdfs_on_report_id",
+                 if_exists: true
+    add_index :report_pdfs, :report_id, unique: true,
+              name: "index_report_pdfs_on_report_id"
+  end
+
+  def down
+    remove_index :report_pdfs,
+                 name: "index_report_pdfs_on_report_id",
+                 if_exists: true
+    add_index :report_pdfs, :report_id,
+              name: "index_report_pdfs_on_report_id"
+  end
+
+  private
+
+  # Survivor policy for duplicate report_pdfs rows, from best to worst:
+  #   1. completed (status=2) with a non-empty file_path — the actual PDF
+  #   2. any row with a non-empty file_path
+  #   3. completed (status=2) without file_path
+  #   4. highest id as a deterministic tiebreaker
+  def cleanup_duplicate_report_pdfs
+    duplicates = execute(<<~SQL).to_a
+      SELECT report_id
+      FROM report_pdfs
+      GROUP BY report_id
+      HAVING COUNT(*) > 1
+    SQL
+
+    return if duplicates.empty?
+
+    say "Found #{duplicates.size} duplicate report_pdf groups — keeping best completed/file_path row per report_id"
+
+    execute(<<~SQL)
+      DELETE FROM report_pdfs
+      WHERE id NOT IN (
+        SELECT DISTINCT ON (report_id) id
+        FROM report_pdfs
+        ORDER BY
+          report_id,
+          CASE
+            WHEN status = 2 AND file_path IS NOT NULL AND file_path <> '' THEN 0
+            WHEN file_path IS NOT NULL AND file_path <> '' THEN 1
+            WHEN status = 2 THEN 2
+            ELSE 3
+          END,
+          id DESC
+      )
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_18_193602) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -250,13 +250,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_120000) do
 
   create_table "report_pdfs", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.datetime "downloaded_at"
     t.text "error_message"
     t.string "file_path"
     t.bigint "report_id", null: false
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
+    t.index ["downloaded_at"], name: "index_report_pdfs_on_downloaded_at"
     t.index ["report_id", "created_at"], name: "index_report_pdfs_on_report_id_and_created_at"
-    t.index ["report_id"], name: "index_report_pdfs_on_report_id"
+    t.index ["report_id"], name: "index_report_pdfs_on_report_id", unique: true
     t.index ["status"], name: "index_report_pdfs_on_status"
   end
 

--- a/spec/controllers/report_details_controller_spec.rb
+++ b/spec/controllers/report_details_controller_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe ReportDetailsController, type: :controller do
   let(:user) { create(:user) }
-  let(:report) { instance_double(Report, id: 1) }
-  let(:decorated_report) { double('ReportDecorator', __getobj__: report) }
+  let(:report) { instance_double(Report, id: 1, to_param: "1") }
+  let(:decorated_report) do
+    double('ReportDecorator', __getobj__: report, id: 1, to_param: "1")
+  end
 
   before do
     sign_in user
@@ -23,133 +25,386 @@ RSpec.describe ReportDetailsController, type: :controller do
   end
 
   describe '#pdf' do
-    let(:pdf_filename) { 'report.pdf' }
-
     before do
-      allow(decorated_report).to receive(:id).and_return(1)
       allow(decorated_report).to receive(:target_name).and_return('test_target')
       allow(decorated_report).to receive(:created_at).and_return(Time.zone.parse('2026-01-01'))
     end
 
-    context 'when PDF is ready' do
-      let(:report_pdf) { instance_double(ReportPdf, ready?: true, file_path: '/tmp/test.pdf') }
+    context 'without a pdf_token (status-or-enqueue)' do
+      context 'when the PDF is downloadable' do
+        let(:report_pdf) do
+          instance_double(ReportPdf,
+            id: 77,
+            downloadable?: true,
+            status_processing?: false,
+            status_pending?: false)
+        end
 
-      before do
-        allow(decorated_report).to receive(:report_pdf).and_return(report_pdf)
-        allow(controller).to receive(:send_file) { controller.head :ok }
+        before do
+          allow(decorated_report).to receive(:report_pdf).and_return(report_pdf)
+          allow(Reports::PdfDownloadToken).to receive(:generate).with(report_pdf).and_return('signed-token')
+        end
+
+        it 'returns 200 with ready status and a signed download_url containing pdf_token' do
+          get :pdf, params: { id: 1 }
+
+          expect(response).to have_http_status(:ok)
+          json = JSON.parse(response.body)
+          expect(json['status']).to eq('ready')
+          expect(json['download_url']).to include('pdf_token=signed-token')
+          expect(json['download_url']).to match(%r{/report_details/1/pdf})
+        end
       end
 
-      it 'sends the PDF file' do
-        get :pdf, params: { id: 1 }
+      context 'when the PDF is processing' do
+        let(:report_pdf) do
+          instance_double(ReportPdf,
+            downloadable?: false,
+            status_processing?: true,
+            status_pending?: false,
+            status: 'processing')
+        end
 
-        expect(controller).to have_received(:send_file).with(
-          '/tmp/test.pdf',
-          filename: 'test_target_2026-01-01.pdf',
-          type: 'application/pdf',
-          disposition: 'attachment'
-        )
+        before do
+          allow(decorated_report).to receive(:report_pdf).and_return(report_pdf)
+        end
+
+        it 'returns 202 with processing status' do
+          get :pdf, params: { id: 1 }
+
+          expect(response).to have_http_status(:accepted)
+          json = JSON.parse(response.body)
+          expect(json['status']).to eq('processing')
+        end
+      end
+
+      context 'when the PDF is pending' do
+        let(:report_pdf) do
+          instance_double(ReportPdf,
+            downloadable?: false,
+            status_processing?: false,
+            status_pending?: true,
+            status: 'pending')
+        end
+
+        before do
+          allow(decorated_report).to receive(:report_pdf).and_return(report_pdf)
+        end
+
+        it 'returns 202 with pending status' do
+          get :pdf, params: { id: 1 }
+
+          expect(response).to have_http_status(:accepted)
+          json = JSON.parse(response.body)
+          expect(json['status']).to eq('pending')
+        end
+      end
+
+      context 'when no PDF record exists yet' do
+        let(:new_report_pdf) { instance_double(ReportPdf, save!: true) }
+
+        before do
+          allow(decorated_report).to receive(:report_pdf).and_return(nil)
+          allow(decorated_report).to receive(:create_report_pdf!).with(status: :pending).and_return(new_report_pdf)
+          allow(GeneratePdfJob).to receive(:perform_later)
+        end
+
+        it 'creates a pending record, enqueues GeneratePdfJob with report_id and user_id, and returns 202' do
+          get :pdf, params: { id: 1 }
+
+          expect(decorated_report).to have_received(:create_report_pdf!).with(status: :pending)
+          expect(GeneratePdfJob).to have_received(:perform_later).with(1, user.id)
+          expect(response).to have_http_status(:accepted)
+          json = JSON.parse(response.body)
+          expect(json['status']).to eq('pending')
+        end
+      end
+
+      context 'when an existing record is stale (not downloadable, not processing/pending/failed)' do
+        let(:stale_report_pdf) do
+          instance_double(ReportPdf,
+            id: 99,
+            downloadable?: false,
+            status_processing?: false,
+            status_pending?: false,
+            status_failed?: false,
+            destroy!: true)
+        end
+        let(:new_report_pdf) { instance_double(ReportPdf, save!: true) }
+
+        before do
+          allow(decorated_report).to receive(:report_pdf).and_return(stale_report_pdf)
+          allow(decorated_report).to receive(:create_report_pdf!).with(status: :pending).and_return(new_report_pdf)
+          allow(GeneratePdfJob).to receive(:perform_later)
+        end
+
+        it 'destroys the stale record, creates a new one, enqueues, and returns 202 pending' do
+          get :pdf, params: { id: 1 }
+
+          expect(stale_report_pdf).to have_received(:destroy!)
+          expect(decorated_report).to have_received(:create_report_pdf!).with(status: :pending)
+          expect(GeneratePdfJob).to have_received(:perform_later).with(1, user.id)
+          expect(response).to have_http_status(:accepted)
+        end
+      end
+
+      context 'when the PDF is in a failed terminal state' do
+        let(:failed_report_pdf) do
+          instance_double(ReportPdf,
+            id: 55,
+            downloadable?: false,
+            status_processing?: false,
+            status_pending?: false,
+            status_failed?: true,
+            status: 'failed',
+            error_message: 'Timeout::Error: rendering took too long')
+        end
+
+        before do
+          allow(decorated_report).to receive(:report_pdf).and_return(failed_report_pdf)
+          allow(decorated_report).to receive(:create_report_pdf!)
+          allow(GeneratePdfJob).to receive(:perform_later)
+        end
+
+        it 'returns a 422 failed JSON with a retryable flag + retry_url and does not enqueue a new job' do
+          get :pdf, params: { id: 1 }
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          json = JSON.parse(response.body)
+          expect(json['status']).to eq('failed')
+          expect(json['message']).to include('Timeout::Error')
+          expect(json['retryable']).to eq(true)
+          expect(json['retry_url']).to match(%r{/report_details/1/pdf_retry})
+
+          expect(failed_report_pdf).not_to have_received(:destroy!) if failed_report_pdf.respond_to?(:destroy!)
+          expect(decorated_report).not_to have_received(:create_report_pdf!)
+          expect(GeneratePdfJob).not_to have_received(:perform_later)
+        end
+
+        context 'when error_message is blank' do
+          let(:failed_report_pdf) do
+            instance_double(ReportPdf,
+              id: 56,
+              downloadable?: false,
+              status_processing?: false,
+              status_pending?: false,
+              status_failed?: true,
+              status: 'failed',
+              error_message: nil)
+          end
+
+          it 'still returns 422 failed with a generic fallback message' do
+            get :pdf, params: { id: 1 }
+
+            expect(response).to have_http_status(:unprocessable_entity)
+            json = JSON.parse(response.body)
+            expect(json['status']).to eq('failed')
+            expect(json['message']).to be_present
+          end
+        end
+      end
+
+      context 'when another request wins the create race with a unique-index violation' do
+        let(:existing_processing_pdf) do
+          instance_double(ReportPdf,
+            id: 88,
+            downloadable?: false,
+            status_processing?: true,
+            status_pending?: false,
+            status_failed?: false,
+            status: 'processing')
+        end
+
+        before do
+          call_count = 0
+          allow(decorated_report).to receive(:report_pdf) do
+            call_count += 1
+            call_count == 1 ? nil : existing_processing_pdf
+          end
+          allow(decorated_report).to receive(:reload).and_return(decorated_report)
+          allow(decorated_report).to receive(:create_report_pdf!).with(status: :pending)
+            .and_raise(ActiveRecord::RecordNotUnique.new('duplicate key value'))
+          allow(GeneratePdfJob).to receive(:perform_later)
+        end
+
+        it 'fetches the existing row and returns 202 without enqueuing a duplicate job' do
+          get :pdf, params: { id: 1 }
+
+          expect(response).to have_http_status(:accepted)
+          json = JSON.parse(response.body)
+          expect(json['status']).to eq('processing')
+          expect(GeneratePdfJob).not_to have_received(:perform_later)
+        end
       end
     end
 
-    context 'when PDF is being generated' do
+    context 'with a pdf_token (serve_downloadable_pdf)' do
+      let(:sandbox_path) { Rails.root.join('storage', 'pdfs', 'report_1.pdf').to_s }
       let(:report_pdf) do
         instance_double(ReportPdf,
-          ready?: false,
-          status_processing?: true,
-          status_pending?: false,
-          status: 'processing')
+          id: 42,
+          ready?: true,
+          file_path: sandbox_path,
+          downloadable?: true)
       end
 
       before do
         allow(decorated_report).to receive(:report_pdf).and_return(report_pdf)
       end
 
-      it 'returns 202 with processing status' do
-        get :pdf, params: { id: 1 }
+      context 'when the user is not signed in' do
+        before do
+          sign_out user
+          allow(controller).to receive(:send_file)
+        end
 
-        expect(response).to have_http_status(:accepted)
-        json = JSON.parse(response.body)
-        expect(json['status']).to eq('processing')
-      end
-    end
+        it 'redirects to sign in and does not serve the file' do
+          get :pdf, params: { id: 1, pdf_token: 'good-token' }
 
-    context 'when PDF does not exist' do
-      let(:new_report_pdf) { instance_double(ReportPdf, save!: true) }
-
-      before do
-        allow(decorated_report).to receive(:report_pdf).and_return(nil)
-        allow(decorated_report).to receive(:build_report_pdf).with(status: :pending).and_return(new_report_pdf)
-        allow(GeneratePdfJob).to receive(:perform_later)
+          expect(response).to redirect_to(new_user_session_path)
+          expect(controller).not_to have_received(:send_file)
+        end
       end
 
-      it 'creates ReportPdf record, starts PDF generation and returns pending status' do
-        get :pdf, params: { id: 1 }
+      context 'when token is valid, file in sandbox, and claim succeeds' do
+        before do
+          allow(Reports::PdfDownloadToken).to receive(:verify).with('good-token', report_pdf).and_return(true)
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(File.expand_path(sandbox_path)).and_return(true)
+          allow(report_pdf).to receive(:claim_download!).and_return(true)
+          allow(DeletePdfJob).to receive_message_chain(:set, :perform_later)
+          allow(controller).to receive(:send_file) { controller.head :ok }
+        end
 
-        expect(decorated_report).to have_received(:build_report_pdf).with(status: :pending)
-        expect(new_report_pdf).to have_received(:save!)
-        expect(GeneratePdfJob).to have_received(:perform_later).with(1)
-        expect(response).to have_http_status(:accepted)
-        json = JSON.parse(response.body)
-        expect(json['status']).to eq('pending')
+        it 'sends the PDF and schedules DeletePdfJob' do
+          get :pdf, params: { id: 1, pdf_token: 'good-token' }
+
+          expect(controller).to have_received(:send_file).with(
+            File.expand_path(sandbox_path),
+            filename: 'test_target_2026-01-01.pdf',
+            type: 'application/pdf',
+            disposition: 'attachment'
+          )
+          expect(DeletePdfJob).to have_received(:set).with(wait: 2.minutes)
+        end
+      end
+
+      context 'when claim_download! returns false (within grace-window re-download)' do
+        before do
+          allow(Reports::PdfDownloadToken).to receive(:verify).with('good-token', report_pdf).and_return(true)
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(File.expand_path(sandbox_path)).and_return(true)
+          allow(report_pdf).to receive(:claim_download!).and_return(false)
+          allow(DeletePdfJob).to receive(:set)
+          allow(controller).to receive(:send_file) { controller.head :ok }
+        end
+
+        it 'still serves the file but does NOT enqueue DeletePdfJob' do
+          get :pdf, params: { id: 1, pdf_token: 'good-token' }
+
+          expect(controller).to have_received(:send_file)
+          expect(DeletePdfJob).not_to have_received(:set)
+        end
+      end
+
+      context 'when token is invalid' do
+        before do
+          allow(Reports::PdfDownloadToken).to receive(:verify).with('bad-token', report_pdf).and_return(false)
+          allow(controller).to receive(:send_file)
+        end
+
+        it 'returns 404 and does not send_file' do
+          get :pdf, params: { id: 1, pdf_token: 'bad-token' }
+
+          expect(response).to have_http_status(:not_found)
+          expect(controller).not_to have_received(:send_file)
+        end
+      end
+
+      context 'when report_pdf.downloadable? is false' do
+        before do
+          allow(report_pdf).to receive(:downloadable?).and_return(false)
+          allow(Reports::PdfDownloadToken).to receive(:verify).with('good-token', report_pdf).and_return(true)
+          allow(controller).to receive(:send_file)
+        end
+
+        it 'returns 404 and does not send_file' do
+          get :pdf, params: { id: 1, pdf_token: 'good-token' }
+
+          expect(response).to have_http_status(:not_found)
+          expect(controller).not_to have_received(:send_file)
+        end
+      end
+
+      context 'when file_path is outside the storage/pdfs sandbox' do
+        let(:report_pdf) do
+          instance_double(ReportPdf,
+            id: 42,
+            ready?: true,
+            file_path: '/etc/passwd',
+            downloadable?: true)
+        end
+
+        before do
+          allow(Reports::PdfDownloadToken).to receive(:verify).with('good-token', report_pdf).and_return(true)
+          allow(controller).to receive(:send_file)
+        end
+
+        it 'returns 404 and does not send_file' do
+          get :pdf, params: { id: 1, pdf_token: 'good-token' }
+
+          expect(response).to have_http_status(:not_found)
+          expect(controller).not_to have_received(:send_file)
+        end
+      end
+
+      context 'when report_pdf is nil' do
+        before do
+          allow(decorated_report).to receive(:report_pdf).and_return(nil)
+          allow(controller).to receive(:send_file)
+        end
+
+        it 'returns 404' do
+          get :pdf, params: { id: 1, pdf_token: 'good-token' }
+
+          expect(response).to have_http_status(:not_found)
+          expect(controller).not_to have_received(:send_file)
+        end
       end
     end
   end
 
-  describe '#pdf_status' do
-    context 'when PDF is ready' do
-      let(:report_pdf) do
+  describe '#pdf_retry' do
+    context 'when another request wins the create race with a unique-index violation' do
+      let(:existing_processing_pdf) do
         instance_double(ReportPdf,
-          ready?: true,
-          status_failed?: false)
+          id: 123,
+          downloadable?: false,
+          status_processing?: true,
+          status_pending?: false,
+          status_failed?: false,
+          status: 'processing')
       end
 
       before do
-        allow(decorated_report).to receive(:report_pdf).and_return(report_pdf)
+        call_count = 0
+        allow(decorated_report).to receive(:report_pdf) do
+          call_count += 1
+          call_count == 1 ? nil : existing_processing_pdf
+        end
+        allow(decorated_report).to receive(:reload).and_return(decorated_report)
+        allow(decorated_report).to receive(:create_report_pdf!).with(status: :pending)
+          .and_raise(ActiveRecord::RecordNotUnique.new('duplicate key value'))
+        allow(GeneratePdfJob).to receive(:perform_later)
       end
 
-      it 'returns completed status with download URL' do
-        get :pdf_status, params: { id: 1 }
+      it 'fetches the existing row and returns 202 without enqueuing a duplicate job' do
+        post :pdf_retry, params: { id: 1 }
 
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(:accepted)
         json = JSON.parse(response.body)
-        expect(json['status']).to eq('completed')
-        expect(json['download_url']).to be_present
-      end
-    end
-
-    context 'when PDF generation failed' do
-      let(:report_pdf) do
-        instance_double(ReportPdf,
-          ready?: false,
-          status_failed?: true,
-          error_message: 'Generation failed')
-      end
-
-      before do
-        allow(decorated_report).to receive(:report_pdf).and_return(report_pdf)
-      end
-
-      it 'returns failed status with error' do
-        get :pdf_status, params: { id: 1 }
-
-        expect(response).to have_http_status(:success)
-        json = JSON.parse(response.body)
-        expect(json['status']).to eq('failed')
-        expect(json['error']).to eq('Generation failed')
-      end
-    end
-
-    context 'when PDF does not exist' do
-      before do
-        allow(decorated_report).to receive(:report_pdf).and_return(nil)
-      end
-
-      it 'returns not_found status' do
-        get :pdf_status, params: { id: 1 }
-
-        expect(response).to have_http_status(:success)
-        json = JSON.parse(response.body)
-        expect(json['status']).to eq('not_found')
+        expect(json['status']).to eq('processing')
+        expect(GeneratePdfJob).not_to have_received(:perform_later)
       end
     end
   end

--- a/spec/factories/report_pdfs.rb
+++ b/spec/factories/report_pdfs.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :report_pdf do
+    report
+    status { :pending }
+
+    trait :completed do
+      status { :completed }
+      file_path { Rails.root.join("storage", "pdfs", "report_#{report&.id || 0}.pdf").to_s }
+    end
+
+    trait :downloaded do
+      completed
+      downloaded_at { Time.current }
+    end
+  end
+end

--- a/spec/jobs/cleanup_old_pdfs_job_spec.rb
+++ b/spec/jobs/cleanup_old_pdfs_job_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe CleanupOldPdfsJob, type: :job do
+  let(:company) { create(:company) }
+  let(:report) { ActsAsTenant.with_tenant(company) { create(:report) } }
+  let(:sandbox_dir) { Rails.root.join("storage", "pdfs") }
+
+  before { FileUtils.mkdir_p(sandbox_dir) }
+
+  describe "#perform" do
+    it "deletes files and records older than the grace window" do
+      path = sandbox_dir.join("stale_#{SecureRandom.hex(4)}.pdf").to_s
+      File.write(path, "pdf")
+      pdf = ActsAsTenant.with_tenant(company) do
+        create(:report_pdf, :completed, report: report, file_path: path)
+      end
+      pdf.update_column(:created_at, 25.hours.ago)
+
+      described_class.new.perform
+
+      expect(File.exist?(path)).to be(false)
+      expect(ReportPdf.exists?(pdf.id)).to be(false)
+    end
+
+    it "refuses to delete files outside the storage/pdfs sandbox" do
+      evil_path = Rails.root.join("tmp", "cleanup_escape_#{SecureRandom.hex(4)}.pdf").to_s
+      File.write(evil_path, "outside")
+      pdf = ActsAsTenant.with_tenant(company) do
+        create(:report_pdf, :completed, report: report, file_path: evil_path)
+      end
+      pdf.update_column(:created_at, 25.hours.ago)
+
+      described_class.new.perform
+
+      expect(File.exist?(evil_path)).to be(true)
+      expect(ReportPdf.exists?(pdf.id)).to be(false)
+    ensure
+      File.delete(evil_path) if evil_path && File.exist?(evil_path)
+    end
+  end
+end

--- a/spec/jobs/delete_pdf_job_spec.rb
+++ b/spec/jobs/delete_pdf_job_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe DeletePdfJob, type: :job do
+  let(:company) { create(:company) }
+  let(:report) { ActsAsTenant.with_tenant(company) { create(:report) } }
+  let(:sandbox_dir) { Rails.root.join("storage", "pdfs") }
+
+  before { FileUtils.mkdir_p(sandbox_dir) }
+
+  describe "#perform" do
+    it "deletes the file on disk and destroys the record" do
+      path = sandbox_dir.join("report_delete_#{SecureRandom.hex(4)}.pdf").to_s
+      File.write(path, "pdf")
+      pdf = ActsAsTenant.with_tenant(company) do
+        create(:report_pdf, :completed, report: report, file_path: path)
+      end
+
+      described_class.new.perform(pdf.id)
+
+      expect(File.exist?(path)).to be(false)
+      expect(ReportPdf.exists?(pdf.id)).to be(false)
+    end
+
+    it "is idempotent when the file is already gone" do
+      path = sandbox_dir.join("missing_#{SecureRandom.hex(4)}.pdf").to_s
+      pdf = ActsAsTenant.with_tenant(company) do
+        create(:report_pdf, :completed, report: report, file_path: path)
+      end
+
+      expect {
+        described_class.new.perform(pdf.id)
+      }.not_to raise_error
+
+      expect(ReportPdf.exists?(pdf.id)).to be(false)
+    end
+
+    it "discards when the ReportPdf has already been removed" do
+      expect {
+        described_class.perform_now(-1)
+      }.not_to raise_error
+    end
+
+    it "refuses to delete files outside the storage/pdfs sandbox" do
+      evil_path = Rails.root.join("tmp", "escape_#{SecureRandom.hex(4)}.pdf").to_s
+      File.write(evil_path, "outside")
+      pdf = ActsAsTenant.with_tenant(company) do
+        create(:report_pdf, :completed, report: report, file_path: evil_path)
+      end
+
+      described_class.new.perform(pdf.id)
+
+      expect(File.exist?(evil_path)).to be(true)
+      expect(ReportPdf.exists?(pdf.id)).to be(false)
+    ensure
+      File.delete(evil_path) if evil_path && File.exist?(evil_path)
+    end
+  end
+
+  describe "queue configuration" do
+    it "uses the low_priority queue" do
+      expect(described_class.new.queue_name).to eq("low_priority")
+    end
+  end
+end

--- a/spec/jobs/generate_pdf_job_spec.rb
+++ b/spec/jobs/generate_pdf_job_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GeneratePdfJob, type: :job do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, company: company) }
+  let(:report) { ActsAsTenant.with_tenant(company) { create(:report) } }
+  let!(:report_pdf) do
+    ActsAsTenant.with_tenant(company) { create(:report_pdf, report: report) }
+  end
+  let(:storage_dir) { Rails.root.join("tmp", "spec_pdf_job_#{SecureRandom.hex(4)}") }
+
+  before do
+    allow(Rails.root).to receive(:join).and_call_original
+    allow(Rails.root).to receive(:join).with("storage", "pdfs").and_return(storage_dir)
+    allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
+    allow(MonitoringService).to receive(:active?).and_return(false)
+  end
+
+  after { FileUtils.rm_rf(storage_dir) }
+
+  describe "MAX_ATTEMPTS" do
+    it "is 3" do
+      expect(described_class::MAX_ATTEMPTS).to eq(3)
+    end
+  end
+
+  describe "#perform" do
+    context "when the report has no pdf record" do
+      before { report_pdf.destroy! }
+
+      it "returns early without invoking the generator" do
+        expect(Reports::PdfGenerator).not_to receive(:new)
+
+        expect {
+          described_class.new.perform(report.id, user.id)
+        }.not_to raise_error
+      end
+
+      it "does not broadcast anything" do
+        described_class.new.perform(report.id, user.id)
+
+        expect(Turbo::StreamsChannel).not_to have_received(:broadcast_replace_to)
+      end
+    end
+
+    context "when the report itself no longer exists" do
+      it "discards without raising" do
+        expect {
+          described_class.perform_now(-1, user.id)
+        }.not_to raise_error
+      end
+    end
+
+    context "on success" do
+      before do
+        allow_any_instance_of(Reports::PdfGenerator).to receive(:generate).and_return("PDF-BYTES")
+      end
+
+      it "marks the report_pdf completed and writes the bytes to disk" do
+        described_class.new.perform(report.id, user.id)
+
+        reloaded = report_pdf.reload
+        expect(reloaded.status_completed?).to be(true)
+        expect(reloaded.file_path).to eq(storage_dir.join("report_#{report.id}.pdf").to_s)
+        expect(File.read(reloaded.file_path)).to eq("PDF-BYTES")
+      end
+
+      it "broadcasts ready on the user+report scoped stream" do
+        described_class.new.perform(report.id, user.id)
+
+        expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to).with(
+          "pdf_notifications:user_#{user.id}:report_#{report.id}",
+          hash_including(target: "pdf-status-#{report.id}")
+        )
+      end
+
+      it "includes a signed download_url that PdfDownloadToken can verify" do
+        captured = nil
+        allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to) do |_stream, **opts|
+          captured = opts
+        end
+
+        described_class.new.perform(report.id, user.id)
+
+        expect(captured).to be_present
+        html = captured[:html]
+        expect(html).to include("data-pdf-status='ready'")
+
+        download_url = html[/data-download-url='([^']+)'/, 1]
+        expect(download_url).to be_present
+
+        token = Rack::Utils.parse_nested_query(URI(download_url).query)["pdf_token"]
+        expect(token).to be_present
+        expect(Reports::PdfDownloadToken.verify(token, report_pdf.reload)).to be(true)
+      end
+    end
+
+    context "on a mid-retry failure" do
+      before do
+        allow_any_instance_of(Reports::PdfGenerator).to receive(:generate)
+          .and_raise(StandardError, "boom")
+      end
+
+      it "leaves the record in :processing (retry_on re-enqueues instead of marking failed)" do
+        job = described_class.new(report.id, user.id)
+
+        job.perform_now
+
+        expect(report_pdf.reload.status_processing?).to be(true)
+      end
+
+      it "does not emit a failed broadcast" do
+        job = described_class.new(report.id, user.id)
+
+        job.perform_now
+
+        expect(Turbo::StreamsChannel).not_to have_received(:broadcast_replace_to).with(
+          anything,
+          hash_including(html: a_string_matching(/data-pdf-status='failed'/))
+        )
+      end
+
+      it "re-enqueues the job for another attempt" do
+        expect {
+          described_class.new(report.id, user.id).perform_now
+        }.to have_enqueued_job(described_class)
+      end
+    end
+
+    context "on the final failure" do
+      before do
+        allow_any_instance_of(Reports::PdfGenerator).to receive(:generate)
+          .and_raise(StandardError, "kaboom")
+      end
+
+      # With `retry_on ... do |job, error|`, Rails invokes the block on
+      # the final attempt instead of re-raising. We express final-attempt
+      # behavior by calling the block handler directly rather than trying
+      # to simulate Rails' internal retry counters.
+      it "marks the record :failed and broadcasts failed on the user+report stream" do
+        job = described_class.new(report.id, user.id)
+        error = StandardError.new("kaboom")
+
+        job.send(:on_attempts_exceeded, error)
+
+        expect(report_pdf.reload.status_failed?).to be(true)
+        expect(report_pdf.reload.error_message).to eq("StandardError: kaboom")
+        expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to).with(
+          "pdf_notifications:user_#{user.id}:report_#{report.id}",
+          hash_including(html: a_string_matching(/data-pdf-status='failed'/))
+        )
+      end
+
+      it "includes retryable flag and pdf_retry URL so the frontend can auto-retry" do
+        captured = nil
+        allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to) do |_stream, **opts|
+          captured = opts
+        end
+
+        job = described_class.new(report.id, user.id)
+        job.send(:on_attempts_exceeded, StandardError.new("kaboom"))
+
+        expect(captured).to be_present
+        html = captured[:html]
+        expect(html).to include("data-pdf-retryable='true'")
+        retry_url = html[/data-retry-url='([^']+)'/, 1]
+        expect(retry_url).to be_present
+        expect(retry_url).to match(%r{/report_details/#{report.id}/pdf_retry\z})
+      end
+    end
+  end
+
+  describe "queue configuration" do
+    it "uses the default queue" do
+      expect(described_class.new.queue_name).to eq("default")
+    end
+  end
+end

--- a/spec/migrations/add_unique_index_to_report_pdfs_report_id_spec.rb
+++ b/spec/migrations/add_unique_index_to_report_pdfs_report_id_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe AddUniqueIndexToReportPdfsReportId do
       migration.up
 
       remaining = ReportPdf.where(report_id: report.id)
-      expect(remaining.pluck(:id)).to eq([good_id])
+      expect(remaining.pluck(:id)).to eq([ good_id ])
 
       expect(conn.index_exists?(:report_pdfs, :report_id,
                                 name: "index_report_pdfs_on_report_id", unique: true)).to be true
@@ -86,7 +86,7 @@ RSpec.describe AddUniqueIndexToReportPdfsReportId do
 
       migration.send(:cleanup_duplicate_report_pdfs)
 
-      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([completed_id])
+      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([ completed_id ])
     end
 
     it "prefers a row with a file_path over rows without one when none is completed" do
@@ -97,7 +97,7 @@ RSpec.describe AddUniqueIndexToReportPdfsReportId do
 
       migration.send(:cleanup_duplicate_report_pdfs)
 
-      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([with_file_id])
+      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([ with_file_id ])
     end
 
     it "prefers a completed row without file_path over other non-file rows" do
@@ -109,7 +109,7 @@ RSpec.describe AddUniqueIndexToReportPdfsReportId do
 
       migration.send(:cleanup_duplicate_report_pdfs)
 
-      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([completed_id])
+      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([ completed_id ])
     end
 
     it "falls back to the newest id when no row has file_path or completed status" do
@@ -121,7 +121,7 @@ RSpec.describe AddUniqueIndexToReportPdfsReportId do
 
       migration.send(:cleanup_duplicate_report_pdfs)
 
-      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([newest_id])
+      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([ newest_id ])
     end
 
     it "treats an empty-string file_path as no file" do
@@ -132,7 +132,7 @@ RSpec.describe AddUniqueIndexToReportPdfsReportId do
 
       migration.send(:cleanup_duplicate_report_pdfs)
 
-      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([completed_no_file_id])
+      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([ completed_no_file_id ])
     end
 
     it "does not remove non-duplicate report_pdfs" do

--- a/spec/migrations/add_unique_index_to_report_pdfs_report_id_spec.rb
+++ b/spec/migrations/add_unique_index_to_report_pdfs_report_id_spec.rb
@@ -1,0 +1,165 @@
+require "rails_helper"
+require Rails.root.join("db/migrate/20260418193602_add_unique_index_to_report_pdfs_report_id")
+
+RSpec.describe AddUniqueIndexToReportPdfsReportId do
+  let(:migration) { described_class.new }
+  let(:conn) { ActiveRecord::Base.connection }
+
+  def insert_report_pdf(report_id:, status:, file_path: nil)
+    now = Time.current.utc.iso8601
+    path_sql = file_path.nil? ? "NULL" : "'#{conn.quote_string(file_path)}'"
+    conn.execute(<<~SQL)
+      INSERT INTO report_pdfs (report_id, status, file_path, created_at, updated_at)
+      VALUES (#{report_id}, #{status}, #{path_sql}, '#{now}', '#{now}')
+    SQL
+    conn.execute(
+      "SELECT id FROM report_pdfs WHERE report_id = #{report_id} ORDER BY id DESC LIMIT 1"
+    ).first["id"]
+  end
+
+  describe "migration safety" do
+    it "runs inside the default DDL transaction so cleanup+uniqueness are atomic" do
+      expect(described_class.disable_ddl_transaction).to be_falsey
+    end
+  end
+
+  describe "#up idempotency" do
+    it "is a no-op when the unique index already exists" do
+      expect(conn.index_exists?(:report_pdfs, :report_id,
+                                name: "index_report_pdfs_on_report_id", unique: true)).to be true
+
+      expect { migration.up }.not_to raise_error
+    end
+  end
+
+  context "real upgrade path from a non-unique index with duplicate data" do
+    around do |example|
+      conn.remove_index :report_pdfs, name: "index_report_pdfs_on_report_id", if_exists: true
+      conn.add_index :report_pdfs, :report_id, name: "index_report_pdfs_on_report_id"
+      example.run
+    ensure
+      conn.remove_index :report_pdfs, name: "index_report_pdfs_on_report_id", if_exists: true
+      conn.add_index :report_pdfs, :report_id, unique: true, name: "index_report_pdfs_on_report_id"
+    end
+
+    it "collapses duplicates to the best row and installs the unique index in one pass" do
+      report = create(:report)
+
+      good_id = insert_report_pdf(report_id: report.id, status: 2, file_path: "/tmp/good.pdf")
+      insert_report_pdf(report_id: report.id, status: 0) # later pending retry
+      insert_report_pdf(report_id: report.id, status: 3) # even-later failed row
+
+      expect(ReportPdf.where(report_id: report.id).count).to eq(3)
+
+      migration.up
+
+      remaining = ReportPdf.where(report_id: report.id)
+      expect(remaining.pluck(:id)).to eq([good_id])
+
+      expect(conn.index_exists?(:report_pdfs, :report_id,
+                                name: "index_report_pdfs_on_report_id", unique: true)).to be true
+
+      expect {
+        ActiveRecord::Base.transaction(requires_new: true) do
+          insert_report_pdf(report_id: report.id, status: 0)
+        end
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+
+  describe "#cleanup_duplicate_report_pdfs survivor policy" do
+    around do |example|
+      conn.remove_index :report_pdfs, name: "index_report_pdfs_on_report_id", if_exists: true
+      conn.add_index :report_pdfs, :report_id, name: "index_report_pdfs_on_report_id"
+      example.run
+    ensure
+      conn.remove_index :report_pdfs, name: "index_report_pdfs_on_report_id", if_exists: true
+      conn.add_index :report_pdfs, :report_id, unique: true, name: "index_report_pdfs_on_report_id"
+    end
+
+    it "keeps the completed+file_path row even when a later pending/failed row exists" do
+      report = create(:report)
+
+      completed_id = insert_report_pdf(report_id: report.id, status: 2, file_path: "/tmp/report.pdf")
+      insert_report_pdf(report_id: report.id, status: 0)
+      insert_report_pdf(report_id: report.id, status: 3)
+
+      migration.send(:cleanup_duplicate_report_pdfs)
+
+      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([completed_id])
+    end
+
+    it "prefers a row with a file_path over rows without one when none is completed" do
+      report = create(:report)
+
+      with_file_id = insert_report_pdf(report_id: report.id, status: 1, file_path: "/tmp/processing.pdf")
+      insert_report_pdf(report_id: report.id, status: 0)
+
+      migration.send(:cleanup_duplicate_report_pdfs)
+
+      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([with_file_id])
+    end
+
+    it "prefers a completed row without file_path over other non-file rows" do
+      report = create(:report)
+
+      completed_id = insert_report_pdf(report_id: report.id, status: 2)
+      insert_report_pdf(report_id: report.id, status: 0)
+      insert_report_pdf(report_id: report.id, status: 3)
+
+      migration.send(:cleanup_duplicate_report_pdfs)
+
+      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([completed_id])
+    end
+
+    it "falls back to the newest id when no row has file_path or completed status" do
+      report = create(:report)
+
+      insert_report_pdf(report_id: report.id, status: 0)
+      insert_report_pdf(report_id: report.id, status: 3)
+      newest_id = insert_report_pdf(report_id: report.id, status: 0)
+
+      migration.send(:cleanup_duplicate_report_pdfs)
+
+      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([newest_id])
+    end
+
+    it "treats an empty-string file_path as no file" do
+      report = create(:report)
+
+      completed_no_file_id = insert_report_pdf(report_id: report.id, status: 2, file_path: "")
+      insert_report_pdf(report_id: report.id, status: 0)
+
+      migration.send(:cleanup_duplicate_report_pdfs)
+
+      expect(ReportPdf.where(report_id: report.id).pluck(:id)).to eq([completed_no_file_id])
+    end
+
+    it "does not remove non-duplicate report_pdfs" do
+      report_a = create(:report)
+      report_b = create(:report)
+
+      insert_report_pdf(report_id: report_a.id, status: 0)
+      insert_report_pdf(report_id: report_b.id, status: 0)
+
+      migration.send(:cleanup_duplicate_report_pdfs)
+
+      expect(ReportPdf.where(report_id: report_a.id).count).to eq(1)
+      expect(ReportPdf.where(report_id: report_b.id).count).to eq(1)
+    end
+  end
+
+  describe "resulting schema" do
+    it "enforces uniqueness on report_pdfs.report_id" do
+      report = create(:report)
+
+      insert_report_pdf(report_id: report.id, status: 0)
+
+      expect {
+        ActiveRecord::Base.transaction(requires_new: true) do
+          insert_report_pdf(report_id: report.id, status: 0)
+        end
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+end

--- a/spec/models/report_pdf_spec.rb
+++ b/spec/models/report_pdf_spec.rb
@@ -1,0 +1,156 @@
+require "rails_helper"
+
+RSpec.describe ReportPdf, type: :model do
+  let(:company) { create(:company) }
+  let(:report) { ActsAsTenant.with_tenant(company) { create(:report) } }
+  let(:sandbox_path) { Rails.root.join("storage", "pdfs", "report.pdf").to_s }
+
+  describe "#ready?" do
+    it "is false when file_path resolves outside the storage/pdfs sandbox" do
+      outside = "/etc/passwd"
+      pdf = build_stubbed(:report_pdf, :completed, file_path: outside)
+      allow(File).to receive(:exist?).with(outside).and_return(true)
+
+      expect(pdf.ready?).to be(false)
+    end
+
+    it "is false when the sandbox path does not actually exist on disk" do
+      pdf = build_stubbed(:report_pdf, :completed, file_path: sandbox_path)
+      allow(File).to receive(:exist?).with(File.expand_path(sandbox_path)).and_return(false)
+
+      expect(pdf.ready?).to be(false)
+    end
+
+    it "is true when status is completed and the sandbox path exists" do
+      pdf = build_stubbed(:report_pdf, :completed, file_path: sandbox_path)
+      allow(File).to receive(:exist?).with(File.expand_path(sandbox_path)).and_return(true)
+
+      expect(pdf.ready?).to be(true)
+    end
+  end
+
+  describe "#downloadable?" do
+    it "is false when the record is not ready" do
+      pdf = build_stubbed(:report_pdf, status: :pending, file_path: nil)
+      expect(pdf.downloadable?).to be(false)
+    end
+
+    it "is false when the file lives outside the sandbox, even if it exists on disk" do
+      outside = "/tmp/pdfs/report.pdf"
+      pdf = build_stubbed(:report_pdf, :completed, file_path: outside)
+      allow(File).to receive(:exist?).with(outside).and_return(true)
+
+      expect(pdf.downloadable?).to be(false)
+    end
+
+    it "is true when ready and never downloaded" do
+      pdf = build_stubbed(:report_pdf, :completed, file_path: sandbox_path)
+      allow(File).to receive(:exist?).with(File.expand_path(sandbox_path)).and_return(true)
+
+      expect(pdf.downloadable?).to be(true)
+    end
+
+    it "is true when downloaded_at is inside the 2-minute grace window" do
+      pdf = build_stubbed(
+        :report_pdf,
+        :completed,
+        file_path: sandbox_path,
+        downloaded_at: 30.seconds.ago
+      )
+      allow(File).to receive(:exist?).with(File.expand_path(sandbox_path)).and_return(true)
+
+      expect(pdf.downloadable?).to be(true)
+    end
+
+    it "is false when downloaded_at is past the grace window" do
+      pdf = build_stubbed(
+        :report_pdf,
+        :completed,
+        file_path: sandbox_path,
+        downloaded_at: 3.minutes.ago
+      )
+      allow(File).to receive(:exist?).with(File.expand_path(sandbox_path)).and_return(true)
+
+      expect(pdf.downloadable?).to be(false)
+    end
+
+    it "is false at the exact DOWNLOAD_GRACE_WINDOW boundary" do
+      freeze_time do
+        pdf = build_stubbed(
+          :report_pdf,
+          :completed,
+          file_path: sandbox_path,
+          downloaded_at: ReportPdf::DOWNLOAD_GRACE_WINDOW.ago
+        )
+        allow(File).to receive(:exist?).with(File.expand_path(sandbox_path)).and_return(true)
+
+        expect(pdf.downloadable?).to be(false)
+      end
+    end
+  end
+
+  describe "#safe_file_path" do
+    it "returns the expanded sandbox path when the file exists inside storage/pdfs" do
+      pdf = build_stubbed(:report_pdf, :completed, file_path: sandbox_path)
+      allow(File).to receive(:exist?).with(File.expand_path(sandbox_path)).and_return(true)
+
+      expect(pdf.safe_file_path).to eq(File.expand_path(sandbox_path))
+    end
+
+    it "returns nil for a path outside the sandbox" do
+      outside = "/etc/passwd"
+      pdf = build_stubbed(:report_pdf, :completed, file_path: outside)
+      allow(File).to receive(:exist?).with(outside).and_return(true)
+
+      expect(pdf.safe_file_path).to be_nil
+    end
+  end
+
+  describe "#claim_download!" do
+    let(:pdf) do
+      ActsAsTenant.with_tenant(company) do
+        create(:report_pdf, :completed, report: report, file_path: sandbox_path)
+      end
+    end
+
+    it "returns true on the first claim and false on subsequent claims" do
+      expect(pdf.claim_download!).to be(true)
+      expect(pdf.reload.downloaded_at).to be_present
+      expect(pdf.claim_download!).to be(false)
+    end
+
+    it "still returns false once the grace window has elapsed" do
+      pdf.update!(downloaded_at: 5.minutes.ago)
+
+      expect(pdf.claim_download!).to be(false)
+    end
+  end
+
+  describe "DOWNLOAD_GRACE_WINDOW" do
+    it "is 2 minutes" do
+      expect(ReportPdf::DOWNLOAD_GRACE_WINDOW).to eq(2.minutes)
+    end
+  end
+
+  describe "single report_pdf per report invariant" do
+    it "rejects a second ReportPdf for the same report at the model layer" do
+      ActsAsTenant.with_tenant(company) do
+        create(:report_pdf, report: report)
+        duplicate = build(:report_pdf, report: report)
+
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:report_id]).to be_present
+      end
+    end
+
+    it "rejects a second ReportPdf for the same report at the database layer" do
+      ActsAsTenant.with_tenant(company) do
+        create(:report_pdf, report: report)
+
+        expect {
+          ReportPdf.new(report_id: report.id, status: :pending).save(validate: false)
+        }.to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
+  end
+end

--- a/spec/requests/report_details_spec.rb
+++ b/spec/requests/report_details_spec.rb
@@ -40,10 +40,10 @@ RSpec.describe "ReportDetails", type: :request do
       let!(:detector_result) { create(:detector_result, report: report, passed: 3, total: 10) }
 
       let(:pdf_token) do
-        Rails.application.message_verifier("pdf").generate(
+        Rails.application.message_verifier(Reports::PdfGenerator::RENDER_TOKEN_VERIFIER_KEY).generate(
           report.id,
-          expires_in: 5.minutes,
-          purpose: :pdf_render
+          expires_in: Reports::PdfGenerator::RENDER_TOKEN_TTL,
+          purpose: Reports::PdfGenerator::RENDER_TOKEN_PURPOSE
         )
       end
 
@@ -64,10 +64,10 @@ RSpec.describe "ReportDetails", type: :request do
 
     context "with pdf=true and an expired pdf_token" do
       let(:expired_token) do
-        Rails.application.message_verifier("pdf").generate(
+        Rails.application.message_verifier(Reports::PdfGenerator::RENDER_TOKEN_VERIFIER_KEY).generate(
           report.id,
           expires_at: 1.minute.ago,
-          purpose: :pdf_render
+          purpose: Reports::PdfGenerator::RENDER_TOKEN_PURPOSE
         )
       end
 
@@ -85,10 +85,10 @@ RSpec.describe "ReportDetails", type: :request do
     end
 
     let(:pdf_token) do
-      Rails.application.message_verifier("pdf").generate(
+      Rails.application.message_verifier(Reports::PdfGenerator::RENDER_TOKEN_VERIFIER_KEY).generate(
         report.id,
-        expires_in: 5.minutes,
-        purpose: :pdf_render
+        expires_in: Reports::PdfGenerator::RENDER_TOKEN_TTL,
+        purpose: Reports::PdfGenerator::RENDER_TOKEN_PURPOSE
       )
     end
 
@@ -108,6 +108,377 @@ RSpec.describe "ReportDetails", type: :request do
       get report_detail_path(report, pdf: "true", pdf_token: pdf_token)
 
       expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /report_details/:id/pdf_retry" do
+    let(:user) { create(:user, company: company) }
+
+    context "when the existing report_pdf is failed" do
+      before do
+        sign_in user
+        ActsAsTenant.with_tenant(company) do
+          create(:report_pdf,
+                 report: report,
+                 status: :failed,
+                 error_message: "Timeout::Error")
+        end
+      end
+
+      it "replaces the failed record with a fresh pending one and enqueues a new job" do
+        expect {
+          post pdf_retry_report_detail_path(report)
+        }.to change {
+          ActiveJob::Base.queue_adapter.enqueued_jobs.count { |j| j[:job] == GeneratePdfJob }
+        }.by(1)
+
+        expect(response).to have_http_status(:accepted)
+        json = JSON.parse(response.body)
+        expect(json["status"]).to eq("pending")
+
+        expect(report.reload.report_pdf.status).to eq("pending")
+      end
+    end
+
+    context "when no report_pdf exists yet" do
+      before { sign_in user }
+
+      it "creates a pending record and enqueues generation" do
+        expect {
+          post pdf_retry_report_detail_path(report)
+        }.to change {
+          ActiveJob::Base.queue_adapter.enqueued_jobs.count { |j| j[:job] == GeneratePdfJob }
+        }.by(1)
+
+        expect(response).to have_http_status(:accepted)
+        expect(report.reload.report_pdf.status).to eq("pending")
+      end
+    end
+
+    context "when the record is already processing" do
+      before do
+        sign_in user
+        ActsAsTenant.with_tenant(company) do
+          create(:report_pdf, report: report, status: :processing)
+        end
+      end
+
+      it "does not enqueue a duplicate job and returns the in-flight status" do
+        expect {
+          post pdf_retry_report_detail_path(report)
+        }.not_to change {
+          ActiveJob::Base.queue_adapter.enqueued_jobs.count { |j| j[:job] == GeneratePdfJob }
+        }
+
+        expect(response).to have_http_status(:accepted)
+        json = JSON.parse(response.body)
+        expect(json["status"]).to eq("processing")
+      end
+    end
+
+    context "when the record is completed and ready" do
+      before do
+        sign_in user
+        ActsAsTenant.with_tenant(company) do
+          create(:report_pdf, :completed, report: report)
+        end
+        pdf = report.report_pdf
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(pdf.file_path).and_return(true)
+      end
+
+      it "returns 200 with ready status and a signed download URL" do
+        post pdf_retry_report_detail_path(report)
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["status"]).to eq("ready")
+        expect(json["download_url"]).to include("pdf_token=")
+      end
+    end
+
+    context "cross-tenant isolation" do
+      let(:company_a) { create(:company) }
+      let(:company_b) { create(:company) }
+      let(:user_a) { create(:user, company: company_a) }
+      let(:report_b) { create(:report, :completed, company: company_b) }
+
+      it "prevents a Company-A user from retrying Company-B PDF generation" do
+        sign_in user_a
+
+        expect {
+          post pdf_retry_report_detail_path(report_b)
+        }.not_to change { ReportPdf.count }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "without authentication" do
+      it "rejects the request" do
+        post pdf_retry_report_detail_path(report)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "GET /report_details/:id/pdf" do
+    let(:user) { create(:user, company: company) }
+
+    context "cross-tenant isolation" do
+      let(:company_a) { create(:company) }
+      let(:company_b) { create(:company) }
+      let(:user_a) { create(:user, company: company_a) }
+      let(:report_b) { create(:report, :completed, company: company_b) }
+
+      it "prevents a Company-A user from checking Company-B PDF status" do
+        sign_in user_a
+
+        expect {
+          get pdf_report_detail_path(report_b)
+        }.not_to change { ReportPdf.count }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "without any pdf_token" do
+      context "when no ReportPdf exists yet" do
+        before { sign_in user }
+
+        it "creates a pending record, enqueues GeneratePdfJob(report.id, user.id), and returns 202" do
+          expect {
+            get pdf_report_detail_path(report)
+          }.to change { report.reload.report_pdf }.from(nil)
+
+          expect(response).to have_http_status(:accepted)
+          json = JSON.parse(response.body)
+          expect(json["status"]).to eq("pending")
+
+          enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs.find do |j|
+            j[:job] == GeneratePdfJob
+          end
+          expect(enqueued).to be_present
+          expect(enqueued[:args]).to eq([ report.id, user.id ])
+        end
+      end
+
+      context "when a ready record exists" do
+        before do
+          sign_in user
+          ActsAsTenant.with_tenant(company) do
+            create(:report_pdf, :completed, report: report)
+          end
+          pdf = report.report_pdf
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(pdf.file_path).and_return(true)
+        end
+
+        it "returns 200 with status=ready and signed download URL carrying pdf_token" do
+          get pdf_report_detail_path(report)
+
+          expect(response).to have_http_status(:ok)
+          json = JSON.parse(response.body)
+          expect(json["status"]).to eq("ready")
+          expect(json["download_url"]).to include("pdf_token=")
+          expect(json["download_url"]).to match(%r{/report_details/#{report.id}/pdf})
+        end
+      end
+
+      context "when the existing record is in the :failed terminal state" do
+        before do
+          sign_in user
+          ActsAsTenant.with_tenant(company) do
+            create(:report_pdf,
+                   report: report,
+                   status: :failed,
+                   error_message: "Playwright::Error: boom")
+          end
+        end
+
+        it "returns a 422 failed JSON flagged retryable and does not enqueue a new job" do
+          expect {
+            get pdf_report_detail_path(report)
+          }.not_to change {
+            ActiveJob::Base.queue_adapter.enqueued_jobs.count { |j| j[:job] == GeneratePdfJob }
+          }
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          json = JSON.parse(response.body)
+          expect(json["status"]).to eq("failed")
+          expect(json["message"]).to include("Playwright::Error")
+          expect(json["retryable"]).to eq(true)
+          expect(json["retry_url"]).to match(%r{/report_details/#{report.id}/pdf_retry})
+          expect(report.reload.report_pdf.status).to eq("failed")
+        end
+      end
+
+      context "when an existing completed record's file_path is outside the sandbox" do
+        before do
+          sign_in user
+          ActsAsTenant.with_tenant(company) do
+            create(:report_pdf,
+                   :completed,
+                   report: report,
+                   file_path: "/etc/passwd")
+          end
+          # Even if the attacker-controlled path happens to exist, the status
+          # endpoint must not flag the record as ready/downloadable.
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with("/etc/passwd").and_return(true)
+        end
+
+        it "does not return status=ready and instead replaces the record with a fresh pending one" do
+          get pdf_report_detail_path(report)
+
+          expect(response).to have_http_status(:accepted)
+          json = JSON.parse(response.body)
+          expect(json["status"]).to eq("pending")
+          expect(json).not_to have_key("download_url")
+
+          expect(report.reload.report_pdf.status).to eq("pending")
+          expect(report.report_pdf.file_path).to be_nil
+        end
+      end
+
+      context "when a stale (past-grace) completed record exists" do
+        before do
+          sign_in user
+          ActsAsTenant.with_tenant(company) do
+            create(:report_pdf, :completed, report: report, downloaded_at: 5.minutes.ago)
+          end
+          pdf = report.report_pdf
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(pdf.file_path).and_return(true)
+        end
+
+        it "destroys the stale record and enqueues a fresh generation" do
+          get pdf_report_detail_path(report)
+
+          expect(response).to have_http_status(:accepted)
+          json = JSON.parse(response.body)
+          expect(json["status"]).to eq("pending")
+
+          enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs.select do |j|
+            j[:job] == GeneratePdfJob
+          end
+          expect(enqueued.size).to eq(1)
+          expect(enqueued.first[:args]).to eq([ report.id, user.id ])
+
+          # A brand-new pending record replaces the stale one
+          expect(report.reload.report_pdf.status).to eq("pending")
+        end
+      end
+    end
+
+    context "with a pdf_token" do
+      let!(:report_pdf) do
+        ActsAsTenant.with_tenant(company) do
+          create(:report_pdf, :completed, report: report)
+        end
+      end
+
+      before do
+        # Seed a real file inside storage/pdfs so the sandbox check passes.
+        FileUtils.mkdir_p(File.dirname(report_pdf.file_path))
+        File.binwrite(report_pdf.file_path, "pdf-bytes")
+        sign_in user
+      end
+
+      after do
+        File.delete(report_pdf.file_path) if File.exist?(report_pdf.file_path)
+      end
+
+      context "when the request is anonymous" do
+        before do
+          sign_out user
+        end
+
+        it "redirects to sign in instead of serving the file" do
+          token = Reports::PdfDownloadToken.generate(report_pdf)
+
+          get pdf_report_detail_path(report, pdf_token: token)
+
+          expect(response).to redirect_to(new_user_session_path)
+          expect(response.headers["Content-Type"]).not_to include("application/pdf")
+        end
+      end
+
+      it "serves the file for a valid token and enqueues DeletePdfJob exactly once" do
+        token = Reports::PdfDownloadToken.generate(report_pdf)
+
+        get pdf_report_detail_path(report, pdf_token: token)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers["Content-Type"]).to include("application/pdf")
+
+        delete_jobs = ActiveJob::Base.queue_adapter.enqueued_jobs.select do |j|
+          j[:job] == DeletePdfJob
+        end
+        expect(delete_jobs.size).to eq(1)
+        expect(delete_jobs.first[:args]).to eq([ report_pdf.id ])
+      end
+
+      it "serves the file on a second (within-grace) download without scheduling a second DeletePdfJob" do
+        token = Reports::PdfDownloadToken.generate(report_pdf)
+
+        get pdf_report_detail_path(report, pdf_token: token)
+        get pdf_report_detail_path(report, pdf_token: token)
+
+        expect(response).to have_http_status(:ok)
+
+        delete_jobs = ActiveJob::Base.queue_adapter.enqueued_jobs.select do |j|
+          j[:job] == DeletePdfJob
+        end
+        expect(delete_jobs.size).to eq(1)
+      end
+
+      it "returns 404 for a tampered token" do
+        token = Reports::PdfDownloadToken.generate(report_pdf)
+
+        get pdf_report_detail_path(report, pdf_token: "#{token}tamper")
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns 404 when a token generated for a different report_pdf is used" do
+        other_report = create(:report, :completed, company: company)
+        other_report_pdf = ActsAsTenant.with_tenant(company) do
+          create(:report_pdf, :completed, report: other_report)
+        end
+
+        FileUtils.mkdir_p(File.dirname(other_report_pdf.file_path))
+        File.binwrite(other_report_pdf.file_path, "other-pdf-bytes")
+
+        token = Reports::PdfDownloadToken.generate(other_report_pdf)
+
+        get pdf_report_detail_path(report, pdf_token: token)
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.headers["Content-Type"]).not_to include("application/pdf")
+      ensure
+        File.delete(other_report_pdf.file_path) if other_report_pdf && File.exist?(other_report_pdf.file_path)
+      end
+
+      it "returns 404 for an expired token" do
+        token = Reports::PdfDownloadToken.generate(report_pdf)
+
+        travel_to((Reports::PdfDownloadToken::TTL + 1.minute).from_now) do
+          get pdf_report_detail_path(report, pdf_token: token)
+        end
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns 404 when the token is valid but the file is missing from disk" do
+        token = Reports::PdfDownloadToken.generate(report_pdf)
+        File.delete(report_pdf.file_path)
+
+        get pdf_report_detail_path(report, pdf_token: token)
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.headers["Content-Type"]).not_to include("application/pdf")
+      end
     end
   end
 end

--- a/spec/services/reports/pdf_download_token_spec.rb
+++ b/spec/services/reports/pdf_download_token_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Reports::PdfDownloadToken do
+  let(:report_pdf) { instance_double(ReportPdf, id: 42) }
+  let(:other_report_pdf) { instance_double(ReportPdf, id: 99) }
+
+  describe ".generate / .verify" do
+    it "round-trips a token bound to the report_pdf id" do
+      token = described_class.generate(report_pdf)
+
+      expect(described_class.verify(token, report_pdf)).to be(true)
+    end
+
+    it "rejects a tampered token" do
+      token = described_class.generate(report_pdf)
+      tampered = "#{token}tamper"
+
+      expect(described_class.verify(tampered, report_pdf)).to be(false)
+    end
+
+    it "rejects an expired token" do
+      token = described_class.generate(report_pdf)
+
+      travel_to((described_class::TTL + 1.minute).from_now) do
+        expect(described_class.verify(token, report_pdf)).to be(false)
+      end
+    end
+
+    it "rejects a token generated for a different report_pdf id" do
+      token = described_class.generate(other_report_pdf)
+
+      expect(described_class.verify(token, report_pdf)).to be(false)
+    end
+
+    it "returns false for blank or nil tokens" do
+      expect(described_class.verify(nil, report_pdf)).to be(false)
+      expect(described_class.verify("", report_pdf)).to be(false)
+      expect(described_class.verify("  ", report_pdf)).to be(false)
+    end
+  end
+end

--- a/spec/services/reports/pdf_generator_spec.rb
+++ b/spec/services/reports/pdf_generator_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe Reports::PdfGenerator do
     allow(url_helpers).to receive(:report_detail_url).and_return(url)
   end
 
+  describe 'render token constants' do
+    it 'exposes a :report_pdf verifier key' do
+      expect(described_class::RENDER_TOKEN_VERIFIER_KEY).to eq(:report_pdf)
+    end
+
+    it 'exposes the :pdf_render purpose' do
+      expect(described_class::RENDER_TOKEN_PURPOSE).to eq(:pdf_render)
+    end
+
+    it 'exposes a short-lived TTL' do
+      expect(described_class::RENDER_TOKEN_TTL).to eq(5.minutes)
+    end
+  end
+
   describe '#initialize' do
     it 'sets the report attribute' do
       expect(generator.report).to eq(report)
@@ -71,6 +85,23 @@ RSpec.describe Reports::PdfGenerator do
 
       expect(File).to have_received(:delete).with(temp_pdf_path)
       expect(Rails.logger).to have_received(:info).with("Cleaned up temporary PDF file for report 123")
+    end
+
+    it 'signs the render token with the :report_pdf verifier and :pdf_render purpose' do
+      captured_token = nil
+      url_helpers = Rails.application.routes.url_helpers
+      allow(url_helpers).to receive(:report_detail_url) do |_report, **opts|
+        captured_token = opts.dig(:params, :pdf_token)
+        url
+      end
+
+      generator.generate
+
+      expect(captured_token).to be_present
+      verifier = Rails.application.message_verifier(described_class::RENDER_TOKEN_VERIFIER_KEY)
+      expect(
+        verifier.verify(captured_token, purpose: described_class::RENDER_TOKEN_PURPOSE)
+      ).to eq(report.id)
     end
 
     context 'when PDF generation fails' do

--- a/spec/services/reports/pdf_storage_spec.rb
+++ b/spec/services/reports/pdf_storage_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+require "tmpdir"
+require "fileutils"
+
+RSpec.describe Reports::PdfStorage do
+  describe ".safe_path" do
+    let(:sandbox) { File.realpath(Rails.root.join("storage", "pdfs").to_s) }
+
+    it "returns the resolved absolute path for paths inside the sandbox" do
+      inside = File.join(sandbox, "report_1.pdf")
+
+      expect(described_class.safe_path(inside)).to eq(inside)
+    end
+
+    it "accepts relative paths that resolve inside the sandbox" do
+      relative = Rails.root.join("storage", "pdfs", "report_7.pdf").to_s
+
+      expect(described_class.safe_path(relative)).to eq(File.join(sandbox, "report_7.pdf"))
+    end
+
+    it "rejects paths that sit outside the sandbox" do
+      expect(described_class.safe_path("/etc/passwd")).to be_nil
+    end
+
+    it "rejects directory traversal attempts" do
+      traversal = File.join(sandbox, "..", "..", "etc", "passwd")
+
+      expect(described_class.safe_path(traversal)).to be_nil
+    end
+
+    it "rejects paths whose prefix matches the sandbox but escapes it" do
+      sibling = "#{sandbox}_evil/report.pdf"
+
+      expect(described_class.safe_path(sibling)).to be_nil
+    end
+
+    it "rejects blank or nil paths" do
+      expect(described_class.safe_path(nil)).to be_nil
+      expect(described_class.safe_path("")).to be_nil
+      expect(described_class.safe_path("   ")).to be_nil
+    end
+
+    it "returns nil when the input contains a null byte" do
+      expect(described_class.safe_path("#{sandbox}/report.pdf\u0000/evil")).to be_nil
+    end
+
+    it "logs a warning when rejecting a path outside the sandbox" do
+      expect(Rails.logger).to receive(:warn).with(/Rejected PDF path outside sandbox/)
+
+      described_class.safe_path("/etc/passwd")
+    end
+
+    context "with symlink escape attempts" do
+      before do
+        @tmp_dir = Dir.mktmpdir
+        @tmp_root = Pathname.new(File.realpath(@tmp_dir))
+        FileUtils.mkdir_p(@tmp_root.join("storage", "pdfs"))
+        allow(Rails).to receive(:root).and_return(@tmp_root)
+      end
+
+      after do
+        FileUtils.remove_entry(@tmp_dir) if @tmp_dir && File.exist?(@tmp_dir)
+      end
+
+      let(:tmp_sandbox) { File.realpath(@tmp_root.join("storage", "pdfs").to_s) }
+
+      it "rejects a symlink inside the sandbox that points to a file outside" do
+        outside_target = File.join(@tmp_root, "secret.txt")
+        File.write(outside_target, "secret")
+        link = File.join(tmp_sandbox, "sneak.pdf")
+        File.symlink(outside_target, link)
+
+        expect(Rails.logger).to receive(:warn).with(/Rejected PDF path outside sandbox/)
+        expect(described_class.safe_path(link)).to be_nil
+      end
+
+      it "rejects paths whose parent directory is a symlink pointing outside the sandbox" do
+        outside_dir = File.join(@tmp_root, "evil")
+        FileUtils.mkdir_p(outside_dir)
+        parent_link = File.join(tmp_sandbox, "evil_link")
+        File.symlink(outside_dir, parent_link)
+
+        expect(described_class.safe_path(File.join(parent_link, "report.pdf"))).to be_nil
+      end
+
+      it "rejects broken symlinks that could later become escape vectors" do
+        link = File.join(tmp_sandbox, "broken.pdf")
+        File.symlink("/definitely/does/not/exist", link)
+
+        expect(described_class.safe_path(link)).to be_nil
+      end
+
+      it "allows in-sandbox symlinks pointing to files inside the sandbox" do
+        real = File.join(tmp_sandbox, "real.pdf")
+        File.write(real, "pdf")
+        link = File.join(tmp_sandbox, "link.pdf")
+        File.symlink(real, link)
+
+        expect(described_class.safe_path(link)).to eq(real)
+      end
+
+      it "accepts non-existent files whose parent is the real sandbox" do
+        future_file = File.join(tmp_sandbox, "future.pdf")
+
+        expect(described_class.safe_path(future_file)).to eq(future_file)
+      end
+    end
+  end
+end

--- a/spec/services/reports/pdf_storage_spec.rb
+++ b/spec/services/reports/pdf_storage_spec.rb
@@ -104,6 +104,13 @@ RSpec.describe Reports::PdfStorage do
 
         expect(described_class.safe_path(future_file)).to eq(future_file)
       end
+
+      it "accepts in-sandbox paths even when storage/pdfs does not exist yet" do
+        FileUtils.rm_rf(@tmp_root.join("storage"))
+        future_file = @tmp_root.join("storage", "pdfs", "future.pdf").to_s
+
+        expect(described_class.safe_path(future_file)).to eq(future_file)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- harden the PDF download lifecycle with signed per-download tokens
- scope PDF status updates to the requesting user/report instead of company-wide streams
- add a retry flow for failed PDF generation without manual cleanup
- centralize PDF storage path validation and use it for serving and deletion
- make the `report_pdfs.report_id` unique-index migration safe for drifted databases

## Details
- add `Reports::PdfDownloadToken` for signed download URLs
- add `Reports::PdfStorage` to validate sandboxed PDF paths, including symlink escape protection
- update `ReportDetailsController` and Stimulus PDF handling to support ready / processing / failed / retryable states
- harden `DeletePdfJob` and `CleanupOldPdfsJob` to avoid deleting files outside `storage/pdfs`
- ensure `ReportPdf#ready?` / `#downloadable?` only return true for valid sandboxed files
- add retry support via `POST /report_details/:id/pdf_retry`
- harden the unique-index migration by deduplicating `report_pdfs` rows before enforcing uniqueness
- expand request / model / job / service coverage around the PDF flow and migration behavior
