### PR TITLE
fix(docker): use /var/lib/postgresql mount for pg18+ compatibility

### DIFF
--- a/dist/docker-compose.yml
+++ b/dist/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_DB: postgres
       POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=C.UTF-8 --data-checksums"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-scanner} -d postgres"]
       interval: 5s

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_DB: postgres
       POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=C.UTF-8 --data-checksums"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     ports:
       - "127.0.0.1:5432:5432"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_DB: postgres
       POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=C.UTF-8 --data-checksums"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-scanner} -d postgres"]
       interval: 5s


### PR DESCRIPTION
Fixes #20.

Mount the named postgres volume at `/var/lib/postgresql` instead of `/var/lib/postgresql/data` in `dist/`, root, and dev compose files so the pg18+ image can manage its version-qualified data layout.

Verified locally against `dist/docker-compose.yml` (the file `install.sh` serves): postgres healthy, scanner returns HTTP 200 on `/up`, data stored at `/var/lib/postgresql/18/docker/`.