### PR TITLE
fix(reports): show live running report counts

### DIFF
--- a/app/jobs/broadcast_running_stats_job.rb
+++ b/app/jobs/broadcast_running_stats_job.rb
@@ -18,8 +18,7 @@ class BroadcastRunningStatsJob < ApplicationJob
   private
 
   def broadcast_company_stats(company_id)
-    stats = calculate_company_stats(company_id)
-    Rails.cache.write(cache_key_for(company_id), stats, expires_in: 1.hour)
+    stats = Reports::RunningStats.write_company(company_id)
 
     Turbo::StreamsChannel.broadcast_replace_to(
       stream_name_for(company_id),
@@ -30,8 +29,7 @@ class BroadcastRunningStatsJob < ApplicationJob
   end
 
   def broadcast_global_stats
-    stats = calculate_global_stats
-    Rails.cache.write(cache_key_for(:global), stats, expires_in: 1.hour)
+    stats = Reports::RunningStats.write_global
 
     Turbo::StreamsChannel.broadcast_replace_to(
       stream_name_for(:global),
@@ -42,22 +40,15 @@ class BroadcastRunningStatsJob < ApplicationJob
   end
 
   def calculate_company_stats(company_id)
-    scans = Report.where(company_id: company_id).active.where(parent_report_id: nil).count
-    variants = Report.where(company_id: company_id).active.where.not(parent_report_id: nil).count
-    { scans: scans, variants: variants, total: scans + variants }
+    Reports::RunningStats.company(company_id)
   end
 
   def calculate_global_stats
-    ActsAsTenant.without_tenant do
-      scans = Report.active.where(parent_report_id: nil).count
-      variants = Report.active.where.not(parent_report_id: nil).count
-      priority = Report.active.where(parent_report_id: nil).joins(:scan).where(scans: { priority: true }).count
-      { scans: scans, variants: variants, priority: priority, total: scans + variants }
-    end
+    Reports::RunningStats.global
   end
 
   def cache_key_for(identifier)
-    "running_scans_stats:#{identifier}"
+    Reports::RunningStats.cache_key_for(identifier)
   end
 
   def stream_name_for(identifier)

--- a/app/services/reports/running_stats.rb
+++ b/app/services/reports/running_stats.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Reports
+  class RunningStats
+    CACHE_TTL = 1.hour
+
+    class << self
+      def company(company_id)
+        base_scope = Report.where(company_id: company_id).active
+        stats_for(base_scope)
+      end
+
+      def global
+        ActsAsTenant.without_tenant do
+          base_scope = Report.active
+          stats_for(base_scope).merge(
+            priority: base_scope.where(parent_report_id: nil).joins(:scan).where(scans: { priority: true }).count
+          )
+        end
+      end
+
+      def write_company(company_id)
+        stats = company(company_id)
+        Rails.cache.write(cache_key_for(company_id), stats, expires_in: CACHE_TTL)
+        stats
+      end
+
+      def write_global
+        stats = global
+        Rails.cache.write(cache_key_for(:global), stats, expires_in: CACHE_TTL)
+        stats
+      end
+
+      def cache_key_for(identifier)
+        "running_scans_stats:#{identifier}"
+      end
+
+      private
+
+      def stats_for(base_scope)
+        scans = base_scope.where(parent_report_id: nil).count
+        variants = base_scope.where.not(parent_report_id: nil).count
+        { scans: scans, variants: variants, total: scans + variants }
+      end
+    end
+  end
+end

--- a/app/views/application/_system_status.html.erb
+++ b/app/views/application/_system_status.html.erb
@@ -2,14 +2,14 @@
   # Main system status wrapper - contains company stats and optionally global stats
   cid = local_assigns[:company_id]
 
-  # Read company-scoped stats
-  company_stats = cid ? Rails.cache.read("running_scans_stats:#{cid}") : nil
-  company_stats ||= { scans: 0, variants: 0, total: 0 }
+  # Calculate from the DB so the sidebar stays correct after cache eviction,
+  # deploys, or missed broadcasts.
+  company_stats = cid ? Reports::RunningStats.company(cid) : { scans: 0, variants: 0, total: 0 }
 %>
 <div id="system-status" class="mt-auto border-t border-borderPrimary pt-4" role="status" aria-live="polite">
   <%= render 'application/system_status_company', stats: company_stats %>
 
   <% if local_assigns[:is_super_admin] %>
-    <%= render 'application/system_status_global', stats: Rails.cache.read("running_scans_stats:global") || { scans: 0, variants: 0, priority: 0, total: 0 } %>
+    <%= render 'application/system_status_global', stats: Reports::RunningStats.global %>
   <% end %>
 </div>

--- a/spec/services/reports/running_stats_spec.rb
+++ b/spec/services/reports/running_stats_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Reports::RunningStats, type: :service do
+  let(:company) { create(:company) }
+  let(:other_company) { create(:company) }
+  let(:target) { create(:target, company: company) }
+  let(:scan) { create(:complete_scan, company: company) }
+  let(:other_target) { create(:target, company: other_company) }
+  let(:other_scan) { create(:complete_scan, company: other_company) }
+
+  before do
+    allow_any_instance_of(RunGarakScan).to receive(:call)
+    allow_any_instance_of(ToastNotifier).to receive(:call)
+    allow(BroadcastRunningStatsJob).to receive(:perform_later)
+  end
+
+  describe '.company' do
+    it 'counts active parent and variant reports for the requested company' do
+      create(:report, target: target, scan: scan, status: :running, company: company)
+      create(:report, target: target, scan: scan, status: :starting, company: company)
+      parent_report = create(:report, target: target, scan: scan, status: :running, company: company)
+      create(:report, target: target, scan: scan, status: :running, parent_report: parent_report, company: company)
+      create(:report, target: target, scan: scan, status: :completed, company: company)
+      create(:report, target: other_target, scan: other_scan, status: :running, company: other_company)
+
+      stats = described_class.company(company.id)
+
+      expect(stats).to eq(scans: 3, variants: 1, total: 4)
+    end
+
+    it 'works when the requested company is the current tenant' do
+      create(:report, target: target, scan: scan, status: :running, company: company)
+      create(:report, target: other_target, scan: other_scan, status: :running, company: other_company)
+
+      ActsAsTenant.with_tenant(company) do
+        expect(described_class.company(company.id)).to eq(scans: 1, variants: 0, total: 1)
+      end
+    end
+  end
+
+  describe '.global' do
+    it 'counts active reports across tenants and includes priority parent reports' do
+      priority_scan = create(:complete_scan, company: company, priority: true)
+      priority_report = create(:report, target: target, scan: priority_scan, status: :running, company: company)
+      create(:report, target: target, scan: scan, status: :running, parent_report: priority_report, company: company)
+      create(:report, target: other_target, scan: other_scan, status: :starting, company: other_company)
+      create(:report, target: target, scan: scan, status: :completed, company: company)
+
+      stats = described_class.global
+
+      expect(stats).to eq(scans: 2, variants: 1, total: 3, priority: 1)
+    end
+
+    it 'ignores the current tenant when calculating global stats' do
+      create(:report, target: target, scan: scan, status: :running, company: company)
+      create(:report, target: other_target, scan: other_scan, status: :running, company: other_company)
+
+      ActsAsTenant.with_tenant(company) do
+        expect(described_class.global).to eq(scans: 2, variants: 0, total: 2, priority: 0)
+      end
+    end
+  end
+
+  describe '.write_company' do
+    it 'writes the current company stats to the cache' do
+      create(:report, target: target, scan: scan, status: :running, company: company)
+      allow(Rails.cache).to receive(:write)
+
+      stats = described_class.write_company(company.id)
+
+      expect(stats).to eq(scans: 1, variants: 0, total: 1)
+      expect(Rails.cache).to have_received(:write).with(
+        "running_scans_stats:#{company.id}",
+        stats,
+        expires_in: described_class::CACHE_TTL
+      )
+    end
+  end
+
+  describe '.write_global' do
+    it 'writes the current global stats to the cache' do
+      create(:report, target: target, scan: scan, status: :running, company: company)
+      allow(Rails.cache).to receive(:write)
+
+      stats = described_class.write_global
+
+      expect(stats).to eq(scans: 1, variants: 0, total: 1, priority: 0)
+      expect(Rails.cache).to have_received(:write).with(
+        'running_scans_stats:global',
+        stats,
+        expires_in: described_class::CACHE_TTL
+      )
+    end
+  end
+end

--- a/spec/views/application/system_status_spec.rb
+++ b/spec/views/application/system_status_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'application/_system_status', type: :view do
+  let(:company) { create(:company) }
+  let(:target) { create(:target, company: company) }
+  let(:scan) { create(:complete_scan, company: company) }
+
+  before do
+    allow_any_instance_of(RunGarakScan).to receive(:call)
+    allow_any_instance_of(ToastNotifier).to receive(:call)
+    allow(SettingsService).to receive(:parallel_scans_limit).and_return(20)
+    Rails.cache.delete("running_scans_stats:#{company.id}")
+    Rails.cache.delete('running_scans_stats:global')
+  end
+
+  it 'shows live running report counts when the stats cache is empty' do
+    create(:report, target: target, scan: scan, status: :running, company: company)
+
+    render partial: 'application/system_status', locals: { company_id: company.id, is_super_admin: true }
+
+    expect(rendered).to include('Reports Running')
+    expect(rendered).to include('System Total')
+    expect(company_badge_text).to eq('1')
+    expect(global_badge_text).to eq('1/20')
+  end
+
+  it 'uses the database as the source of truth instead of cached stats on initial render' do
+    create(:report, target: target, scan: scan, status: :running, company: company)
+    allow(Rails.cache).to receive(:fetch).and_raise('system status initial render must not depend on cached stats')
+    allow(Rails.cache).to receive(:read).and_raise('system status initial render must not depend on cached stats')
+
+    render partial: 'application/system_status', locals: { company_id: company.id, is_super_admin: true }
+
+    expect(company_badge_text).to eq('1')
+    expect(global_badge_text).to eq('1/20')
+  end
+
+  def company_badge_text
+    Nokogiri::HTML.fragment(rendered).at_css('#system-status-company .inline-flex').text.squish
+  end
+
+  def global_badge_text
+    Nokogiri::HTML.fragment(rendered).at_css('#system-status-global .inline-flex').text.squish
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a `Reports::RunningStats` service to centralize running report count calculation.
- Updates the system status sidebar to calculate live counts from the database on initial render instead of relying on cached broadcast state.
- Keeps broadcast updates cache-backed, but delegates count/cache logic to the new service.
- Adds regression coverage for empty/stale cache behavior and tenant-safe running stats.
