### PR TITLE
feat: add report debug log streaming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,7 @@ POSTGRES_PASSWORD=change_me            # Required for production docker-compose.
 
 # Logging
 # RAILS_LOG_LEVEL=info                 # Log level: debug, info, warn, error (default: info)
+# DEBUG_LOG_TAIL_BYTES=131072          # Live report execution-log tail bytes (0 disables live tails)
 
 # Microsoft Clarity Analytics (Demo Only)
 # Clarity provides heatmaps and session recordings for UX analysis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Rails 8 + NVIDIA garak scanner for AI model safety assessments.
 ```bash
 # Dev: docker compose -f docker-compose.dev.yml up|exec scanner /bin/bash
 # Test: RAILS_ENV=test bundle exec rspec | brakeman | rubocop -A
+# Python/JS checks: python3 -m unittest discover -s script/tests | python3 -m py_compile script/db_notifier.py script/run_garak.py | npm run test:js
 # NOTE: Run all rails/bundle commands inside the dev container
 ```
 
@@ -24,6 +25,7 @@ Rails 8 + NVIDIA garak scanner for AI model safety assessments.
 
 ## Pitfalls
 - Always `RAILS_ENV=test` for rspec | Max 5 concurrent scans | `Shellwords.escape` for shell
+- Report execution logs live in `report_debug_logs.logs`; live tails live in `report_debug_logs.tail`; Rails callers should use `Report#logs`
 
 ## HTTP/HTTPS
 Localhost: HTTP allowed | Production: `ASSUME_SSL=true` (behind TLS-terminating proxy)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,9 @@ Run tests locally before opening a PR:
 ```bash
 # Inside the dev container:
 RAILS_ENV=test bundle exec rspec   # Always use RAILS_ENV=test
+python3 -m unittest discover -s script/tests
+python3 -m py_compile script/db_notifier.py script/run_garak.py
+npm run test:js
 rubocop -A                          # Linter with auto-fix
 brakeman                            # Security scanner
 ```
@@ -95,7 +98,7 @@ docs: update contributing guide
 
 - Add unit tests for model, service, and job changes
 - Stub garak execution in tests: `allow_any_instance_of(RunGarakScan).to receive(:call)`
-- Mock Unix socket communication
+- Mock `JournalSyncThread` and database notifier behavior for garak integration paths
 - Run rubocop and fix warnings before opening a PR
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ An open-source web application for AI model security assessments, built with Rub
 - **Multi-target scanning** — test API-based LLMs and browser-based chat UIs
 - **Scheduled and on-demand scans** with configurable recurrence
 - **Attack Success Rate (ASR)** scoring with trend tracking across scan runs
+- **Live Activity Stream** — monitor queued and running scans with database-backed execution-log tails and final report logs
 - **PDF report export** with per-probe, per-attempt drill-down
 - **SIEM integration** — forward results to Splunk or Rsyslog
 - **Multi-tenant** — multiple organizations on a single deployment, data encrypted at rest

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -4,6 +4,7 @@ module Admin
   class ReportsController < Admin::BaseController
     # probes_tab and attempt_content load @report with custom includes — excluded intentionally
     before_action :set_report, only: [ :show, :destroy, :stop, :asr_history, :top_probes ]
+    before_action :set_debug_lease_report, only: [ :refresh_debug_lease ]
 
     include TargetsHelper
 
@@ -51,6 +52,7 @@ module Admin
     def show
       authorize @report
       @page_title = "Report ##{@report.id}"
+      # Activity Stream leases are refreshed by the mounted lease controller.
     end
 
     def destroy
@@ -207,12 +209,22 @@ module Admin
       }
     end
 
+    def refresh_debug_lease
+      authorize @report, :show?
+      Reports::DebugWatcher.refresh_and_enqueue(@report)
+      head :ok
+    end
+
     private
 
     def set_report
       @report = Report.includes(:target, :scan,
                                 detector_results: :detector)
                       .find(params[:id])
+    end
+
+    def set_debug_lease_report
+      @report = Report.select(:id, :status, :company_id).find(params[:id])
     end
 
     def apply_sorting(scope)

--- a/app/controllers/report_details_controller.rb
+++ b/app/controllers/report_details_controller.rb
@@ -5,9 +5,16 @@ class ReportDetailsController < ApplicationController
   skip_before_action :set_tenant, only: [ :show ]
   before_action :authenticate_show, only: [ :show ]
   before_action :set_show_tenant, only: [ :show ]
-  before_action :set_report
+  before_action :set_report, except: [ :refresh_debug_lease ]
+  before_action :set_debug_lease_report, only: [ :refresh_debug_lease ]
 
   def show
+    # Activity Stream leases are refreshed by the mounted lease controller.
+  end
+
+  def refresh_debug_lease
+    Reports::DebugWatcher.refresh_and_enqueue(@report)
+    head :ok
   end
 
   def pdf
@@ -132,6 +139,10 @@ class ReportDetailsController < ApplicationController
   def set_report
     report = @_unscoped_report || Report.includes(*SHOW_INCLUDES).find(params[:id])
     @report = ReportDecorator.new(report)
+  end
+
+  def set_debug_lease_report
+    @report = Report.select(:id, :status, :company_id).find(params[:id])
   end
 
   def pdf_filename

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,4 +1,18 @@
 module ReportsHelper
+  def activity_stream_active_status_for_report?(report)
+    return false if report.blank?
+
+    (Report::DEBUG_BROADCAST_ACTIVE_STATUSES + %w[pending]).uniq.include?(report.status.to_s)
+  end
+
+  def show_activity_stream_for_report?(report, params:, user:, pdf_mode: false)
+    return false if pdf_mode
+    return false if user.blank?
+    return false if report.blank?
+
+    activity_stream_active_status_for_report?(report) || debug_param_enabled?(params)
+  end
+
   # Get CSS classes for success rate coloring
   def success_rate_classes(rate)
     case rate
@@ -75,5 +89,14 @@ module ReportsHelper
   def format_token_count(input_tokens, output_tokens)
     return nil if input_tokens.to_i == 0 && output_tokens.to_i == 0
     "#{number_with_delimiter(input_tokens)} in / #{number_with_delimiter(output_tokens)} out"
+  end
+
+  private
+
+  def debug_param_enabled?(params)
+    value = params[:debug] if params.respond_to?(:[])
+    value ||= params["debug"] if params.respond_to?(:[])
+
+    value.to_s == "true"
   end
 end

--- a/app/javascript/controllers/activity_stream_controller.js
+++ b/app/javascript/controllers/activity_stream_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "summary", "details", "button", "buttonLabel" ]
+
+  connect() {
+    this.expanded = false
+    this.sync()
+  }
+
+  toggle() {
+    this.expanded = !this.expanded
+    this.sync()
+
+    if (this.expanded) {
+      this.focusDetails()
+    }
+  }
+
+  sync() {
+    if (!this.hasDetailsTarget || !this.hasButtonTarget || !this.hasButtonLabelTarget) return
+
+    this.detailsTarget.classList.toggle("hidden", !this.expanded)
+    this.buttonTarget.setAttribute("aria-expanded", this.expanded.toString())
+    this.buttonLabelTarget.textContent = this.expanded ? "Hide activity" : "View activity"
+  }
+
+  focusDetails() {
+    if (!this.hasDetailsTarget) return
+
+    const focusTarget = this.detailsTarget.querySelector("[data-activity-stream-focus-target]")
+    if (!focusTarget) return
+
+    requestAnimationFrame(() => focusTarget.focus({ preventScroll: true }))
+  }
+}

--- a/app/javascript/controllers/debug_stream_filter_controller.js
+++ b/app/javascript/controllers/debug_stream_filter_controller.js
@@ -1,0 +1,73 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["query", "row", "group", "emptyState"]
+
+  connect() {
+    this.filter()
+  }
+
+  rowTargetConnected(row) {
+    this.applyRow(row)
+    this.updateEmptyStates()
+  }
+
+  filter() {
+    this.rowTargets.forEach((row) => {
+      this.applyRow(row)
+    })
+
+    this.updateEmptyStates()
+  }
+
+  clearQuery() {
+    if (!this.hasQueryTarget) return
+
+    this.queryTarget.value = ""
+    this.filter()
+  }
+
+  applyRow(row) {
+    const matchesQuery = this.query === "" || row.textContent.toLowerCase().includes(this.query)
+
+    row.dataset.debugStreamFilterMatch = matchesQuery ? "true" : "false"
+    this.applyVisibility(row)
+  }
+
+  // Visibility composition note:
+  // Rows are visible iff data-debug-stream-filter-match !== "false" AND
+  // data-log-viewer-filter-match !== "false". Both this controller and
+  // log_viewer_controller.js evaluate the same predicate. If a third
+  // visibility axis is ever added, both files must update in lockstep.
+  applyVisibility(row) {
+    row.style.display = this.rowVisible(row) ? "" : "none"
+  }
+
+  updateEmptyStates() {
+    this.groupTargets.forEach((group) => {
+      const emptyState = group.querySelector('[data-debug-stream-filter-target~="emptyState"]')
+
+      if (!emptyState) return
+
+      const rows = Array.from(group.querySelectorAll('[data-debug-stream-filter-target~="row"]'))
+      const hasVisibleRows = rows.some((row) => this.rowVisible(row))
+      const hasActiveFilter =
+        this.query !== "" || rows.some((row) => row.dataset.logViewerFilterMatch === "false")
+
+      emptyState.hidden = rows.length === 0 || hasVisibleRows || !hasActiveFilter
+    })
+  }
+
+  rowVisible(row) {
+    const matchesStreamFilter = row.dataset.debugStreamFilterMatch !== "false"
+    const matchesLogFilter = row.dataset.logViewerFilterMatch !== "false"
+
+    return matchesStreamFilter && matchesLogFilter
+  }
+
+  get query() {
+    if (!this.hasQueryTarget) return ""
+
+    return this.queryTarget.value.trim().toLowerCase()
+  }
+}

--- a/app/javascript/controllers/debug_stream_lease_controller.js
+++ b/app/javascript/controllers/debug_stream_lease_controller.js
@@ -1,0 +1,63 @@
+import { Controller } from "@hotwired/stimulus"
+
+const DEFAULT_INTERVAL_MS = 30000
+
+export default class extends Controller {
+  static values = {
+    url: String,
+    interval: Number
+  }
+
+  connect() {
+    if (!this.hasUrlValue) return
+
+    this.inFlight = false
+    this.refreshLease()
+    this.timer = window.setInterval(() => this.refreshLease(), this.intervalMs)
+  }
+
+  disconnect() {
+    if (this.timer) {
+      window.clearInterval(this.timer)
+      this.timer = null
+    }
+  }
+
+  get intervalMs() {
+    if (this.hasIntervalValue && this.intervalValue > 0) {
+      return this.intervalValue
+    }
+
+    return DEFAULT_INTERVAL_MS
+  }
+
+  async refreshLease() {
+    if (this.inFlight) return
+
+    this.inFlight = true
+
+    try {
+      const response = await fetch(this.urlValue, {
+        method: "POST",
+        headers: {
+          "Accept": "text/plain",
+          "X-CSRF-Token": this.csrfToken(),
+          "X-Requested-With": "XMLHttpRequest"
+        },
+        credentials: "same-origin"
+      })
+
+      if (!response.ok) {
+        console.warn(`Debug stream lease refresh failed with status ${response.status}`)
+      }
+    } catch (error) {
+      console.warn("Debug stream lease refresh failed", error)
+    } finally {
+      this.inFlight = false
+    }
+  }
+
+  csrfToken() {
+    return document.querySelector("meta[name='csrf-token']")?.content || ""
+  }
+}

--- a/app/javascript/controllers/debug_tabs_controller.js
+++ b/app/javascript/controllers/debug_tabs_controller.js
@@ -1,0 +1,58 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["tab", "panel"]
+  static values = { storageKey: String }
+
+  panelTargetConnected() {
+    this.applyTab(this.resolveTab(this.storedTab()))
+  }
+
+  switch(event) {
+    const selectedTab = event.currentTarget.dataset.tab
+    this.storeTab(selectedTab)
+    this.applyTab(selectedTab)
+  }
+
+  applyTab(selectedTab) {
+    this.tabTargets.forEach((tab) => {
+      if (tab.dataset.tab === selectedTab) {
+        tab.classList.add("bg-zinc-800", "text-white")
+        tab.classList.remove("text-zinc-400", "hover:text-zinc-200")
+      } else {
+        tab.classList.remove("bg-zinc-800", "text-white")
+        tab.classList.add("text-zinc-400", "hover:text-zinc-200")
+      }
+    })
+
+    this.panelTargets.forEach((panel) => {
+      panel.classList.toggle("hidden", panel.dataset.tab !== selectedTab)
+    })
+  }
+
+  resolveTab(candidate) {
+    const known = this.tabTargets.map((tab) => tab.dataset.tab)
+    if (candidate && known.includes(candidate)) return candidate
+    return "timeline"
+  }
+
+  storedTab() {
+    if (!this.hasStorageKeyValue) return null
+
+    try {
+      return sessionStorage.getItem(this.storageKeyValue)
+    } catch (err) {
+      return null
+    }
+  }
+
+  storeTab(selectedTab) {
+    if (!this.hasStorageKeyValue) return
+
+    try {
+      sessionStorage.setItem(this.storageKeyValue, selectedTab)
+    } catch (err) {
+      // best-effort persistence; ignore failures (private mode, embedded contexts, full quota).
+    }
+  }
+}

--- a/app/javascript/controllers/log_viewer_controller.js
+++ b/app/javascript/controllers/log_viewer_controller.js
@@ -1,50 +1,77 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["search", "content"]
+  static targets = ["content", "search"]
 
   filter(event) {
     const type = event.currentTarget.dataset.filterType
-    const lines = this.contentTarget.querySelectorAll('.log-line')
 
-    lines.forEach(line => {
-      line.style.display = 'flex'
+    this.lines.forEach(line => {
+      // Hide only the opposite type — info/emoji/module/progress/detector lines stay visible.
+      const hide =
+        (type === 'pass' && line.classList.contains('fail-line')) ||
+        (type === 'fail' && line.classList.contains('pass-line'))
 
-      if (type === 'pass' && !line.classList.contains('pass-line')) {
-        line.style.display = 'none'
-      }
-
-      if (type === 'fail' && !line.classList.contains('fail-line')) {
-        line.style.display = 'none'
-      }
+      line.dataset.logViewerStatusMatch = hide ? 'false' : 'true'
+      this.updateLogViewerMatch(line)
     })
+
+    this.notifyFilterChange()
   }
 
   resetFilter() {
-    const lines = this.contentTarget.querySelectorAll('.log-line')
-    lines.forEach(line => {
-      line.style.display = 'flex'
+    if (this.hasSearchTarget) {
+      this.searchTarget.value = ''
+    }
+
+    this.lines.forEach(line => {
+      line.dataset.logViewerStatusMatch = 'true'
+      line.dataset.logViewerSearchMatch = 'true'
+      this.updateLogViewerMatch(line)
       line.style.backgroundColor = ''
     })
+
+    this.notifyFilterChange()
+    // Fired after notifyFilterChange so cross-panel listeners can also clear their query state.
+    this.element.dispatchEvent(new CustomEvent('log-viewer:reset', { bubbles: true }))
   }
 
   search() {
     const query = this.searchTarget.value.toLowerCase()
-    const lines = this.contentTarget.querySelectorAll('.log-line')
 
-    if (query === '') {
-      this.resetFilter()
-      return
-    }
-
-    lines.forEach(line => {
-      const text = line.textContent.toLowerCase()
-      if (text.includes(query)) {
-        line.style.display = 'flex'
-        line.style.backgroundColor = 'rgba(255, 255, 0, 0.1)'
-      } else {
-        line.style.display = 'none'
-      }
+    this.lines.forEach(line => {
+      const matchesSearch = query === '' || line.textContent.toLowerCase().includes(query)
+      line.dataset.logViewerSearchMatch = matchesSearch ? 'true' : 'false'
+      this.updateLogViewerMatch(line)
+      line.style.backgroundColor = query !== '' && matchesSearch ? 'rgba(255, 255, 0, 0.1)' : ''
     })
+
+    this.notifyFilterChange()
+  }
+
+  updateLogViewerMatch(line) {
+    const matchesStatusFilter = line.dataset.logViewerStatusMatch !== 'false'
+    const matchesSearchFilter = line.dataset.logViewerSearchMatch !== 'false'
+
+    line.dataset.logViewerFilterMatch = matchesStatusFilter && matchesSearchFilter ? 'true' : 'false'
+    this.applyVisibility(line)
+  }
+
+  applyVisibility(line) {
+    const matchesStreamFilter = line.dataset.debugStreamFilterMatch !== 'false'
+    const matchesLogFilter = line.dataset.logViewerFilterMatch !== 'false'
+
+    line.style.display = matchesStreamFilter && matchesLogFilter ? '' : 'none'
+  }
+
+  notifyFilterChange() {
+    this.element.dispatchEvent(new CustomEvent('log-viewer:filter-change', { bubbles: true }))
+  }
+
+  get lines() {
+    if (!this._cachedLines || !this.contentTarget.contains(this._cachedLines[0])) {
+      this._cachedLines = Array.from(this.contentTarget.querySelectorAll('.log-line'))
+    }
+    return this._cachedLines
   }
 }

--- a/app/jobs/broadcast_report_debug_job.rb
+++ b/app/jobs/broadcast_report_debug_job.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+class BroadcastReportDebugJob < ApplicationJob
+  queue_as :default
+
+  limits_concurrency to: 1, key: ->(report_id) { "broadcast_report_debug:#{report_id}" }, on_conflict: :block
+
+  POLL_INTERVAL = 10.seconds
+  POLLER_LEASE_TTL = 35.seconds
+  CACHE_PREFIX = "broadcast_report_debug:"
+  # SIGTERM-driven terminal transitions: Python's HeartbeatThread (script/db_notifier.py) takes
+  # up to ~30s to detect the new status, then SIGTERM triggers JournalSyncThread.stop() which
+  # writes one final tail to report_debug_logs. The delay below must exceed
+  # HeartbeatThread::DEFAULT_INTERVAL (30s) + JournalSyncThread join (5s) + DB write headroom.
+  # If either Python-side timing constant changes, revisit this delay.
+  FINAL_TAIL_FOLLOWUP_STATUSES = %w[stopped failed interrupted].freeze
+  FINAL_TAIL_FOLLOWUP_DELAY = 60.seconds
+
+  def self.enqueue_unless_active(report_id)
+    return false unless Rails.cache.write(poller_cache_key(report_id), true, expires_in: POLLER_LEASE_TTL, unless_exist: true)
+
+    perform_later(report_id)
+    true
+  end
+
+  def self.enqueue_status_change(report_id, status)
+    return enqueue_unless_active(report_id) if status.to_s.in?(Report::DEBUG_STREAM_POLLING_STATUSES)
+
+    mark_poller_active(report_id)
+    perform_later(report_id)
+    schedule_final_tail_followup(report_id) if status.to_s.in?(FINAL_TAIL_FOLLOWUP_STATUSES)
+    true
+  end
+
+  def self.schedule_final_tail_followup(report_id)
+    set(wait: FINAL_TAIL_FOLLOWUP_DELAY).perform_later(report_id)
+  end
+
+  def self.mark_poller_active(report_id)
+    Rails.cache.write(poller_cache_key(report_id), true, expires_in: POLLER_LEASE_TTL)
+  end
+
+  def self.clear_poller(report_id)
+    Rails.cache.delete(poller_cache_key(report_id))
+    Rails.cache.delete(digest_cache_key(report_id))
+    Rails.cache.delete(fingerprint_cache_key(report_id))
+  end
+
+  def self.poller_cache_key(report_id)
+    "#{CACHE_PREFIX}poller:#{report_id}"
+  end
+
+  def self.digest_cache_key(report_id)
+    "#{CACHE_PREFIX}digest:#{report_id}"
+  end
+
+  def self.fingerprint_cache_key(report_id)
+    "#{CACHE_PREFIX}fingerprint:#{report_id}"
+  end
+
+  def perform(report_id)
+    self.class.mark_poller_active(report_id)
+
+    unless Reports::DebugWatcher.watching?(report_id)
+      self.class.clear_poller(report_id)
+      return
+    end
+
+    report = ActsAsTenant.without_tenant { Report.find_by(id: report_id) }
+    if report.nil?
+      self.class.clear_poller(report_id)
+      return
+    end
+
+    errored = false
+    report_gone = false
+    reenqueued = false
+
+    begin
+      ActsAsTenant.with_tenant(report.company) do
+        if reload_report(report)
+          fingerprint = Reports::DebugStreamFingerprint.new(report).call
+          build_and_broadcast(report, fingerprint) unless fingerprint_unchanged?(report_id, fingerprint)
+        else
+          report_gone = true
+        end
+      end
+    rescue StandardError => e
+      errored = true
+      Rails.logger.error("[BroadcastReportDebugJob] report=#{report_id}: #{e.class} - #{e.message}")
+      raise
+    ensure
+      reenqueued = reenqueue_if_watching_polling(report_id) unless errored || report_gone
+      self.class.clear_poller(report_id) unless reenqueued
+    end
+  end
+
+  private
+
+  def reload_report(report)
+    report.reload
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+
+  def polling_report?(report)
+    report.status.in?(Report::DEBUG_STREAM_POLLING_STATUSES)
+  end
+
+  def reenqueue_if_watching_polling(report_id)
+    return false unless Reports::DebugWatcher.watching?(report_id)
+
+    report = ActsAsTenant.without_tenant { Report.find_by(id: report_id) }
+    return false unless report.present? && polling_report?(report)
+
+    reenqueue(report_id)
+    true
+  end
+
+  def reenqueue(report_id)
+    self.class.mark_poller_active(report_id)
+    self.class.set(wait: POLL_INTERVAL).perform_later(report_id)
+  end
+
+  def fingerprint_unchanged?(report_id, fingerprint)
+    return false if fingerprint.blank?
+
+    Rails.cache.read(self.class.fingerprint_cache_key(report_id)) == fingerprint[:digest]
+  end
+
+  def build_and_broadcast(report, fingerprint)
+    payload = Reports::DebugStreamPayload.new(report).call
+    current_digest = broadcast_digest(report, payload)
+    last_digest = Rails.cache.read(self.class.digest_cache_key(report.id))
+
+    if current_digest != last_digest
+      broadcast_debug_stream(report, payload)
+      broadcast_activity_summary(report, payload)
+      Rails.cache.write(self.class.digest_cache_key(report.id), current_digest, expires_in: 5.minutes)
+    end
+
+    cache_fingerprint(report, fingerprint)
+  end
+
+  def cache_fingerprint(report, fingerprint)
+    return if fingerprint.blank?
+
+    Rails.cache.write(self.class.fingerprint_cache_key(report.id), fingerprint[:digest])
+  end
+
+  def broadcast_digest(report, payload)
+    activity = payload[:activity] || {}
+    log_metadata = payload[:log_metadata] || {}
+
+    Digest::MD5.hexdigest({
+      payload_digest: payload[:digest],
+      report_status: report.status,
+      activity_active: activity[:active],
+      activity_status_label: activity[:status_label],
+      activity_entry_count: activity[:entry_count],
+      activity_log_line_count: activity[:log_line_count],
+      activity_updated_at: digest_timestamp(activity[:updated_at]),
+      log_source: log_metadata[:source],
+      log_offset: log_metadata[:offset],
+      log_synced_at: digest_timestamp(log_metadata[:synced_at]),
+      log_truncated: log_metadata[:truncated],
+      log_digest: log_metadata[:digest]
+    }.to_json)
+  end
+
+  def digest_timestamp(value)
+    return nil if value.blank?
+    return value.iso8601(6) if value.respond_to?(:iso8601)
+
+    value.to_s
+  end
+
+  def broadcast_debug_stream(report, payload)
+    Turbo::StreamsChannel.broadcast_replace_to(
+      Reports::DebugWatcher.stream_name(report),
+      target: "report-debug-stream-content",
+      partial: "admin/reports/debug_panel_stream",
+      locals: { report: report, payload: payload }
+    )
+  end
+
+  def broadcast_activity_summary(report, payload)
+    Turbo::StreamsChannel.broadcast_replace_to(
+      Reports::DebugWatcher.stream_name(report),
+      target: "report-activity-stream-summary",
+      partial: "admin/reports/activity_stream_summary",
+      locals: { report: report, payload: payload }
+    )
+  end
+end

--- a/app/jobs/check_stale_reports_job.rb
+++ b/app/jobs/check_stale_reports_job.rb
@@ -222,15 +222,18 @@ class CheckStaleReportsJob < ApplicationJob
       "moving to pending for retry (attempt #{report.retry_count + 1}/#{MAX_START_RETRIES})"
     )
 
-    report.update!(
-      status: :pending,
-      retry_count: report.retry_count + 1,
-      last_retry_at: Time.current,
-      logs: append_log(
-        report.logs,
-        "Retry #{report.retry_count + 1}: Previous start attempt timed out after #{STARTING_TIMEOUT.inspect}"
+    Report.transaction do
+      report.update!(
+        status: :pending,
+        retry_count: report.retry_count + 1,
+        last_retry_at: Time.current,
+        logs: append_log(
+          report.logs,
+          "Retry #{report.retry_count + 1}: Previous start attempt timed out after #{STARTING_TIMEOUT.inspect}"
+        )
       )
-    )
+      ReportDebugLog.clear_tail_for_report(report.id)
+    end
   end
 
   # Mark report as interrupted for automatic retry by RetryInterruptedReportsJob.
@@ -243,7 +246,7 @@ class CheckStaleReportsJob < ApplicationJob
 
     report.update!(
       status: :interrupted,
-      logs: append_log(report.logs, "Interrupted: #{reason}")
+      logs: append_log(logs_with_live_tail(report), "Interrupted: #{reason}")
     )
   end
 
@@ -252,8 +255,29 @@ class CheckStaleReportsJob < ApplicationJob
 
     report.update!(
       status: :failed,
-      logs: append_log(report.logs, reason)
+      logs: append_log(logs_with_live_tail(report), reason)
     )
+  end
+
+  def logs_with_live_tail(report)
+    logs = report.logs
+    tail = current_live_tail(report)
+
+    return logs if tail.blank?
+    return tail if logs.blank?
+    return logs if logs_end_with_tail?(logs, tail)
+
+    "#{logs}\n#{tail}"
+  end
+
+  def logs_end_with_tail?(logs, tail)
+    logs.to_s.rstrip.end_with?(tail.to_s.rstrip)
+  end
+
+  def current_live_tail(report)
+    return nil unless report.running?
+
+    report.report_debug_log&.tail
   end
 
   def append_log(existing_logs, message)

--- a/app/jobs/retry_interrupted_reports_job.rb
+++ b/app/jobs/retry_interrupted_reports_job.rb
@@ -53,17 +53,20 @@ class RetryInterruptedReportsJob < ApplicationJob
       "attempt #{report.retry_count + 1}/#{CheckStaleReportsJob::MAX_INTERRUPT_RETRIES}"
     )
 
-    report.update!(
-      status: :pending,
-      retry_count: report.retry_count + 1,
-      last_retry_at: Time.current,
-      heartbeat_at: nil, # Reset heartbeat for fresh start
-      pid: nil, # Clear stale PID so new run gets a fresh process identity
-      logs: append_log(
-        report.logs,
-        "Auto-retry #{report.retry_count + 1}: Requeued after interruption"
+    Report.transaction do
+      report.update!(
+        status: :pending,
+        retry_count: report.retry_count + 1,
+        last_retry_at: Time.current,
+        heartbeat_at: nil, # Reset heartbeat for fresh start
+        pid: nil, # Clear stale PID so new run gets a fresh process identity
+        logs: append_log(
+          report.logs,
+          "Auto-retry #{report.retry_count + 1}: Requeued after interruption"
+        )
       )
-    )
+      ReportDebugLog.clear_tail_for_report(report.id)
+    end
   end
 
   def append_log(existing_logs, message)

--- a/app/jobs/start_pending_scans_job.rb
+++ b/app/jobs/start_pending_scans_job.rb
@@ -115,8 +115,12 @@ class StartPendingScansJob < ApplicationJob
 
   # Atomic claim: UPDATE only succeeds if report is still pending
   def claim_for_starting(report)
-    updated_count = Report.where(id: report.id, status: :pending)
-                          .update_all(status: :starting, updated_at: Time.current)
+    updated_count = 0
+    Report.transaction do
+      updated_count = Report.where(id: report.id, status: :pending)
+                            .update_all(status: :starting, updated_at: Time.current)
+      ReportDebugLog.clear_tail_for_report(report.id) if updated_count.positive?
+    end
     claimed = updated_count.positive?
 
     # Broadcast immediately since update_all bypasses callbacks

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -10,6 +10,7 @@ class Report < ApplicationRecord
   belongs_to :parent_report, class_name: "Report", optional: true
   has_one :child_report, class_name: "Report", foreign_key: "parent_report_id", dependent: :destroy
   has_one :raw_report_data, dependent: :destroy
+  has_one :report_debug_log, dependent: :destroy, autosave: true
   has_one :report_pdf, dependent: :destroy
 
   validates :uuid, presence: true, uniqueness: true
@@ -48,6 +49,7 @@ class Report < ApplicationRecord
 
   # Trigger widget broadcast when status affects running count (multi-pod safe)
   after_commit :broadcast_running_stats_if_needed, if: :saved_change_to_status?
+  after_commit :broadcast_debug_stream_if_watched, if: :saved_change_to_status?
 
   enum :status, {
     pending: 0,
@@ -65,6 +67,9 @@ class Report < ApplicationRecord
   # - interrupted is visible so users can monitor auto-retry behavior
   ACTIONABLE_STATUSES = (statuses.keys - %w[processing starting]).freeze
   BROADCAST_ACTIVE_STATUSES = %w[running starting].freeze
+  DEBUG_BROADCAST_ACTIVE_STATUSES = (BROADCAST_ACTIVE_STATUSES + %w[processing]).freeze
+  DEBUG_STREAM_LIVE_TAIL_STATUSES = %w[running processing].freeze
+  DEBUG_STREAM_POLLING_STATUSES = (DEBUG_BROADCAST_ACTIVE_STATUSES + %w[pending]).freeze
 
   def self.ransackable_attributes(auth_object = nil)
     [ "company_id", "name", "created_at", "id", "status", "target_id", "updated_at", "uuid", "asr" ]
@@ -72,6 +77,23 @@ class Report < ApplicationRecord
 
   def self.ransackable_associations(auth_object = nil)
     [ "company", "target", "scan" ]
+  end
+
+  def logs
+    debug_logs = report_debug_log&.logs if report_debug_logs_table_available?
+    return debug_logs unless debug_logs.nil?
+
+    legacy_logs_value
+  end
+
+  def logs=(value)
+    if report_debug_logs_table_available?
+      debug_log = report_debug_log || find_or_build_report_debug_log
+      debug_log.logs = value
+    end
+
+    self[:logs] = value if has_attribute?(:logs)
+    value
   end
 
   def detector_results_as_hash
@@ -142,6 +164,24 @@ class Report < ApplicationRecord
 
   private
 
+  def find_or_build_report_debug_log
+    if persisted?
+      ReportDebugLog.find_or_initialize_by(report_id: id).tap do |record|
+        self.report_debug_log = record
+      end
+    else
+      build_report_debug_log
+    end
+  end
+
+  def legacy_logs_value
+    self[:logs] if has_attribute?(:logs)
+  end
+
+  def report_debug_logs_table_available?
+    self.class.connection.data_source_exists?("report_debug_logs")
+  end
+
   # Failed/stopped scans should not count against the company's weekly quota.
   # Decrements the scan count so the user can retry without being penalized.
   def refund_scan_quota
@@ -178,6 +218,13 @@ class Report < ApplicationRecord
 
     # Pass company_id for company-scoped broadcast
     BroadcastRunningStatsJob.perform_later(company_id) if affects_count
+  end
+
+  def broadcast_debug_stream_if_watched
+    return unless Reports::DebugWatcher.watching?(id)
+
+    _old_status, new_status = saved_change_to_status
+    BroadcastReportDebugJob.enqueue_status_change(id, new_status)
   end
 
   def collect_metrics

--- a/app/models/report_debug_log.rb
+++ b/app/models/report_debug_log.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ReportDebugLog < ApplicationRecord
+  TAIL_RESET_ATTRIBUTES = {
+    tail: nil,
+    tail_offset: 0,
+    tail_digest: nil,
+    tail_synced_at: nil,
+    tail_truncated: false
+  }.freeze
+
+  belongs_to :report
+
+  validates :report_id, uniqueness: true
+
+  def self.clear_tail_for_report(report_id)
+    where(report_id: report_id).update_all(TAIL_RESET_ATTRIBUTES.merge(updated_at: Time.current))
+  end
+end

--- a/app/services/reports/debug_stream_fingerprint.rb
+++ b/app/services/reports/debug_stream_fingerprint.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Reports
+  class DebugStreamFingerprint
+    SELECT_COLUMNS = [
+      "reports.id",
+      "reports.status",
+      "reports.updated_at AS report_updated_at",
+      "raw_report_data.id AS raw_report_data_id",
+      "raw_report_data.updated_at AS raw_report_data_updated_at",
+      "octet_length(raw_report_data.jsonl_data) AS raw_jsonl_bytes",
+      "report_debug_logs.id AS report_debug_log_id",
+      "report_debug_logs.tail_offset AS tail_offset",
+      "report_debug_logs.tail_digest AS tail_digest",
+      "report_debug_logs.tail_synced_at AS tail_synced_at",
+      "report_debug_logs.tail_truncated AS tail_truncated"
+    ].freeze
+
+    def initialize(source)
+      @report_id = source.respond_to?(:id) ? source.id : source
+    end
+
+    def call
+      return nil if report_id.blank?
+
+      record = fingerprint_record
+      return nil if record.nil?
+
+      metadata = fingerprint_metadata(record)
+      metadata.merge(digest: digest(metadata))
+    end
+
+    private
+
+    attr_reader :report_id
+
+    def fingerprint_record
+      Report
+        .left_joins(:raw_report_data, :report_debug_log)
+        .select(*SELECT_COLUMNS)
+        .find_by(id: report_id)
+    end
+
+    def fingerprint_metadata(record)
+      {
+        report_id: record.id,
+        status: record.status,
+        report_updated_at: timestamp_attribute(record, "report_updated_at"),
+        raw_report_data_id: integer_attribute(record, "raw_report_data_id"),
+        raw_report_data_updated_at: timestamp_attribute(record, "raw_report_data_updated_at"),
+        raw_jsonl_bytes: integer_attribute(record, "raw_jsonl_bytes"),
+        report_debug_log_id: integer_attribute(record, "report_debug_log_id"),
+        tail_offset: integer_attribute(record, "tail_offset"),
+        tail_digest: record.read_attribute("tail_digest"),
+        tail_synced_at: timestamp_attribute(record, "tail_synced_at"),
+        tail_truncated: boolean_attribute(record, "tail_truncated")
+      }
+    end
+
+    def digest(metadata)
+      Digest::SHA256.hexdigest(metadata.to_json)
+    end
+
+    def integer_attribute(record, name)
+      value = record.read_attribute(name)
+      return nil if value.nil?
+
+      value.to_i
+    end
+
+    def boolean_attribute(record, name)
+      value = record.read_attribute(name)
+      return nil if value.nil?
+
+      ActiveModel::Type::Boolean.new.cast(value)
+    end
+
+    def timestamp_attribute(record, name)
+      timestamp = record.read_attribute(name)
+      return nil if timestamp.blank?
+      return timestamp.iso8601(6) if timestamp.respond_to?(:iso8601)
+
+      timestamp.to_s
+    end
+  end
+end

--- a/app/services/reports/debug_stream_payload.rb
+++ b/app/services/reports/debug_stream_payload.rb
@@ -1,0 +1,294 @@
+# frozen_string_literal: true
+
+module Reports
+  class DebugStreamPayload
+    PREVIEW_LIMIT = 200
+    RAW_TAIL_LINES = 100
+    TIMELINE_TAIL_LIMIT = 500
+    LOG_TAIL_LINES = 500
+    ACTIVITY_PREVIEW_LIMIT = 22
+
+    attr_reader :raw_report_data, :report
+
+    def initialize(source)
+      @raw_report_data = source if source.is_a?(RawReportData)
+      @report = source if source.is_a?(Report) || report_like?(source)
+      @report ||= @raw_report_data&.report
+      @raw_report_data ||= @report&.raw_report_data
+    end
+
+    def call
+      timeline = build_timeline
+      raw_tail = build_raw_tail
+      logs = build_logs
+
+      {
+        timeline: timeline,
+        raw_tail: raw_tail,
+        logs: logs[:data],
+        log_metadata: logs.except(:data),
+        activity: build_activity(timeline, logs),
+        digest: compute_digest(timeline, raw_tail, logs)
+      }
+    end
+
+    private
+
+    def report_like?(source)
+      source.respond_to?(:raw_report_data) && source.respond_to?(:report_debug_log)
+    end
+
+    def parsed_lines
+      parsed_jsonl[:lines]
+    end
+
+    def parsed_jsonl
+      @parsed_jsonl ||= parse_jsonl
+    end
+
+    def jsonl_data
+      return @jsonl_data if defined?(@jsonl_data)
+
+      @jsonl_data = raw_report_data&.jsonl_data.to_s
+    end
+
+    def parse_jsonl
+      data = jsonl_data
+      return { lines: [], tail: "" } if data.blank?
+
+      lines = []
+      tail = []
+
+      data.each_line do |line|
+        safe_line = line.to_s.dup.force_encoding(Encoding::UTF_8)
+        safe_line = safe_line.scrub unless safe_line.valid_encoding?
+
+        tail << safe_line
+        tail.shift if tail.size > RAW_TAIL_LINES
+
+        parsed = parse_line(safe_line)
+        next if parsed.nil?
+
+        lines << parsed
+        lines.shift if lines.size > TIMELINE_TAIL_LIMIT
+      end
+
+      { lines: lines, tail: tail.join }
+    end
+
+    def parse_line(line)
+      stripped = line.strip
+      return nil if stripped.empty?
+
+      data = JSON.parse(stripped)
+      data if data.is_a?(Hash) && data["entry_type"]
+    rescue JSON::ParserError, EncodingError => e
+      report_id = raw_report_data&.report_id
+      preview = truncate(stripped.to_s, PREVIEW_LIMIT)
+      line_digest = Digest::SHA256.hexdigest(stripped.to_s)
+      Rails.logger.warn(
+        "[DebugStreamPayload] malformed JSONL report=#{report_id} " \
+        "error=#{e.class}: #{e.message} line_bytes=#{stripped.to_s.bytesize} " \
+        "line_sha256=#{line_digest}"
+      )
+      { "entry_type" => "_parse_error", "_raw" => preview }
+    end
+
+    def build_timeline
+      parsed_lines.map { |line| timeline_entry(line) }
+    end
+
+    def timeline_entry(data)
+      case data["entry_type"]
+      when "init"
+        { type: "init", start_time: data["start_time"] }
+      when "attempt"
+        {
+          type: "attempt",
+          probe: data["probe_classname"],
+          uuid: data["uuid"],
+          prompt_preview: truncate(extract_prompt(data), PREVIEW_LIMIT),
+          output_preview: truncate(extract_output(data), PREVIEW_LIMIT)
+        }
+      when "eval"
+        {
+          type: "eval",
+          probe: data["probe"],
+          detector: data["detector"],
+          passed: data["passed"],
+          total: data["total_evaluated"]
+        }
+      when "completion"
+        { type: "completion", end_time: data["end_time"] }
+      when "_parse_error"
+        { type: "_parse_error", raw: data["_raw"] }
+      else
+        { type: data["entry_type"] }
+      end
+    end
+
+    def extract_prompt(data)
+      TokenEstimator.extract_prompt_text(data["prompt"]).to_s
+    end
+
+    def extract_output(data)
+      outputs = data["outputs"]
+      return "" if outputs.nil?
+      return outputs if outputs.is_a?(String)
+
+      first = outputs.is_a?(Array) ? outputs.first : outputs
+      TokenEstimator.extract_output_text(first).to_s
+    end
+
+    def build_raw_tail
+      parsed_jsonl[:tail]
+    end
+
+    def build_logs
+      debug_log = report&.report_debug_log
+      return empty_log_payload if debug_log.nil?
+
+      return live_tail_log_payload(debug_log) if live_tail_report? && debug_log.tail.present?
+      return empty_log_payload if polling_report?
+      return live_tail_log_payload(debug_log) if report&.stopped? && debug_log.tail.present?
+
+      if debug_log.logs.present?
+        return full_logs_payload(debug_log.logs.to_s)
+      end
+
+      empty_log_payload
+    end
+
+    def live_tail_log_payload(debug_log)
+      {
+        data: debug_log.tail.to_s,
+        offset: debug_log.tail_offset,
+        synced_at: debug_log.tail_synced_at,
+        truncated: debug_log.tail_truncated,
+        source: "live_tail",
+        digest: debug_log.tail_digest.presence || Digest::MD5.hexdigest(debug_log.tail.to_s)
+      }
+    end
+
+    def full_logs_payload(raw_logs)
+      lines = raw_logs.lines
+      truncated = lines.size > LOG_TAIL_LINES
+      data = truncated ? lines.last(LOG_TAIL_LINES).join : raw_logs
+
+      {
+        data: data,
+        offset: nil,
+        synced_at: nil,
+        truncated: truncated,
+        source: "full_logs",
+        digest: Digest::MD5.hexdigest(raw_logs)
+      }
+    end
+
+    def empty_log_payload
+      {
+        data: "",
+        offset: nil,
+        synced_at: nil,
+        truncated: false,
+        source: "none",
+        digest: nil
+      }
+    end
+
+    def polling_report?
+      report&.status.in?(Report::DEBUG_STREAM_POLLING_STATUSES)
+    end
+
+    def live_tail_report?
+      report&.status.in?(Report::DEBUG_STREAM_LIVE_TAIL_STATUSES)
+    end
+
+    def activity_active?
+      report&.status.in?((Report::DEBUG_BROADCAST_ACTIVE_STATUSES + %w[pending]).uniq)
+    end
+
+    def build_activity(timeline, logs)
+      attempt_count = timeline.count { |entry| entry[:type] == "attempt" }
+      eval_count = timeline.count { |entry| entry[:type] == "eval" }
+      log_line_count = logs[:data].to_s.lines.count
+
+      {
+        active: activity_active?,
+        status_label: activity_status_label,
+        attempt_count: attempt_count,
+        eval_count: eval_count,
+        probe_count: activity_probe_count(timeline),
+        entry_count: timeline.count + log_line_count,
+        updated_at: activity_updated_at(logs),
+        log_line_count: log_line_count,
+        preview: activity_preview(timeline)
+      }
+    end
+
+    def activity_status_label
+      return "Your scan is running." if activity_active?
+      return "Scan complete." if report&.completed?
+      return "No scan status available." if report&.status.blank?
+
+      "Scan #{report.status.tr("_", " ")}."
+    end
+
+    def activity_probe_count(timeline)
+      timeline.filter_map do |entry|
+        next unless entry[:type].in?(%w[attempt eval])
+
+        entry[:probe].to_s.strip.presence
+      end.uniq.count
+    end
+
+    def activity_updated_at(logs)
+      return logs[:synced_at] if logs[:source] == "live_tail" && logs[:synced_at].present?
+      return raw_report_data.updated_at if raw_report_data&.updated_at.present?
+
+      report&.updated_at
+    end
+
+    def activity_preview(timeline)
+      timeline.last(ACTIVITY_PREVIEW_LIMIT).map do |entry|
+        preview = { type: entry[:type].to_s }
+        probe = entry[:probe].to_s.strip
+        detector = entry[:detector].to_s.strip
+
+        preview[:probe] = probe if probe.present?
+        preview[:detector] = detector if detector.present?
+        preview
+      end
+    end
+
+    def compute_digest(timeline, raw_tail, logs)
+      has_raw_data = jsonl_data.present?
+      has_log_data = logs[:data].present?
+      return nil unless has_raw_data || has_log_data
+
+      Digest::MD5.hexdigest({
+        timeline: timeline,
+        raw_tail: raw_tail,
+        logs: logs[:data],
+        log_offset: logs[:offset],
+        log_synced_at: digest_timestamp(logs[:synced_at]),
+        log_truncated: logs[:truncated],
+        log_source: logs[:source],
+        log_digest: logs[:digest]
+      }.to_json)
+    end
+
+    def digest_timestamp(value)
+      return nil if value.blank?
+      return value.iso8601(6) if value.respond_to?(:iso8601)
+
+      value.to_s
+    end
+
+    def truncate(str, limit)
+      return "" if str.nil?
+
+      str.length > limit ? "#{str[0, limit]}..." : str
+    end
+  end
+end

--- a/app/services/reports/debug_watcher.rb
+++ b/app/services/reports/debug_watcher.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Reports
+  module DebugWatcher
+    LEASE_TTL = 45.seconds
+    CACHE_PREFIX = "debug_watcher:report:"
+
+    module_function
+
+    def refresh(report_id)
+      Rails.cache.write(cache_key(report_id), true, expires_in: LEASE_TTL)
+    end
+
+    def refresh_and_enqueue(report)
+      refresh(report.id)
+      BroadcastReportDebugJob.enqueue_unless_active(report.id) if report.status.in?(Report::DEBUG_STREAM_POLLING_STATUSES)
+    end
+
+    def watching?(report_id)
+      Rails.cache.exist?(cache_key(report_id))
+    end
+
+    def stream_name(report)
+      "report-debug:company_#{report.company_id}:report_#{report.id}"
+    end
+
+    def cache_key(report_id)
+      "#{CACHE_PREFIX}#{report_id}"
+    end
+  end
+end

--- a/app/services/reports/process.rb
+++ b/app/services/reports/process.rb
@@ -32,19 +32,35 @@ module Reports
 
     def process_from_database
       @raw_data.mark_processing!
-      process_jsonl_data(@raw_data.jsonl_data)
+      report.update!(status: :processing)
 
-      report.logs = @raw_data.logs_data if @raw_data.logs_data.present?
-      report.save
-      save_detector_results
-      update_target_token_rate
+      Report.transaction do
+        process_jsonl_data(@raw_data.jsonl_data, mark_processing: false)
 
-      @raw_data.destroy!
+        persist_final_logs
+        save_detector_results
+        update_target_token_rate
+
+        @raw_data.destroy!
+        report.save!
+      end
       Rails.logger.info("Report #{id}: Processed from database, raw_report_data deleted")
     end
 
-    def process_jsonl_data(jsonl_string)
-      report.update(status: :processing)
+    def persist_final_logs
+      final_logs = @raw_data.logs_data.presence || report.report_debug_log&.tail.presence
+      return if final_logs.nil? && report.report_debug_log.nil?
+      return if final_logs.nil? && preserve_existing_logs_without_final_logs?
+
+      report.logs = final_logs
+    end
+
+    def preserve_existing_logs_without_final_logs?
+      report.retry_count.to_i.positive? && report.logs.present?
+    end
+
+    def process_jsonl_data(jsonl_string, mark_processing: true)
+      report.update!(status: :processing) if mark_processing
 
       processed = false
       line_number = 0

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -65,35 +65,37 @@ class RunGarakScan
   end
 
   def build_argv
-    script_path = Rails.root.join("script", "run_garak.py")
-    [ "/opt/venv/bin/python3", script_path.to_s, report.uuid ] + params
+    with_report_tenant do
+      script_path = Rails.root.join("script", "run_garak.py")
+      [ "/opt/venv/bin/python3", script_path.to_s, report.uuid ] + params
+    end
   end
 
   def build_env
-    # Tenant context needed for decrypting EnvironmentVariable.env_value
-    # via per-tenant key provider
-    merged = merged_env_vars
-    env = merged.dup
+    with_report_tenant do
+      merged = merged_env_vars
+      env = merged.dup
 
-    env["HOME"] = "/home/rails"
-    env["VARIANT_SCAN"] = "true" if report.is_variant_report?
+      env["HOME"] = "/home/rails"
+      env["VARIANT_SCAN"] = "true" if report.is_variant_report?
 
-    env["LOG_FILE_PATH"] = scan_log_path
-    env["DATABASE_URL"] = database_url_for_python
+      env["LOG_FILE_PATH"] = scan_log_path
+      env["DATABASE_URL"] = database_url_for_python
 
-    if MonitoringService.active?
-      MonitoringService.trace_context.each do |key, value|
-        env[key] = value
+      if MonitoringService.active?
+        MonitoringService.trace_context.each do |key, value|
+          env[key] = value
+        end
       end
+
+      env["REPORT_UUID"] = report.uuid
+      env["SCAN_ID"] = report.scan.id.to_s
+      env["SCAN_NAME"] = report.scan.name
+      env["TARGET_ID"] = target.id.to_s
+      env["TARGET_NAME"] = target.name
+
+      env
     end
-
-    env["REPORT_UUID"] = report.uuid
-    env["SCAN_ID"] = report.scan.id.to_s
-    env["SCAN_NAME"] = report.scan.name
-    env["TARGET_ID"] = target.id.to_s
-    env["TARGET_NAME"] = target.name
-
-    env
   end
 
   def scan_log_path
@@ -162,29 +164,33 @@ class RunGarakScan
   end
 
   def api_params
-    [
-      [ "--skip_unknown" ],
-      target_type_arg,
-      target_name_arg,
-      probes_config,
-      report_prefix,
-      evaluation_threshold,
-      parallel_attempts,
-      generator_options
-    ].compact.flatten
+    with_report_tenant do
+      [
+        [ "--skip_unknown" ],
+        target_type_arg,
+        target_name_arg,
+        probes_config,
+        report_prefix,
+        evaluation_threshold,
+        parallel_attempts,
+        generator_options
+      ].compact.flatten
+    end
   end
 
   def web_chat_params
-    [
-      [ "--skip_unknown" ],
-      [ "--target_type", "web_chatbot.WebChatbotGenerator" ],
-      web_chat_target_name,
-      probes_config,
-      report_prefix,
-      evaluation_threshold,
-      parallel_attempts,
-      web_chat_generator_options
-    ].compact.flatten
+    with_report_tenant do
+      [
+        [ "--skip_unknown" ],
+        [ "--target_type", "web_chatbot.WebChatbotGenerator" ],
+        web_chat_target_name,
+        probes_config,
+        report_prefix,
+        evaluation_threshold,
+        parallel_attempts,
+        web_chat_generator_options
+      ].compact.flatten
+    end
   end
 
   def target
@@ -311,15 +317,22 @@ class RunGarakScan
   end
 
   def evaluation_threshold
-    # Tenant context is set by execute_scan's with_tenant wrapper
-    env_var = target.environment_variables.find_by(env_name: EVALUATION_THRESHOLD_ENV_NAME) ||
-      EnvironmentVariable.global.find_by(env_name: EVALUATION_THRESHOLD_ENV_NAME)
+    with_report_tenant do
+      env_var = target.environment_variables.find_by(env_name: EVALUATION_THRESHOLD_ENV_NAME) ||
+        EnvironmentVariable.global.find_by(env_name: EVALUATION_THRESHOLD_ENV_NAME)
 
-    if env_var&.env_value
-      value = env_var.env_value.to_s.strip
-      raise ArgumentError, "Invalid evaluation threshold: #{value}" unless value.match?(/\A\d+(\.\d+)?\z/)
-      [ "--eval_threshold", value ]
+      if env_var&.env_value
+        value = env_var.env_value.to_s.strip
+        raise ArgumentError, "Invalid evaluation threshold: #{value}" unless value.match?(/\A\d+(\.\d+)?\z/)
+        [ "--eval_threshold", value ]
+      end
     end
+  end
+
+  def with_report_tenant(&block)
+    return yield if ActsAsTenant.current_tenant == report.company
+
+    ActsAsTenant.with_tenant(report.company, &block)
   end
 
   # Returns the list of remaining probes for a regular report, filtering out
@@ -429,19 +442,19 @@ class RunGarakScan
   # previous day (scan crossing a date boundary).
   def persist_existing_logs
     raw_data = report.raw_report_data
-    return unless raw_data
+    return if raw_data.nil? || raw_data.logs_data.present?
 
     log_path = LogPathManager.find_existing_log_for_report(report)
     return unless log_path&.exist?
 
-    raw_data.update(logs_data: File.read(log_path))
+    raw_data.update!(logs_data: File.read(log_path))
     Rails.logger.info("[ScanResume] Report #{report.uuid}: Persisted existing log file to raw_report_data")
   rescue StandardError => e
     Rails.logger.warn("[ScanResume] Report #{report.uuid}: Could not persist logs: #{e.message}")
   end
 
   def read_log_tail
-    log_path = LogPathManager.scan_log_file_for_report(report)
+    log_path = scan_log_path
     return nil unless log_path && File.exist?(log_path.to_s)
 
     content = File.read(log_path.to_s)

--- a/app/views/admin/reports/_activity_stream_card.html.erb
+++ b/app/views/admin/reports/_activity_stream_card.html.erb
@@ -1,0 +1,32 @@
+<% payload = local_assigns[:payload] || Reports::DebugStreamPayload.new(report).call %>
+
+<div id="report-activity-stream"
+     class="bg-zinc-900 rounded-lg border border-zinc-700 overflow-hidden"
+     data-controller="activity-stream">
+  <div class="p-4 sm:p-5">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <%= render partial: "admin/reports/activity_stream_summary", locals: { report: report, payload: payload } %>
+
+      <div class="flex shrink-0 flex-col gap-2 sm:flex-row sm:items-center lg:pt-0.5">
+        <span class="text-xs font-sans text-contentTertiary">Timeline, JSONL, logs</span>
+        <button type="button"
+                class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-zinc-600 bg-zinc-800 px-3 py-2 text-sm font-sans font-medium text-primary transition-colors hover:bg-zinc-700 focus:outline-none focus:ring-2 focus:ring-yellow-400/50"
+                data-action="click->activity-stream#toggle"
+                data-activity-stream-target="button"
+                aria-controls="report-activity-stream-details"
+                aria-expanded="false">
+          <span data-activity-stream-target="buttonLabel">View activity</span>
+          <span class="icon icon-xs icon-chevron-right text-contentSecondary"></span>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div id="report-activity-stream-details"
+       class="hidden border-t border-zinc-700"
+       data-activity-stream-target="details">
+    <div tabindex="-1" data-activity-stream-focus-target>
+      <%= render partial: "admin/reports/debug_panel", locals: { report: report, payload: payload } %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/reports/_activity_stream_summary.html.erb
+++ b/app/views/admin/reports/_activity_stream_summary.html.erb
@@ -1,0 +1,57 @@
+<% payload = local_assigns[:payload] || {} %>
+<% activity = payload[:activity] || {} %>
+<% updated_at = activity[:updated_at] %>
+<%
+  attempt_count = activity[:attempt_count].to_i
+  probe_count = activity[:probe_count].to_i
+  log_line_count = activity[:log_line_count].to_i
+  has_probe_activity = attempt_count.positive? || probe_count.positive?
+  status_label = activity[:status_label].presence || report.status.to_s.humanize
+
+  progress_text =
+    if has_probe_activity
+      attempts = pluralize(attempt_count, "attempt")
+      probes = pluralize(probe_count, "probe")
+      activity[:active] ? "#{attempts} so far; #{probes} loaded" : "#{attempts} recorded; #{probes} loaded"
+    elsif log_line_count.positive?
+      logs = pluralize(log_line_count, "execution log line")
+      activity[:active] ? "#{logs} captured; waiting for probe events" : "#{logs} captured"
+    elsif activity[:active]
+      "Waiting for the first probe attempt."
+    else
+      "No activity captured for this scan."
+    end
+%>
+
+<div id="report-activity-stream-summary"
+     class="min-w-0 flex-1"
+     data-activity-stream-target="summary">
+  <div class="min-w-0">
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="icon icon-sm icon-sparkles text-yellow-400"></span>
+      <h2 class="text-lg font-sans font-semibold text-primary tracking-wide">Activity Stream</h2>
+      <% if activity[:active] %>
+        <span class="inline-flex items-center gap-1 rounded-full border border-green-400/40 bg-green-500/10 px-2 py-0.5 text-[11px] font-sans font-semibold uppercase tracking-wide text-green-300">
+          <span class="h-1.5 w-1.5 rounded-full bg-green-400"></span>
+          LIVE
+        </span>
+      <% end %>
+    </div>
+
+    <p class="mt-1 text-xs font-sans text-contentSecondary">
+      <% if updated_at.present? %>
+        Updated <%= time_ago_in_words(updated_at) %> ago
+      <% else %>
+        No activity yet
+      <% end %>
+    </p>
+
+    <div class="mt-5">
+      <p class="text-base font-sans font-semibold text-primary"><%= status_label %></p>
+      <p class="mt-1 text-sm font-sans text-contentSecondary"><%= progress_text %></p>
+      <p class="mt-3 max-w-3xl text-sm font-sans leading-6 text-contentSecondary">
+        Activity Stream shows probe attempts, detector checks, and execution logs produced during the scan for progress checks, troubleshooting, and audit review.
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/reports/_debug_execution_logs.html.erb
+++ b/app/views/admin/reports/_debug_execution_logs.html.erb
@@ -1,0 +1,161 @@
+<% log_data = logs.to_s %>
+<% metadata = local_assigns[:metadata] || {} %>
+<%
+  source = metadata[:source].to_s
+  source_label = case source
+  when "live_tail" then "Live tail"
+  when "full_logs" then "Final logs"
+  else "No log source"
+  end
+%>
+<div class="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-sans text-contentSecondary">
+  <span><%= source_label %></span>
+  <% if source == "live_tail" && metadata[:offset].present? %>
+    <span>Offset <%= number_with_delimiter(metadata[:offset]) %> bytes</span>
+  <% end %>
+  <% if metadata[:truncated] %>
+    <span>Tail truncated</span>
+  <% end %>
+  <% if metadata[:synced_at].present? %>
+    <span>Updated <%= time_ago_in_words(metadata[:synced_at]) %> ago</span>
+  <% end %>
+</div>
+
+<% if log_data.present? %>
+  <% log_lines = log_data.lines %>
+  <div class="mt-2" data-controller="log-viewer">
+    <div>
+      <div class="bg-zinc-950 p-4 overflow-auto max-h-[60vh] rounded-lg">
+        <div class="font-mono text-xs break-all"
+             data-log-viewer-target="content"
+             data-debug-stream-filter-target="group">
+          <% log_lines.each_with_index do |line, index| %>
+            <%
+              line_class = "py-0.5 px-1 flex items-start hover:bg-zinc-800/50 rounded relative group min-w-0"
+              line_num_class = "text-zinc-500 w-8 inline-block text-right mr-2 select-none opacity-50 group-hover:opacity-100 shrink-0"
+              status_class =
+                if line =~ /\e?\[1m\e?\[91mFAIL\e?\[0m/
+                  "fail-line"
+                elsif line =~ /\e?\[1m\e?\[92mPASS\e?\[0m/
+                  "pass-line"
+                end
+              row_class = [ line_class, "debug-stream-row", "log-line", status_class ].compact.join(" ")
+              row_attrs = {
+                "data-debug-stream-filter-target" => "row",
+                "data-debug-stream-filter-match" => "true",
+                "data-log-viewer-filter-match" => "true"
+              }
+            %>
+
+            <% if line =~ /\e?\[1m\e?\[91mFAIL\e?\[0m/ %>
+              <div class="<%= row_class %>" <%= row_attrs.map { |k, v| "#{k}=\"#{v}\"" }.join(" ").html_safe %>>
+                <span class="<%= line_num_class %>"><%= index + 1 %></span>
+                <%
+                  styled = ERB::Util.html_escape(line)
+                    .gsub(/\e?\[1m\e?\[91mFAIL\e?\[0m/, '<span class="font-bold text-red-400">FAIL</span>')
+                    .gsub(/\[91mfailure rate:.+?\]/, '<span class="text-red-300">\0</span>')
+                    .gsub(/ok on\s+(\d+)\/\s*(\d+)/, 'ok on <span class="text-blue-400">\1</span>/<span class="text-blue-300">\2</span>')
+                    .gsub(/^(.+?)\s+(\w+\.)/, '<span class="text-orange-400">\1</span> \2')
+                %>
+                <span class="flex-1 min-w-0 break-all overflow-hidden"><%= raw(styled) %></span>
+              </div>
+
+            <% elsif line =~ /\e?\[1m\e?\[92mPASS\e?\[0m/ %>
+              <div class="<%= row_class %>" <%= row_attrs.map { |k, v| "#{k}=\"#{v}\"" }.join(" ").html_safe %>>
+                <span class="<%= line_num_class %>"><%= index + 1 %></span>
+                <%
+                  styled = ERB::Util.html_escape(line)
+                    .gsub(/\e?\[1m\e?\[92mPASS\e?\[0m/, '<span class="font-bold text-green-400">PASS</span>')
+                    .gsub(/ok on\s+(\d+)\/\s*(\d+)/, 'ok on <span class="text-blue-400">\1</span>/<span class="text-blue-300">\2</span>')
+                    .gsub(/^(.+?)\s+(\w+\.)/, '<span class="text-orange-400">\1</span> \2')
+                %>
+                <span class="flex-1 min-w-0 break-all overflow-hidden"><%= raw(styled) %></span>
+              </div>
+
+            <% elsif line =~ /^📜|^🕵️|^🦜|^✔️/ %>
+              <div class="<%= row_class %> emoji-line" <%= row_attrs.map { |k, v| "#{k}=\"#{v}\"" }.join(" ").html_safe %>>
+                <span class="<%= line_num_class %>"><%= index + 1 %></span>
+                <%
+                  styled = ERB::Util.html_escape(line)
+                    .gsub(/(\/[\w\/.~-]+)/, '<span class="text-blue-300">\1</span>')
+                    .gsub(/(\d+\.\d+s|\d{2}:\d{2}:\d{2})/, '<span class="text-yellow-300">\1</span>')
+                %>
+                <span class="flex-1 text-blue-400 min-w-0 break-all overflow-hidden"><%= raw(styled) %></span>
+              </div>
+
+            <% elsif line =~ /\d+%\|\s+\|\s+\d+\/\d+/ %>
+              <div class="<%= row_class %> progress-line opacity-60" <%= row_attrs.map { |k, v| "#{k}=\"#{v}\"" }.join(" ").html_safe %>>
+                <span class="<%= line_num_class %>"><%= index + 1 %></span>
+                <span class="flex-1 text-contentTertiary min-w-0 break-all overflow-hidden"><%= line %></span>
+              </div>
+
+            <% elsif line =~ /^detectors\./ %>
+              <div class="<%= row_class %> detector-line" <%= row_attrs.map { |k, v| "#{k}=\"#{v}\"" }.join(" ").html_safe %>>
+                <span class="<%= line_num_class %>"><%= index + 1 %></span>
+                <span class="flex-1 text-white min-w-0 break-all overflow-hidden"><%= raw(ERB::Util.html_escape(line).gsub(/^(detectors\.\w+):/, '<span class="text-yellow-400">\1</span>:')) %></span>
+              </div>
+
+            <% elsif line =~ /^\w+\.\w/ %>
+              <div class="<%= row_class %> module-line" <%= row_attrs.map { |k, v| "#{k}=\"#{v}\"" }.join(" ").html_safe %>>
+                <span class="<%= line_num_class %>"><%= index + 1 %></span>
+                <span class="flex-1 text-contentSecondary min-w-0 break-all overflow-hidden"><%= raw(ERB::Util.html_escape(line).gsub(/^(\w+\.\w+)/, '<span class="text-cyan-400">\1</span>')) %></span>
+              </div>
+
+            <% elsif line.strip.empty? %>
+              <div class="<%= row_class %> h-1" <%= row_attrs.map { |k, v| "#{k}=\"#{v}\"" }.join(" ").html_safe %>>
+                <span class="<%= line_num_class %>"><%= index + 1 %></span>
+              </div>
+
+            <% else %>
+              <div class="<%= row_class %>" <%= row_attrs.map { |k, v| "#{k}=\"#{v}\"" }.join(" ").html_safe %>>
+                <span class="<%= line_num_class %>"><%= index + 1 %></span>
+                <%
+                  styled = ERB::Util.html_escape(line)
+                    .gsub(/(ERROR|WARNING|INFO)/, '<span class="text-red-400">\1</span>')
+                    .gsub(/(https?:\/\/[^\s]+)/, '<span class="text-blue-400 underline">\1</span>')
+                %>
+                <span class="flex-1 text-green-300 min-w-0 break-all overflow-hidden"><%= raw(styled) %></span>
+              </div>
+            <% end %>
+          <% end %>
+
+          <p class="text-contentSecondary font-sans text-sm py-4 text-center"
+             data-debug-stream-filter-target="emptyState"
+             hidden>
+            No matching activity.
+          </p>
+        </div>
+      </div>
+
+      <div class="px-4 py-3 bg-zinc-900 border-t border-zinc-800 rounded-b-lg">
+        <div class="flex items-center justify-between">
+          <div class="flex items-center space-x-2">
+            <span class="text-xs font-sans text-contentSecondary">Shown lines:</span>
+            <span class="text-sm font-sans font-semibold text-white bg-zinc-800 px-2 py-0.5 rounded"><%= log_lines.count %></span>
+          </div>
+          <div class="flex items-center gap-2">
+            <button type="button"
+                    class="text-xs font-sans text-contentTertiary hover:text-white px-2 py-1 bg-zinc-800 hover:bg-zinc-700 rounded transition-colors"
+                    data-action="click->log-viewer#filter"
+                    data-filter-type="pass">
+              Show PASS
+            </button>
+            <button type="button"
+                    class="text-xs font-sans text-contentTertiary hover:text-white px-2 py-1 bg-zinc-800 hover:bg-zinc-700 rounded transition-colors"
+                    data-action="click->log-viewer#filter"
+                    data-filter-type="fail">
+              Show FAIL
+            </button>
+            <button type="button"
+                    class="text-xs font-sans text-contentTertiary hover:text-white px-2 py-1 bg-zinc-800 hover:bg-zinc-700 rounded transition-colors"
+                    data-action="click->log-viewer#resetFilter">
+              Reset
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% else %>
+  <p class="text-contentSecondary font-sans text-sm py-4">No logs available.</p>
+<% end %>

--- a/app/views/admin/reports/_debug_panel.html.erb
+++ b/app/views/admin/reports/_debug_panel.html.erb
@@ -1,0 +1,59 @@
+<% payload = local_assigns[:payload] || Reports::DebugStreamPayload.new(report).call %>
+
+<div id="report-debug-panel" class="bg-zinc-900 overflow-hidden">
+  <div class="px-4 py-3 border-b border-zinc-700">
+    <div class="flex items-center gap-2">
+      <span class="icon icon-sm icon-signal text-yellow-400"></span>
+      <div class="min-w-0">
+        <h2 class="text-lg font-sans font-semibold text-primary tracking-wide">Activity Stream</h2>
+        <p class="text-xs font-sans text-contentSecondary">Debug Stream · Timeline, JSONL, Logs</p>
+      </div>
+    </div>
+  </div>
+
+  <div data-controller="debug-tabs debug-stream-filter"
+       data-debug-tabs-storage-key-value="report-debug-tab-<%= report.id %>"
+       data-action="log-viewer:filter-change->debug-stream-filter#updateEmptyStates log-viewer:reset->debug-stream-filter#clearQuery">
+    <div class="px-4 pt-3">
+      <label for="debug-stream-filter-<%= report.id %>" class="sr-only">Filter activity</label>
+      <div class="relative">
+        <span class="icon icon-xs icon-search absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500"></span>
+        <input id="debug-stream-filter-<%= report.id %>"
+               type="search"
+               placeholder="Filter probes, prompts, detectors…"
+               autocomplete="off"
+               class="w-full rounded-lg border border-zinc-700 bg-zinc-950 py-2 pl-8 pr-3 text-sm font-sans text-primary placeholder:text-contentTertiary focus:border-yellow-500 focus:outline-none focus:ring-1 focus:ring-yellow-500"
+               data-debug-stream-filter-target="query"
+               data-action="input->debug-stream-filter#filter">
+      </div>
+    </div>
+
+    <nav class="flex gap-1 px-4 pt-3" aria-label="Debug tabs">
+      <button type="button"
+              class="px-3 py-1.5 text-xs font-sans font-medium rounded-t transition-colors bg-zinc-800 text-white"
+              data-action="click->debug-tabs#switch"
+              data-debug-tabs-target="tab"
+              data-tab="timeline">
+        <span class="icon icon-xs icon-clock mr-1"></span>Timeline
+      </button>
+      <button type="button"
+              class="px-3 py-1.5 text-xs font-sans font-medium rounded-t transition-colors text-zinc-400 hover:text-zinc-200"
+              data-action="click->debug-tabs#switch"
+              data-debug-tabs-target="tab"
+              data-tab="raw">
+        <span class="icon icon-xs icon-code mr-1"></span>Raw JSONL
+      </button>
+      <button type="button"
+              class="px-3 py-1.5 text-xs font-sans font-medium rounded-t transition-colors text-zinc-400 hover:text-zinc-200"
+              data-action="click->debug-tabs#switch"
+              data-debug-tabs-target="tab"
+              data-tab="logs">
+        <span class="icon icon-xs icon-document mr-1"></span>Execution Logs
+      </button>
+    </nav>
+
+    <div class="px-4 pb-4">
+      <%= render partial: "admin/reports/debug_panel_stream", locals: { report: report, payload: payload } %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/reports/_debug_panel_stream.html.erb
+++ b/app/views/admin/reports/_debug_panel_stream.html.erb
@@ -1,0 +1,44 @@
+<% payload = local_assigns[:payload] || Reports::DebugStreamPayload.new(report).call %>
+<% activity = payload[:activity] || {} %>
+<% updated_at = activity[:updated_at] %>
+
+<div id="report-debug-stream-content">
+  <div class="debug-stream-metadata mb-3 mt-3 rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-2">
+    <div class="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs font-sans text-contentSecondary">
+      <% if activity[:active] %>
+        <span class="inline-flex items-center gap-1 rounded-full border border-green-400/40 bg-green-500/10 px-2 py-0.5 font-semibold uppercase tracking-wide text-green-300">
+          <span class="h-1.5 w-1.5 rounded-full bg-green-400"></span>
+          LIVE
+        </span>
+      <% end %>
+
+      <span class="inline-flex items-center gap-1">
+        <span class="icon icon-xs icon-document text-zinc-500"></span>
+        <%= pluralize(activity[:entry_count].to_i, "entry") %>
+      </span>
+
+      <span class="inline-flex items-center gap-1">
+        <span class="icon icon-xs icon-clock text-zinc-500"></span>
+        <% if updated_at.present? %>
+          updated <%= time_ago_in_words(updated_at) %> ago
+        <% elsif report.raw_report_data.present? %>
+          updated <%= time_ago_in_words(report.raw_report_data.updated_at) %> ago
+        <% else %>
+          no activity yet
+        <% end %>
+      </span>
+    </div>
+  </div>
+
+  <div data-debug-tabs-target="panel" data-tab="timeline">
+    <%= render partial: "admin/reports/debug_timeline", locals: { timeline: payload[:timeline] } %>
+  </div>
+
+  <div data-debug-tabs-target="panel" data-tab="raw" class="hidden">
+    <%= render partial: "admin/reports/debug_raw_jsonl", locals: { raw_tail: payload[:raw_tail] } %>
+  </div>
+
+  <div data-debug-tabs-target="panel" data-tab="logs" class="hidden">
+    <%= render partial: "admin/reports/debug_execution_logs", locals: { logs: payload[:logs], metadata: payload[:log_metadata] } %>
+  </div>
+</div>

--- a/app/views/admin/reports/_debug_raw_jsonl.html.erb
+++ b/app/views/admin/reports/_debug_raw_jsonl.html.erb
@@ -1,0 +1,27 @@
+<% if raw_tail.blank? %>
+  <p class="text-contentSecondary font-sans text-sm py-4">No raw data available.</p>
+<% else %>
+  <% raw_lines = raw_tail.to_s.lines %>
+  <div class="bg-zinc-950 p-4 overflow-auto max-h-[60vh] rounded-lg">
+    <div class="font-mono text-xs text-green-300 break-all"
+         data-debug-stream-filter-target="group">
+      <% raw_lines.each_with_index do |line, index| %>
+        <div class="debug-stream-row raw-jsonl-line py-0.5 px-1 flex items-start hover:bg-zinc-800/50 rounded relative group min-w-0"
+             data-debug-stream-filter-target="row"
+             data-debug-stream-filter-match="true">
+          <span class="text-zinc-500 w-8 inline-block text-right mr-2 select-none opacity-50 group-hover:opacity-100 shrink-0"><%= index + 1 %></span>
+          <span class="flex-1 whitespace-pre-wrap min-w-0 break-all overflow-hidden"><%= line %></span>
+        </div>
+      <% end %>
+
+      <p class="text-contentSecondary font-sans text-sm py-4 text-center"
+         data-debug-stream-filter-target="emptyState"
+         hidden>
+        No matching activity.
+      </p>
+    </div>
+  </div>
+  <div class="px-4 py-2 text-xs text-zinc-500 font-sans">
+    Showing last <%= Reports::DebugStreamPayload::RAW_TAIL_LINES %> lines
+  </div>
+<% end %>

--- a/app/views/admin/reports/_debug_timeline.html.erb
+++ b/app/views/admin/reports/_debug_timeline.html.erb
@@ -1,0 +1,82 @@
+<% if timeline.blank? %>
+  <p class="text-contentSecondary font-sans text-sm py-4">No events yet.</p>
+<% else %>
+  <div class="space-y-2 max-h-[60vh] overflow-auto" data-debug-stream-filter-target="group">
+    <% timeline.each_with_index do |entry, idx| %>
+      <div class="debug-stream-row flex items-start gap-3 py-2 px-3 rounded-lg hover:bg-zinc-800/50 font-mono text-xs"
+           data-debug-stream-filter-target="row"
+           data-debug-stream-filter-match="true">
+        <span class="text-zinc-500 w-6 text-right shrink-0 select-none"><%= idx + 1 %></span>
+
+        <% case entry[:type] %>
+        <% when "init" %>
+          <span class="icon icon-xs icon-play text-green-400 mt-0.5 shrink-0"></span>
+          <div>
+            <span class="text-green-400 font-semibold">INIT</span>
+            <% if entry[:start_time].present? %>
+              <span class="text-zinc-400 ml-2"><%= entry[:start_time] %></span>
+            <% end %>
+          </div>
+
+        <% when "attempt" %>
+          <span class="icon icon-xs icon-arrow-right text-blue-400 mt-0.5 shrink-0"></span>
+          <div class="min-w-0">
+            <span class="text-blue-400 font-semibold">ATTEMPT</span>
+            <% if entry[:probe].present? %>
+              <span class="text-cyan-400 ml-2"><%= entry[:probe] %></span>
+            <% end %>
+            <% if entry[:prompt_preview].present? %>
+              <div class="text-zinc-400 mt-1 break-all">Prompt: <span class="text-zinc-300"><%= entry[:prompt_preview] %></span></div>
+            <% end %>
+            <% if entry[:output_preview].present? %>
+              <div class="text-zinc-400 mt-0.5 break-all">Output: <span class="text-zinc-300"><%= entry[:output_preview] %></span></div>
+            <% end %>
+          </div>
+
+        <% when "eval" %>
+          <span class="icon icon-xs icon-check text-yellow-400 mt-0.5 shrink-0"></span>
+          <div>
+            <span class="text-yellow-400 font-semibold">EVAL</span>
+            <% if entry[:probe].present? %>
+              <span class="text-cyan-400 ml-2"><%= entry[:probe] %></span>
+            <% end %>
+            <% if entry[:detector].present? %>
+              <span class="text-zinc-400 ml-1">&rarr; <%= entry[:detector] %></span>
+            <% end %>
+            <% if entry[:passed].present? && entry[:total].present? %>
+              <span class="text-zinc-300 ml-2"><%= entry[:passed] %>/<%= entry[:total] %></span>
+            <% end %>
+          </div>
+
+        <% when "completion" %>
+          <span class="icon icon-xs icon-check-circle text-green-400 mt-0.5 shrink-0"></span>
+          <div>
+            <span class="text-green-400 font-semibold">COMPLETE</span>
+            <% if entry[:end_time].present? %>
+              <span class="text-zinc-400 ml-2"><%= entry[:end_time] %></span>
+            <% end %>
+          </div>
+
+        <% when "_parse_error" %>
+          <span class="icon icon-xs icon-exclamation-triangle text-red-400 mt-0.5 shrink-0"></span>
+          <div class="min-w-0">
+            <span class="text-red-400 font-semibold">PARSE ERROR</span>
+            <div class="text-zinc-500 mt-0.5 break-all"><%= entry[:raw] %></div>
+          </div>
+
+        <% else %>
+          <span class="icon icon-xs icon-question text-zinc-500 mt-0.5 shrink-0"></span>
+          <div>
+            <span class="text-zinc-400 font-semibold"><%= entry[:type]&.upcase %></span>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <p class="text-contentSecondary font-sans text-sm py-4 text-center"
+       data-debug-stream-filter-target="emptyState"
+       hidden>
+      No matching activity.
+    </p>
+  </div>
+<% end %>

--- a/app/views/admin/reports/_logs_section.html.erb
+++ b/app/views/admin/reports/_logs_section.html.erb
@@ -1,140 +1,18 @@
-<% if report.logs.present? %>
-  <div class="bg-zinc-900 rounded-lg border border-zinc-700 overflow-hidden">
-    <button
-      class="w-full px-4 py-3 flex items-center justify-between cursor-pointer hover:bg-zinc-800/50 transition-colors duration-200"
-      data-action="click->report-redesigned#toggleLogs">
-      <h2 class="text-xl font-sans font-semibold text-primary tracking-wide">
-        Execution Logs
-      </h2>
-      <span
-        data-report-redesigned-target="logsChevron"
-        class="icon icon-sm icon-chevron-down text-zinc-400 transition-transform duration-200 rotate-180"></span>
-    </button>
+<% lease_url = local_assigns[:lease_url] %>
+<% active_stream = activity_stream_active_status_for_report?(report) %>
+<% payload = Reports::DebugStreamPayload.new(report).call %>
+<% lease_data = if lease_url.present? && active_stream
+  {
+    controller: "debug-stream-lease",
+    debug_stream_lease_url_value: lease_url,
+    debug_stream_lease_interval_value: 30_000
+  }
+end %>
 
-    <div data-report-redesigned-target="logsContent" class="px-4 pb-4">
-      <div class="relative" data-controller="log-viewer">
-        <div class="absolute top-0 right-0 mt-4 mr-4 z-10">
-          <input type="text"
-                 placeholder="Search logs..."
-                 class="px-3 py-1.5 text-xs bg-zinc-800 text-white border border-zinc-600 rounded-lg w-48 focus:outline-none focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500"
-                 data-log-viewer-target="search"
-                 data-action="input->log-viewer#search" />
-        </div>
+<%= tag.div data: lease_data do %>
+  <% if active_stream %>
+    <%= turbo_stream_from Reports::DebugWatcher.stream_name(report) %>
+  <% end %>
 
-        <div class="bg-zinc-950 p-4 pt-14 overflow-auto max-h-[60vh] rounded-lg mt-3">
-          <div class="font-mono text-xs break-all" data-log-viewer-target="content">
-          <% report.logs.lines.each_with_index do |line, index| %>
-            <%
-              line_class = "py-0.5 px-1 flex items-start hover:bg-zinc-800/50 rounded relative group min-w-0"
-              line_num_class = "text-zinc-500 w-8 inline-block text-right mr-2 select-none opacity-50 group-hover:opacity-100 shrink-0"
-            %>
-
-            <% if line =~ /\[1m\[91mFAIL\[0m/ %>
-              <div class="<%= line_class %> log-line fail-line">
-                <span class="<%= line_num_class %>"><%= index + 1 %></span>
-                <%
-                  styled_line = ERB::Util.html_escape(line)
-                    .gsub(/\[1m\[91mFAIL\[0m/, '<span class="font-bold text-red-400">FAIL</span>')
-                    .gsub(/\[91mfailure rate:.+?\]/, '<span class="text-red-300">\0</span>')
-                    .gsub(/ok on\s+(\d+)\/\s*(\d+)/, 'ok on <span class="text-blue-400">\1</span>/<span class="text-blue-300">\2</span>')
-                    .gsub(/^(.+?)\s+(\w+\.)/, '<span class="text-orange-400">\1</span> \2')
-                %>
-                <span class="flex-1 min-w-0 break-all overflow-hidden"><%= raw(styled_line) %></span>
-              </div>
-
-            <% elsif line =~ /\[1m\[92mPASS\[0m/ %>
-              <div class="<%= line_class %> log-line pass-line">
-                <span class="<%= line_num_class %>"><%= index + 1 %></span>
-                <%
-                  styled_line = ERB::Util.html_escape(line)
-                    .gsub(/\[1m\[92mPASS\[0m/, '<span class="font-bold text-green-400">PASS</span>')
-                    .gsub(/ok on\s+(\d+)\/\s*(\d+)/, 'ok on <span class="text-blue-400">\1</span>/<span class="text-blue-300">\2</span>')
-                    .gsub(/^(.+?)\s+(\w+\.)/, '<span class="text-orange-400">\1</span> \2')
-                %>
-                <span class="flex-1 min-w-0 break-all overflow-hidden"><%= raw(styled_line) %></span>
-              </div>
-
-            <% elsif line =~ /^📜|^🕵️|^🦜|^✔️/ %>
-              <div class="<%= line_class %> log-line emoji-line">
-                <span class="<%= line_num_class %>"><%= index + 1 %></span>
-                <%
-                  styled_line = ERB::Util.html_escape(line)
-                    .gsub(/(\/[\w\/.~-]+)/, '<span class="text-blue-300">\1</span>')
-                    .gsub(/(\d+\.\d+s|\d{2}:\d{2}:\d{2})/, '<span class="text-yellow-300">\1</span>')
-                %>
-                <span class="flex-1 text-blue-400 min-w-0 break-all overflow-hidden"><%= raw(styled_line) %></span>
-              </div>
-
-            <% elsif line =~ /\d+%\|\s+\|\s+\d+\/\d+/ %>
-              <div class="<%= line_class %> log-line progress-line opacity-60">
-                <span class="<%= line_num_class %>"><%= index + 1 %></span>
-                <span class="flex-1 text-contentTertiary min-w-0 break-all overflow-hidden"><%= line %></span>
-              </div>
-
-            <% elsif line =~ /^\w+\.\w/ %>
-              <div class="<%= line_class %> log-line module-line">
-                <span class="<%= line_num_class %>"><%= index + 1 %></span>
-                <span class="flex-1 text-contentSecondary min-w-0 break-all overflow-hidden"><%= raw(ERB::Util.html_escape(line).gsub(/^(\w+\.\w+)/, '<span class="text-cyan-400">\1</span>')) %></span>
-              </div>
-
-            <% elsif line =~ /^detectors\./ %>
-              <div class="<%= line_class %> log-line detector-line">
-                <span class="<%= line_num_class %>"><%= index + 1 %></span>
-                <span class="flex-1 text-white min-w-0 break-all overflow-hidden"><%= raw(ERB::Util.html_escape(line).gsub(/^(detectors\.\w+):/, '<span class="text-yellow-400">\1</span>:')) %></span>
-              </div>
-
-            <% elsif line.strip.empty? %>
-              <div class="h-1">
-                <span class="<%= line_num_class %>"><%= index + 1 %></span>
-              </div>
-
-            <% else %>
-              <div class="<%= line_class %> log-line">
-                <span class="<%= line_num_class %>"><%= index + 1 %></span>
-                <%
-                  styled_line = ERB::Util.html_escape(line)
-                    .gsub(/(ERROR|WARNING|INFO)/, '<span class="text-red-400">\1</span>')
-                    .gsub(/(https?:\/\/[^\s]+)/, '<span class="text-blue-400 underline">\1</span>')
-                %>
-                <span class="flex-1 text-green-300 min-w-0 break-all overflow-hidden"><%= raw(styled_line) %></span>
-              </div>
-            <% end %>
-          <% end %>
-        </div>
-      </div>
-
-        <div class="px-4 py-3 bg-zinc-900 border-t border-zinc-800 rounded-b-lg">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center space-x-2">
-              <span class="text-xs font-sans text-contentSecondary">Total lines:</span>
-              <span class="text-sm font-sans font-semibold text-white bg-zinc-800 px-2 py-0.5 rounded"><%= report.logs.lines.count %></span>
-            </div>
-            <div class="flex items-center gap-2">
-              <button type="button"
-                      class="text-xs font-sans text-contentTertiary hover:text-white px-2 py-1 bg-zinc-800 hover:bg-zinc-700 rounded transition-colors"
-                      data-action="click->log-viewer#filter"
-                      data-filter-type="pass">
-                Show PASS
-              </button>
-              <button type="button"
-                      class="text-xs font-sans text-contentTertiary hover:text-white px-2 py-1 bg-zinc-800 hover:bg-zinc-700 rounded transition-colors"
-                      data-action="click->log-viewer#filter"
-                      data-filter-type="fail">
-                Show FAIL
-              </button>
-              <button type="button"
-                      class="text-xs font-sans text-contentTertiary hover:text-white px-2 py-1 bg-zinc-800 hover:bg-zinc-700 rounded transition-colors"
-                      data-action="click->log-viewer#resetFilter">
-                Reset
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-<% else %>
-  <div class="bg-zinc-900 rounded-lg border border-zinc-700 p-4">
-    <p class="text-contentSecondary font-sans text-sm">No logs available</p>
-  </div>
+  <%= render partial: "admin/reports/activity_stream_card", locals: { report: report, payload: payload } %>
 <% end %>

--- a/app/views/admin/reports/_show_v2.html.erb
+++ b/app/views/admin/reports/_show_v2.html.erb
@@ -33,8 +33,9 @@
 
       <%= render partial: 'admin/reports/statistics_section', locals: { report: report } %>
 
-      <% if params[:debug] == 'true' %>
-        <%= render partial: 'admin/reports/logs_section', locals: { report: report } %>
+      <% if show_activity_stream_for_report?(report, params: params, user: current_user) %>
+        <%= render partial: 'admin/reports/logs_section',
+                   locals: { report: report, lease_url: refresh_debug_lease_report_path(report) } %>
       <% end %>
     </div>
   </div>

--- a/app/views/report_details/show.html.erb
+++ b/app/views/report_details/show.html.erb
@@ -419,9 +419,10 @@
     <% end %>
   </div>
 
-  <% if params[:debug] == 'true' && !pdf_mode %>
+  <% if show_activity_stream_for_report?(@report, params: params, user: current_user, pdf_mode: pdf_mode) %>
     <div class="<%= pdf_mode ? 'px-6 py-4' : 'px-8 py-6' %>">
-      <%= render partial: 'admin/reports/logs_section', locals: { report: @report } %>
+      <%= render partial: 'admin/reports/logs_section',
+                 locals: { report: @report, lease_url: refresh_debug_lease_report_detail_path(@report) } %>
     </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
         get :top_probes
         get :probes_tab
         get :attempt_content
+        post :refresh_debug_lease
       end
       collection do
         post :batch
@@ -108,6 +109,7 @@ Rails.application.routes.draw do
     member do
       get :pdf
       post :pdf_retry
+      post :refresh_debug_lease
     end
   end
 

--- a/db/migrate/20260427000000_create_report_debug_logs_and_move_report_logs.rb
+++ b/db/migrate/20260427000000_create_report_debug_logs_and_move_report_logs.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class CreateReportDebugLogsAndMoveReportLogs < ActiveRecord::Migration[8.1]
+  def up
+    create_table :report_debug_logs do |t|
+      t.references :report, null: false, foreign_key: { on_delete: :cascade }, index: { unique: true }
+      t.text :logs
+      t.text :tail
+      t.bigint :tail_offset, null: false, default: 0
+      t.string :tail_digest
+      t.datetime :tail_synced_at
+      t.boolean :tail_truncated, null: false, default: false
+
+      t.timestamps
+    end
+
+    backfill_report_logs if column_exists?(:reports, :logs)
+    remove_column :reports, :logs if column_exists?(:reports, :logs)
+  end
+
+  def down
+    add_column :reports, :logs, :text unless column_exists?(:reports, :logs)
+    restore_report_logs if table_exists?(:report_debug_logs)
+    drop_table :report_debug_logs if table_exists?(:report_debug_logs)
+  end
+
+  private
+
+  def backfill_report_logs
+    execute <<~SQL.squish
+      INSERT INTO report_debug_logs (report_id, logs, created_at, updated_at)
+      SELECT id, logs, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      FROM reports
+      WHERE logs IS NOT NULL AND BTRIM(logs) <> ''
+    SQL
+  end
+
+  def restore_report_logs
+    execute <<~SQL.squish
+      UPDATE reports
+      SET logs = report_debug_logs.logs
+      FROM report_debug_logs
+      WHERE report_debug_logs.report_id = reports.id
+        AND report_debug_logs.logs IS NOT NULL
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_193602) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_27_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -248,6 +248,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_193602) do
     t.index ["report_id"], name: "index_raw_report_data_on_report_id", unique: true
   end
 
+  create_table "report_debug_logs", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "logs"
+    t.bigint "report_id", null: false
+    t.text "tail"
+    t.string "tail_digest"
+    t.bigint "tail_offset", default: 0, null: false
+    t.datetime "tail_synced_at"
+    t.boolean "tail_truncated", default: false, null: false
+    t.datetime "updated_at", null: false
+    t.index ["report_id"], name: "index_report_debug_logs_on_report_id", unique: true
+  end
+
   create_table "report_pdfs", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "downloaded_at"
@@ -277,7 +290,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_193602) do
     t.datetime "end_time"
     t.datetime "heartbeat_at"
     t.datetime "last_retry_at"
-    t.text "logs"
     t.string "name", null: false
     t.integer "parent_report_id"
     t.integer "pid"
@@ -464,6 +476,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_193602) do
   add_foreign_key "probes_techniques", "probes"
   add_foreign_key "probes_techniques", "techniques"
   add_foreign_key "raw_report_data", "reports", on_delete: :cascade
+  add_foreign_key "report_debug_logs", "reports", on_delete: :cascade
   add_foreign_key "report_pdfs", "reports"
   add_foreign_key "reports", "companies"
   add_foreign_key "reports", "reports", column: "parent_report_id"

--- a/docs-site/docs/deployment/upgrading.md
+++ b/docs-site/docs/deployment/upgrading.md
@@ -57,6 +57,16 @@ Or check the GitHub [releases page](https://github.com/0din-ai/ai-scanner/releas
 docker compose exec postgres pg_dump -U scanner scanner_production > backup_$(date +%Y%m%d).sql
 ```
 
+## Report Log Storage Migration
+
+Recent versions store report execution logs in `report_debug_logs` instead of `reports.logs`. The migration backfills existing final logs into `report_debug_logs.logs` and stores live debug tails in `report_debug_logs.tail`. Run migrations after upgrading:
+
+```bash
+docker compose exec scanner rails db:migrate
+```
+
+Rails callers should continue to use `Report#logs`. Direct SQL/reporting integrations must join `report_debug_logs` and read `report_debug_logs.logs` after this migration because the legacy `reports.logs` column is removed. Rolling the migration back restores final logs to `reports.logs`; transient live tails are not preserved on rollback.
+
 ## Rollback
 
 If an upgrade causes issues:

--- a/docs-site/docs/development/architecture.md
+++ b/docs-site/docs/development/architecture.md
@@ -36,10 +36,13 @@ graph TD
     SQ --> Garak
 
     subgraph Garak["garak subprocess"]
-        GarakProcess["garak\n(Python, Unix socket)"]
+        GarakProcess["garak\n(Python runner)"]
+        JournalSync["JournalSyncThread\n(JSONL + log tail sync)"]
     end
 
     GarakProcess --> AI
+    GarakProcess --> JournalSync
+    JournalSync --> Primary
     SQ --> SIEM
 ```
 
@@ -51,9 +54,11 @@ Puma and Solid Queue run in the same container process. This simplifies deployme
 
 ### garak as a Subprocess
 
-[NVIDIA garak](https://github.com/NVIDIA/garak) is a Python library. Scanner invokes it as a separate process and communicates via a Unix socket. This isolates Python dependency management from the Rails app and lets garak run with its own environment.
+[NVIDIA garak](https://github.com/NVIDIA/garak) is a Python library. Scanner invokes it as a separate process so Python dependency management stays isolated from the Rails app and garak can run with its own environment.
 
-The `RunGarakScan` service class manages the garak subprocess lifecycle. Scan results are streamed back through the socket and written to the database in real time.
+The `RunGarakScan` service class starts `script/run_garak.py` and passes the report UUID plus execution-log path. The Python runner writes JSONL progress to disk while `JournalSyncThread` syncs progress into `raw_report_data` and bounded execution-log tails into `report_debug_logs`. When processing completes, `Reports::Process` promotes final logs into `report_debug_logs.logs`; `Report#logs` remains a compatibility accessor for existing Rails callers.
+
+Pending, starting, running, and processing report pages show Activity Stream automatically for authenticated users. The mounted lease controller refreshes a short Rails-cache watcher lease, and `BroadcastReportDebugJob` polls watched active reports and publishes Turbo Stream updates when the rendered debug payload changes. Select **View activity** to expand timeline entries, the raw JSONL tail, and execution logs. Terminal reports can still expose final execution logs with the optional `?debug=true` troubleshooting fallback.
 
 ### Multi-Database PostgreSQL
 

--- a/docs-site/docs/development/testing.md
+++ b/docs-site/docs/development/testing.md
@@ -30,6 +30,13 @@ Without `RAILS_ENV=test`, RSpec will run against the development database.
 ## Static Analysis
 
 ```bash
+# Python notifier/runner tests
+python3 -m unittest discover -s script/tests
+python3 -m py_compile script/db_notifier.py script/run_garak.py
+
+# Stimulus controller tests
+npm run test:js
+
 # Security scan (Brakeman)
 bundle exec brakeman
 
@@ -78,7 +85,7 @@ Stub garak execution in tests to avoid real subprocess calls:
 allow_any_instance_of(RunGarakScan).to receive(:call)
 ```
 
-To test with mock Unix socket communication, see the existing scan job specs for patterns.
+For live progress and execution-log behavior, mock `JournalSyncThread` and database notifier behavior rather than local socket communication.
 
 ## Test Factories
 

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -133,6 +133,8 @@ docker compose exec scanner rails db:migrate
 docker compose logs scanner | grep -i "interrupt\|retry"
 ```
 
+For per-report execution details, open the report while it is pending, starting, running, or processing. Activity Stream appears automatically for authenticated users; select **View activity** to expand timeline entries, the raw JSONL tail, and execution logs. Running scans show a bounded live log tail from the database, including offset, truncation, and last-updated metadata. For terminal reports, `?debug=true` remains an optional troubleshooting fallback for final execution logs.
+
 ---
 
 ## SIEM Integration Issues

--- a/docs-site/docs/user-guide/environment-variables.md
+++ b/docs-site/docs/user-guide/environment-variables.md
@@ -46,6 +46,7 @@ See [Database Configuration](../deployment/database) for `DATABASE_URL` format a
 |---|---|---|
 | `EVALUATION_THRESHOLD` | `0.2` | Controls vulnerability detection strictness. Lower = stricter. |
 | `RETENTION_DAYS` | `90` | Days to keep reports before automatic deletion. |
+| `DEBUG_LOG_TAIL_BYTES` | `131072` | Maximum bytes synced into live report execution-log tails. Set to `0` to disable live-tail reads. Blank, non-integer, or negative values fall back to the default. This is read by the Python runner at startup, applies globally, and requires restarting Scanner after changes. |
 
 ### Logging
 

--- a/docs-site/docs/user-guide/reports.md
+++ b/docs-site/docs/user-guide/reports.md
@@ -6,6 +6,8 @@ sidebar_position: 4
 
 A report is generated after each completed scan. It contains the full results of every probe attempt made against your target.
 
+For troubleshooting queued or active reports, Activity Stream appears automatically for authenticated users while a report is pending, starting, running, or processing. Select **View activity** to expand timeline entries, the raw JSONL tail, and execution logs. Running scans display the live database-backed log tail; terminal reports can use the optional `?debug=true` fallback to show final logs. The log viewer supports search plus PASS/FAIL filters.
+
 ## Report Structure
 
 ### Summary

--- a/docs-site/docs/user-guide/scanning.md
+++ b/docs-site/docs/user-guide/scanning.md
@@ -37,6 +37,10 @@ While a scan runs, the progress view shows:
 
 You can navigate away — the scan continues in the background. Return to the scan page to check status.
 
+### Activity Stream
+
+Authenticated users see Activity Stream automatically on pending, starting, running, and processing report pages while troubleshooting a scan. Select **View activity** to expand timeline entries, the raw JSONL tail, and execution logs. Running scans show a database-backed live tail with offset, truncation, and last-updated metadata. Terminal reports can use the optional `?debug=true` fallback to show final execution logs. PDF rendering does not include Activity Stream.
+
 ## Parallel Attempts
 
 Each probe runs multiple attempts in parallel to improve coverage. The default is **16 parallel attempts**.

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -62,6 +62,8 @@ Environment variables allow you to securely configure API keys and system settin
 
 ## System Configuration Variables
 
+These variables are process-level settings from the root `.env` file or container environment. They are not managed through **Configuration** → **Environment Variables**, and changing them requires restarting Scanner.
+
 ### SESSION_COOKIE_DOMAIN
 - **Purpose**: Enables session cookie sharing across subdomains for WebSocket authentication
 - **When to use**: Required when `ACTION_CABLE_URL` uses a different subdomain than the main application
@@ -81,6 +83,15 @@ Environment variables allow you to securely configure API keys and system settin
 - **Default Value**: `0.2`
 - **Impact**: Lower values (e.g., 0.1) are more strict and will flag more potential issues
 - **Recommendation**: Start with default and adjust based on your security requirements
+
+### DEBUG_LOG_TAIL_BYTES
+- **Purpose**: Controls how many bytes of the garak execution log are synced into the live report debug log tail
+- **Default Value**: `131072`
+- **Location**: Root `.env` file or container environment; read by the Python runner process at startup
+- **Disable live tails**: Set to `0` to skip live-tail reads and database updates
+- **Invalid values**: Blank, non-integer, or negative values fall back to the default
+- **Impact**: Higher values show more live execution-log context while a scan is running; lower values reduce database write size
+- **Restart required**: Restart Scanner after changing this value
 
 ### PARALLEL_ATTEMPTS
 > **Note**: This setting has been moved to the Settings page (`/settings`). It is no longer managed as an Environment Variable.

--- a/docs/diagrams/architecture.mmd
+++ b/docs/diagrams/architecture.mmd
@@ -13,4 +13,9 @@ graph TD
   D --> E
   D --> F
   E --> F
+  E --> H[run_garak.py]
+  H --> I[raw_report_data JSONL]
+  H --> J[report_debug_logs live tails]
+  I --> F
+  J --> F
   F --> G

--- a/docs/plans/completed/2026-04-27-debug-stream-polling-performance.md
+++ b/docs/plans/completed/2026-04-27-debug-stream-polling-performance.md
@@ -1,0 +1,132 @@
+# Debug Stream Polling Performance and Activity Stream Implementation Plan
+
+## Overview
+
+Implement the debug stream performance fix and remove `?debug=true` as the normal requirement for live Activity Stream visibility in ai-scanner.
+
+Keep the implementation public-friendly for the open-source ai-scanner repo: no committed private paths, internal PR references, or private deployment-only wording in production code/docs.
+
+## Context
+
+Current ai-scanner behavior:
+- `Reports::DebugStreamPayload.new(report).call` hydrates `report.raw_report_data` and parses `raw_report_data.jsonl_data`.
+- `BroadcastReportDebugJob` runs every 10 seconds for watched polling-status reports and builds the full payload before it knows whether JSONL/log inputs changed.
+- Admin and report-details pages still require `params[:debug] == 'true'` to render logs/debug stream.
+
+Behavior to implement in ai-scanner:
+- `app/helpers/reports_helper.rb` has `activity_stream_active_status_for_report?` and `show_activity_stream_for_report?`.
+- Active/pending reports show an Activity Stream without `?debug=true`.
+- Timeline / Raw JSONL / Execution Logs are collapsed behind a “View activity” button.
+- PDF mode does not show the stream.
+- Show actions do not start watcher leases directly from `params[:debug]`; the mounted lease controller calls `refresh_debug_lease` on connect.
+
+Important ai-scanner adaptation:
+- Do not copy stricter `user&.super_admin?` semantics from external references blindly. ai-scanner currently allows authenticated same-company users to access the debug stream routes. Use `user.present?` plus existing authorization unless an existing ai-scanner policy indicates a stricter rule.
+- Do not implement the optional Phase 2 JSONL offset/snapshot schema change unless Phase 1 cannot pass tests. The intended implementation is no-schema-change fingerprint gating.
+
+## Success Criteria
+
+Active/pending admin and report-details pages render Activity Stream without `?debug=true`; advanced details stay collapsed by default; PDF mode stays excluded; watched report polling skips payload construction when scalar metadata is unchanged; focused specs pass.
+
+## Validation Commands
+
+Run focused tests after implementation:
+
+```bash
+RAILS_ENV=test bundle exec rspec \
+  spec/services/reports/debug_stream_fingerprint_spec.rb \
+  spec/services/reports/debug_stream_payload_spec.rb \
+  spec/jobs/broadcast_report_debug_job_spec.rb \
+  spec/requests/report_debug_stream_spec.rb
+```
+
+Run targeted RuboCop:
+
+```bash
+bundle exec rubocop \
+  app/services/reports/debug_stream_fingerprint.rb \
+  app/services/reports/debug_stream_payload.rb \
+  app/jobs/broadcast_report_debug_job.rb \
+  app/helpers/reports_helper.rb \
+  spec/services/reports/debug_stream_fingerprint_spec.rb \
+  spec/services/reports/debug_stream_payload_spec.rb \
+  spec/jobs/broadcast_report_debug_job_spec.rb \
+  spec/requests/report_debug_stream_spec.rb
+```
+
+If host DB cannot resolve `postgres`, use a disposable local Postgres or the ai-scanner dev-container testing workflow.
+
+### Task 1: Add metadata-only debug stream fingerprints
+
+- [x] Create `app/services/reports/debug_stream_fingerprint.rb`.
+- [x] Implement a service returning `nil` when the report is missing and otherwise returning a hash with scalar metadata and `:digest`.
+- [x] Query `reports`, `raw_report_data`, and `report_debug_logs` with `LEFT JOIN`s without selecting `raw_report_data.jsonl_data`, `report_debug_logs.logs`, or `report_debug_logs.tail`.
+- [x] Include status, report updated timestamp, raw row updated timestamp, optional `octet_length(raw_report_data.jsonl_data)` as `raw_jsonl_bytes`, tail offset, tail digest, tail synced timestamp, and tail truncated state.
+- [x] Exclude plain `report_debug_logs.updated_at` from the digest if tail metadata is otherwise unchanged, so timestamp-only touches do not force payload rebuilds.
+- [x] Add `spec/services/reports/debug_stream_fingerprint_spec.rb` covering unchanged digest stability, raw JSONL changes, tail digest changes, missing raw data, missing debug log, and missing report.
+- [x] Run the new fingerprint spec and fix failures.
+
+### Task 2: Gate `BroadcastReportDebugJob` before payload construction
+
+- [x] Modify `app/jobs/broadcast_report_debug_job.rb` to compute `Reports::DebugStreamFingerprint` after report reload and before `Reports::DebugStreamPayload.new(report).call`.
+- [x] Add a cache key such as `broadcast_report_debug:fingerprint:#{report_id}`.
+- [x] If the current fingerprint digest equals the cached fingerprint, skip payload construction and broadcasting while preserving current re-enqueue behavior for watched polling-status reports.
+- [x] Write the cached fingerprint only after payload construction and broadcast-digest handling complete successfully.
+- [x] Keep the existing rendered payload digest comparison as a second-stage guard.
+- [x] Keep existing watcher, poller lease, and `limits_concurrency` behavior intact.
+- [x] Update `spec/jobs/broadcast_report_debug_job_spec.rb` to prove unchanged fingerprint does not instantiate/build `Reports::DebugStreamPayload`, but still re-enqueues polling reports.
+- [x] Update job specs proving raw JSONL changes and live-tail digest changes still broadcast.
+- [x] Preserve existing behavior for missing raw data/status-only activity and terminal reports.
+
+### Task 3: Memoize JSONL access inside `Reports::DebugStreamPayload`
+
+- [x] Modify `app/services/reports/debug_stream_payload.rb` so a single payload build reads `raw_report_data.jsonl_data` at most once.
+- [x] Add a private `jsonl_data` helper memoizing `raw_report_data&.jsonl_data.to_s`.
+- [x] Update `parse_jsonl` to use the memoized string instead of calling `raw_report_data.jsonl_data` repeatedly.
+- [x] Update `compute_digest` so it does not cause another raw JSONL read after parsing.
+- [x] Preserve malformed JSONL handling, bounded `RAW_TAIL_LINES`, bounded `TIMELINE_TAIL_LIMIT`, live-tail logs, full terminal logs, and activity summary behavior.
+- [x] Add/adjust `spec/services/reports/debug_stream_payload_spec.rb` to prove `jsonl_data` is called only once per `#call` and existing behavior remains unchanged.
+
+### Task 4: Add Activity Stream visibility helpers
+
+- [x] Modify `app/helpers/reports_helper.rb` to add `activity_stream_active_status_for_report?(report)` for active/pending Activity Stream visibility, using `(Report::DEBUG_BROADCAST_ACTIVE_STATUSES + %w[pending]).uniq`.
+- [x] Add `show_activity_stream_for_report?(report, params:, user:, pdf_mode: false)` that returns false in PDF mode, false without an authenticated user, and true for active/pending reports or optional `?debug=true` fallback.
+- [x] Use ai-scanner-appropriate authorization: do not add stricter `super_admin?` gating unless existing ai-scanner policies require it.
+- [x] Add request/helper coverage proving active/pending reports can render Activity Stream without a debug query and terminal reports do not render by default unless the optional fallback is intentionally kept.
+
+### Task 5: Add collapsed Activity Stream card UI
+
+- [x] Create `app/views/admin/reports/_activity_stream_card.html.erb` for the collapsed Activity Stream card structure.
+- [x] Modify `app/views/admin/reports/_activity_stream_summary.html.erb` so it displays the richer Activity Stream summary: title, LIVE badge for active streams, last updated state, status label, progress text, and explanatory copy.
+- [x] Create `app/javascript/controllers/activity_stream_controller.js`: collapsed by default, “View activity” / “Hide activity” label toggling, `aria-expanded`, and focus handling.
+- [x] Render the existing `admin/reports/debug_panel_stream` inside the collapsed advanced details area, preserving `report-debug-stream-content` and `report-activity-stream-summary` IDs used by Turbo broadcasts.
+- [x] Preserve existing `debug-logs`, `log-viewer`, search/filter controls, and execution log rendering.
+- [x] Continue using ai-scanner’s existing `debug_stream_lease_controller` for lease refresh unless a local test proves a different controller is necessary.
+
+### Task 6: Remove `?debug=true` from normal report rendering
+
+- [x] Modify `app/views/admin/reports/_show_v2.html.erb` to render the Activity Stream card when `show_activity_stream_for_report?(report, params: params, user: current_user)` is true, without requiring `params[:debug] == 'true'`.
+- [x] Mount the lease controller around the Activity Stream card with `refresh_debug_lease_report_path(report)` and keep Turbo stream subscription only for active statuses.
+- [x] Modify `app/views/report_details/show.html.erb` to use `show_activity_stream_for_report?(@report, params: params, user: current_user, pdf_mode: pdf_mode)` instead of `params[:debug] == 'true' && !pdf_mode`.
+- [x] Mount the report-details lease controller with `refresh_debug_lease_report_detail_path(@report)` and keep Turbo stream subscription only for active statuses.
+- [x] Remove direct `refresh_debug_stream_watcher if params[:debug] == "true"` activation from `Admin::ReportsController#show` and `ReportDetailsController#show`; the mounted lease controller should start/refresh watchers on connect.
+- [x] Keep `refresh_debug_lease` endpoints as the watcher-start mechanism and preserve authorization/tenant behavior.
+
+### Task 7: Update request specs and docs for no-query Activity Stream
+
+- [x] Update `spec/requests/report_debug_stream_spec.rb` so `get report_path(running_report)` without debug query renders `report-activity-stream`, `report-activity-stream-summary`, `report-debug-stream-content`, lease controller attributes, and Turbo subscription.
+- [x] Update `spec/requests/report_debug_stream_spec.rb` so `get report_detail_path(running_report)` without debug query renders the same Activity Stream structure.
+- [x] Keep or add specs proving PDF mode does not render Activity Stream.
+- [x] Keep or add specs proving unauthorized/other-company keepalive requests are rejected and do not create watcher leases.
+- [x] Keep or add specs proving lease endpoints enqueue `BroadcastReportDebugJob` for pending, starting, running, and processing reports.
+- [x] Update docs that currently say to append `?debug=true`: `docs-site/docs/development/architecture.md`, `docs-site/docs/troubleshooting.md`, `docs-site/docs/user-guide/reports.md`, and `docs-site/docs/user-guide/scanning.md`.
+- [x] Replace user-facing “append `?debug=true`” guidance with “active reports show Activity Stream automatically; use View activity to expand timeline entries, the raw JSONL tail, and execution logs.”
+- [x] If keeping `?debug=true` fallback for terminal reports, describe it only as an optional troubleshooting fallback, not the normal live-scan path.
+
+### Task 8: Validate, clean up, and keep changes local
+
+- [x] Run the focused RSpec command from the Validation Commands section.
+- [x] Run the targeted RuboCop command from the Validation Commands section.
+- [x] Run any JavaScript controller tests if the new `activity_stream_controller.js` needs coverage in `script/tests/javascript_controller_tests.mjs`.
+- [x] Inspect `git status --short` and ensure no private paths or internal references are present in tracked source/docs changes.
+- [x] Do not push.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build:css": "npx @tailwindcss/cli -i ./app/assets/stylesheets/application.css -o ./app/assets/builds/application.css --minify",
+    "test:js": "node script/tests/javascript_controller_tests.mjs",
     "playwright:install": "npx playwright install chromium",
     "playwright:install-deps": "npx playwright install-deps chromium",
     "playwright:test": "npx playwright test",

--- a/script/db_notifier.py
+++ b/script/db_notifier.py
@@ -18,9 +18,11 @@ Environment Variables:
     DATABASE_URL: PostgreSQL connection string (required)
         Format: postgresql://user:password@host:port/database
     DATABASE_QUEUE_URL: Queue database connection (optional, falls back to DATABASE_URL + _queue suffix)
+    DEBUG_LOG_TAIL_BYTES: Maximum bytes of live execution logs to sync per report (default: 131072)
 """
 
 import atexit
+import hashlib
 import json
 import logging
 import os
@@ -66,6 +68,46 @@ STATUS_PROCESSING = 1
 
 # Report status enum values (matching Rails Report model)
 REPORT_STATUS_RUNNING = 1
+
+# Live execution log tail sync configuration
+DEFAULT_DEBUG_LOG_TAIL_BYTES = 131072
+
+
+def _parse_debug_log_tail_bytes(value: Optional[str]) -> int:
+    if value is None:
+        return DEFAULT_DEBUG_LOG_TAIL_BYTES
+
+    raw_value = value.strip()
+    if not raw_value:
+        logger.warning(
+            "Invalid DEBUG_LOG_TAIL_BYTES=%r; using default %s",
+            value,
+            DEFAULT_DEBUG_LOG_TAIL_BYTES,
+        )
+        return DEFAULT_DEBUG_LOG_TAIL_BYTES
+
+    try:
+        parsed_value = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid DEBUG_LOG_TAIL_BYTES=%r; using default %s",
+            value,
+            DEFAULT_DEBUG_LOG_TAIL_BYTES,
+        )
+        return DEFAULT_DEBUG_LOG_TAIL_BYTES
+
+    if parsed_value < 0:
+        logger.warning(
+            "Invalid DEBUG_LOG_TAIL_BYTES=%r; using default %s",
+            value,
+            DEFAULT_DEBUG_LOG_TAIL_BYTES,
+        )
+        return DEFAULT_DEBUG_LOG_TAIL_BYTES
+
+    return parsed_value
+
+
+DEBUG_LOG_TAIL_BYTES = _parse_debug_log_tail_bytes(os.environ.get("DEBUG_LOG_TAIL_BYTES"))
 
 
 def is_debug_mode() -> bool:
@@ -313,8 +355,8 @@ class HeartbeatThread:
 
 class JournalSyncThread:
     """
-    Background daemon thread that periodically syncs the JSONL report file
-    from disk to the raw_report_data table.
+    Background daemon thread that periodically syncs scan progress from disk
+    to shared database tables.
 
     This ensures partial scan progress is persisted to the database even if
     the garak process is killed unexpectedly (deployment, OOM, pod eviction).
@@ -322,6 +364,9 @@ class JournalSyncThread:
     The thread reads the full JSONL file each cycle and upserts it to the
     database. For resumed scans, a prefix containing previously saved JSONL
     data is prepended to the current file content.
+
+    If a log path is provided, the thread also syncs a bounded execution-log
+    tail to report_debug_logs for live debug streaming.
 
     Usage:
         journal = JournalSyncThread(report_uuid, jsonl_path)
@@ -338,6 +383,7 @@ class JournalSyncThread:
         report_uuid: str,
         jsonl_path: Path,
         prefix: str = "",
+        log_path: Optional[Path] = None,
         interval: int = None,
     ):
         """
@@ -347,11 +393,13 @@ class JournalSyncThread:
             report_uuid: UUID of the report
             jsonl_path: Path to garak's JSONL output file
             prefix: Previously saved JSONL from an interrupted scan (for resumption)
+            log_path: Optional path to the scan execution log file for live tail sync
             interval: Seconds between sync cycles (default: 10)
         """
         self.report_uuid = report_uuid
         self.jsonl_path = jsonl_path
         self.prefix = prefix
+        self.log_path = Path(log_path) if log_path else None
         self.interval = interval if interval is not None else self.DEFAULT_INTERVAL
         self._running = False
         self._final_synced = False
@@ -360,6 +408,7 @@ class JournalSyncThread:
         self._stop_event = threading.Event()
         self._sync_lock = threading.Lock()
         self._last_synced_content: Optional[str] = None
+        self._last_synced_tail_digest: Optional[str] = None
         self._report_id: Optional[int] = None  # Cached after first lookup
         self._consecutive_failures: int = 0
 
@@ -445,22 +494,76 @@ class JournalSyncThread:
                             f"sync failures for {self.report_uuid} — data loss risk"
                         )
 
+    def _read_debug_log_tail(self) -> Optional[dict]:
+        """Read a bounded tail from the scan log file for live debug streaming."""
+        if DEBUG_LOG_TAIL_BYTES == 0:
+            return None
+
+        if not self.log_path or not self.log_path.exists():
+            return None
+
+        try:
+            file_size = self.log_path.stat().st_size
+            tail_limit = max(DEBUG_LOG_TAIL_BYTES, 0)
+            offset = max(file_size - tail_limit, 0) if tail_limit else file_size
+            truncated = offset > 0
+
+            with self.log_path.open("rb") as log_file:
+                log_file.seek(offset)
+                raw_tail = log_file.read(tail_limit) if tail_limit else b""
+
+            tail = raw_tail.decode("utf-8", errors="replace").replace("\x00", "")
+            digest_source = f"{offset}:{int(truncated)}:".encode("utf-8") + tail.encode("utf-8")
+            digest = hashlib.sha256(digest_source).hexdigest()
+
+            return {
+                "tail": tail,
+                "offset": offset,
+                "digest": digest,
+                "synced_at": datetime.now(timezone.utc),
+                "truncated": truncated,
+            }
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            logger.warning(f"JournalSync: failed to read log tail for {self.report_uuid}: {e}")
+            return None
+
     def _sync(self) -> bool:
-        """Read JSONL file from disk and upsert to raw_report_data."""
+        """Read JSONL/log files from disk and upsert changed database state."""
         try:
             # Read current file content (may not exist yet if garak hasn't started)
             file_content = ""
             if self.jsonl_path.exists():
                 file_content = self.jsonl_path.read_text(encoding="utf-8")
+                original_size = len(file_content)
+                file_content = file_content.replace("\x00", "")
+                if len(file_content) < original_size:
+                    nul_count = original_size - len(file_content)
+                    logger.warning(
+                        f"Stripped {nul_count} NUL bytes from JSONL file {self.jsonl_path}. "
+                        f"This is a known garak issue with parallel execution creating sparse files."
+                    )
 
             # Build full content: prefix (old data from previous run) + new file content
             full_content = self.prefix + file_content if self.prefix else file_content
 
-            # Skip if nothing to sync or content unchanged
-            if not full_content or not full_content.strip():
+            jsonl_changed = (
+                bool(full_content and full_content.strip())
+                and full_content != self._last_synced_content
+            )
+
+            tail_payload = self._read_debug_log_tail()
+            tail_changed = (
+                tail_payload is not None
+                and tail_payload["digest"] != self._last_synced_tail_digest
+            )
+
+            # Skip if neither JSONL nor execution log tail changed.
+            if not jsonl_changed and not tail_changed:
                 return True
-            if full_content == self._last_synced_content:
-                return True
+
+            tail_sync_failed = False
 
             with self._sync_lock:
                 if self._cancelled:
@@ -469,26 +572,68 @@ class JournalSyncThread:
                     )
                     return False
 
-                with pooled_connection("primary") as conn:
-                    # Disable autocommit so INSERT runs inside an explicit
-                    # transaction that we can rollback if cancelled.
-                    conn.autocommit = False
-                    with conn.cursor() as cur:
-                        if self._report_id is None:
-                            cur.execute(
-                                "SELECT id FROM reports WHERE uuid = %s",
-                                (self.report_uuid,),
-                            )
-                            result = cur.fetchone()
-                            if not result:
-                                logger.warning(
-                                    f"JournalSync: report not found: "
-                                    f"{self.report_uuid}"
-                                )
-                                return False
-                            self._report_id = result[0]
+                report_id = self._load_report_id()
+                if report_id is None:
+                    return False
 
-                        report_id = self._report_id
+                if jsonl_changed:
+                    if not self._sync_jsonl(report_id, full_content):
+                        return False
+                    self._last_synced_content = full_content
+                    logger.debug(
+                        f"JournalSync: synced {len(full_content)} bytes for {self.report_uuid}"
+                    )
+
+                if tail_changed and not self._cancelled:
+                    tail_synced = self._sync_debug_log_tail(report_id, tail_payload)
+                    if tail_synced:
+                        self._last_synced_tail_digest = tail_payload["digest"]
+                        logger.debug(
+                            f"JournalSync: synced log tail for {self.report_uuid} "
+                            f"({len(tail_payload['tail'])} chars, offset={tail_payload['offset']})"
+                        )
+                    else:
+                        tail_sync_failed = True
+                elif tail_changed:
+                    tail_sync_failed = True
+                    logger.debug(
+                        f"JournalSync: skipped log tail sync for {self.report_uuid} "
+                        "because sync was cancelled"
+                    )
+
+            return jsonl_changed or not tail_sync_failed
+
+        except Exception as e:
+            logger.error(f"JournalSync error for {self.report_uuid}: {e}")
+            return False
+
+    def _load_report_id(self) -> Optional[int]:
+        """Resolve and memoize the database report id."""
+        if self._report_id is not None:
+            return self._report_id
+
+        with pooled_connection("primary") as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT id FROM reports WHERE uuid = %s",
+                    (self.report_uuid,),
+                )
+                result = cur.fetchone()
+                if not result:
+                    logger.warning(
+                        f"JournalSync: report not found: {self.report_uuid}"
+                    )
+                    return None
+                self._report_id = result[0]
+                return self._report_id
+
+    def _sync_jsonl(self, report_id: int, full_content: str) -> bool:
+        """Persist core JSONL data in its own required transaction."""
+        try:
+            with pooled_connection("primary") as conn:
+                conn.autocommit = False
+                try:
+                    with conn.cursor() as cur:
                         now = datetime.now(timezone.utc)
                         cur.execute(
                             """
@@ -502,26 +647,79 @@ class JournalSyncThread:
                             """,
                             (report_id, full_content, STATUS_PENDING, now, now),
                         )
-                    # Re-check cancellation before committing to prevent
-                    # stale writes when stop() set _cancelled while we were
-                    # executing the INSERT (lock-acquire-timeout race).
+
+                    # Re-check cancellation before committing to prevent stale
+                    # writes when stop() set _cancelled while we were executing the
+                    # INSERT (lock-acquire-timeout race).
                     if self._cancelled:
                         conn.rollback()
                         logger.debug(
-                            f"JournalSync: sync cancelled before commit "
+                            f"JournalSync: sync cancelled before JSONL commit "
                             f"for {self.report_uuid}"
                         )
                         return False
                     conn.commit()
-
-            self._last_synced_content = full_content
-            logger.debug(
-                f"JournalSync: synced {len(full_content)} bytes for {self.report_uuid}"
-            )
-            return True
+                    return True
+                except Exception:
+                    conn.rollback()
+                    raise
 
         except Exception as e:
-            logger.error(f"JournalSync error for {self.report_uuid}: {e}")
+            logger.error(f"JournalSync JSONL error for {self.report_uuid}: {e}")
+            return False
+
+    def _sync_debug_log_tail(self, report_id: int, tail_payload: dict) -> bool:
+        """Persist the optional live execution-log tail best-effort."""
+        try:
+            with pooled_connection("primary") as conn:
+                conn.autocommit = False
+                try:
+                    with conn.cursor() as cur:
+                        now = datetime.now(timezone.utc)
+                        cur.execute(
+                            """
+                            INSERT INTO report_debug_logs
+                                (report_id, tail, tail_offset, tail_digest,
+                                 tail_synced_at, tail_truncated,
+                                 created_at, updated_at)
+                            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                            ON CONFLICT (report_id) DO UPDATE SET
+                                tail = EXCLUDED.tail,
+                                tail_offset = EXCLUDED.tail_offset,
+                                tail_digest = EXCLUDED.tail_digest,
+                                tail_synced_at = EXCLUDED.tail_synced_at,
+                                tail_truncated = EXCLUDED.tail_truncated,
+                                updated_at = EXCLUDED.updated_at
+                            """,
+                            (
+                                report_id,
+                                tail_payload["tail"],
+                                tail_payload["offset"],
+                                tail_payload["digest"],
+                                tail_payload["synced_at"],
+                                tail_payload["truncated"],
+                                now,
+                                now,
+                            ),
+                        )
+
+                    if self._cancelled:
+                        conn.rollback()
+                        logger.debug(
+                            f"JournalSync: sync cancelled before tail commit "
+                            f"for {self.report_uuid}"
+                        )
+                        return False
+                    conn.commit()
+                    return True
+                except Exception:
+                    conn.rollback()
+                    raise
+
+        except Exception as e:
+            logger.warning(
+                f"JournalSync: failed to sync log tail for {self.report_uuid}: {e}"
+            )
             return False
 
 
@@ -926,18 +1124,33 @@ def notify_report_running(report_uuid: str, pid: int) -> bool:
                     UPDATE reports
                     SET status = %s, pid = %s, heartbeat_at = NOW(), updated_at = NOW()
                     WHERE uuid = %s
-                    RETURNING company_id
+                    RETURNING id, company_id
                     """,
                     (REPORT_STATUS_RUNNING, pid, report_uuid),
                 )
                 report_row = cur.fetchone()
+
+                if report_row is not None:
+                    cur.execute(
+                        """
+                        UPDATE report_debug_logs
+                        SET tail = NULL,
+                            tail_offset = 0,
+                            tail_digest = NULL,
+                            tail_synced_at = NULL,
+                            tail_truncated = FALSE,
+                            updated_at = NOW()
+                        WHERE report_id = %s
+                        """,
+                        (report_row[0],),
+                    )
             conn.commit()
 
             if report_row is None:
                 logger.warning(f"Report not found: {report_uuid}")
                 return False
 
-            company_id = report_row[0]
+            company_id = report_row[1]
 
             logger.info(f"Report {report_uuid} marked as running (pid={pid})")
 
@@ -1128,14 +1341,30 @@ def notify_report_ready(report_uuid: str, prefix: str = "") -> bool:
     try:
         if jsonl_path.exists():
             jsonl_data = jsonl_path.read_text(encoding="utf-8")
-            logger.debug(f"Read JSONL file: {jsonl_path} ({len(jsonl_data)} bytes)")
+            original_size = len(jsonl_data)
+            jsonl_data = jsonl_data.replace("\x00", "")
+            if len(jsonl_data) < original_size:
+                nul_count = original_size - len(jsonl_data)
+                logger.warning(
+                    f"Stripped {nul_count} NUL bytes from JSONL file {jsonl_path}. "
+                    f"This is a known garak issue with parallel execution creating sparse files."
+                )
+            logger.debug(
+                f"Read JSONL file: {jsonl_path} ({len(jsonl_data)} bytes after sanitization)"
+            )
         else:
             logger.error(f"JSONL file not found: {jsonl_path}")
             return False
 
         if logs_path.exists():
             logs_data = logs_path.read_text(encoding="utf-8")
-            logger.debug(f"Read logs file: {logs_path} ({len(logs_data)} bytes)")
+            original_size = len(logs_data)
+            logs_data = logs_data.replace("\x00", "")
+            if len(logs_data) < original_size:
+                logger.warning(f"Stripped {original_size - len(logs_data)} NUL bytes from logs file")
+            logger.debug(
+                f"Read logs file: {logs_path} ({len(logs_data)} bytes after sanitization)"
+            )
         else:
             logger.debug(f"Logs file not found (optional): {logs_path}")
 
@@ -1268,7 +1497,13 @@ def notify_report_ready_from_synced(report_uuid: str) -> bool:
     if logs_path.exists():
         try:
             logs_data = logs_path.read_text(encoding="utf-8")
-            logger.debug(f"Read logs file: {logs_path} ({len(logs_data)} bytes)")
+            original_size = len(logs_data)
+            logs_data = logs_data.replace("\x00", "")
+            if len(logs_data) < original_size:
+                logger.warning(f"Stripped {original_size - len(logs_data)} NUL bytes from logs file")
+            logger.debug(
+                f"Read logs file: {logs_path} ({len(logs_data)} bytes after sanitization)"
+            )
         except Exception as e:
             logger.warning(f"Failed to read log file: {e}")
 
@@ -1307,17 +1542,17 @@ def notify_report_ready_from_synced(report_uuid: str) -> bool:
                     )
                     return False
 
-                # Update logs_data on existing raw_report_data record
-                if logs_data:
-                    now = datetime.now(timezone.utc)
-                    cur.execute(
-                        """
-                        UPDATE raw_report_data
-                        SET logs_data = %s, updated_at = %s
-                        WHERE report_id = %s
-                        """,
-                        (logs_data, now, report_id),
-                    )
+                # Update logs_data even when the log file is missing or empty so
+                # stale logs from an earlier attempt cannot survive completion.
+                now = datetime.now(timezone.utc)
+                cur.execute(
+                    """
+                    UPDATE raw_report_data
+                    SET logs_data = %s, updated_at = %s
+                    WHERE report_id = %s
+                    """,
+                    (logs_data, now, report_id),
+                )
 
                 job_id = _enqueue_process_report_job(report_id, queue_conn)
                 logger.debug(f"Enqueued job_id={job_id} for report_id={report_id}")

--- a/script/run_garak.py
+++ b/script/run_garak.py
@@ -40,6 +40,7 @@ from db_notifier import (
     notify_report_ready_from_synced as db_notify_ready_from_synced,
     notify_report_stopped as db_notify_stopped,
     load_existing_jsonl_prefix,
+    get_log_file_path,
     HeartbeatThread,
     JournalSyncThread,
     REPORTS_PATH,
@@ -211,7 +212,13 @@ def main():
 
             # Start JournalSyncThread to periodically persist JSONL to database
             jsonl_path = REPORTS_PATH / f"{report_uuid}.report.jsonl"
-            journal_sync = JournalSyncThread(report_uuid, jsonl_path, prefix=prefix)
+            log_path = get_log_file_path(report_uuid)
+            journal_sync = JournalSyncThread(
+                report_uuid,
+                jsonl_path,
+                prefix=prefix,
+                log_path=log_path,
+            )
             current_journal_sync = journal_sync
             journal_sync.start()
 

--- a/script/tests/javascript_controller_tests.mjs
+++ b/script/tests/javascript_controller_tests.mjs
@@ -1,0 +1,654 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import vm from "node:vm"
+
+function loadControllerSource(filename, className) {
+  const source = readFileSync(
+    new URL(`../../app/javascript/controllers/${filename}`, import.meta.url),
+    "utf8"
+  )
+
+  return source
+    .replace(/^import .*?\n/, "")
+    .replace(
+      "export default class extends Controller",
+      `class ${className} extends Controller`
+    )
+}
+
+function loadDebugStreamLeaseController() {
+  const transformed = loadControllerSource(
+    "debug_stream_lease_controller.js",
+    "DebugStreamLeaseController"
+  )
+
+  const context = {
+    Controller: class {},
+    console: { warn() {} },
+    document: { querySelector() { return null } },
+    fetch: async () => ({ ok: true, status: 204 }),
+    window: {
+      setInterval() { return null },
+      clearInterval() {}
+    }
+  }
+
+  const ControllerClass = vm.runInNewContext(
+    `${transformed}\nDebugStreamLeaseController`,
+    context
+  )
+
+  return { ControllerClass, context }
+}
+
+function loadActivityStreamController() {
+  const transformed = loadControllerSource(
+    "activity_stream_controller.js",
+    "ActivityStreamController"
+  )
+
+  const context = {
+    Controller: class {},
+    requestAnimationFrame(callback) { callback() }
+  }
+
+  const ControllerClass = vm.runInNewContext(
+    `${transformed}\nActivityStreamController`,
+    context
+  )
+
+  return { ControllerClass, context }
+}
+
+function loadDebugTabsController() {
+  const transformed = loadControllerSource(
+    "debug_tabs_controller.js",
+    "DebugTabsController"
+  )
+
+  const sessionStore = new Map()
+  const context = {
+    Controller: class {},
+    sessionStorage: {
+      getItem(key) { return sessionStore.has(key) ? sessionStore.get(key) : null },
+      setItem(key, value) { sessionStore.set(key, String(value)) }
+    }
+  }
+
+  const ControllerClass = vm.runInNewContext(
+    `${transformed}\nDebugTabsController`,
+    context
+  )
+
+  return { ControllerClass, context, sessionStore }
+}
+
+function loadDebugStreamFilterController() {
+  const transformed = loadControllerSource(
+    "debug_stream_filter_controller.js",
+    "DebugStreamFilterController"
+  )
+
+  const context = { Controller: class {} }
+
+  const ControllerClass = vm.runInNewContext(
+    `${transformed}\nDebugStreamFilterController`,
+    context
+  )
+
+  return { ControllerClass }
+}
+
+function loadLogViewerController() {
+  const transformed = loadControllerSource(
+    "log_viewer_controller.js",
+    "LogViewerController"
+  )
+
+  const context = {
+    Controller: class {},
+    CustomEvent: class {
+      constructor(type, init = {}) {
+        this.type = type
+        this.bubbles = !!init.bubbles
+        this.detail = init.detail
+      }
+    }
+  }
+
+  const ControllerClass = vm.runInNewContext(
+    `${transformed}\nLogViewerController`,
+    context
+  )
+
+  return { ControllerClass }
+}
+
+function classListWith(...initialClasses) {
+  const classes = new Set(initialClasses)
+
+  return {
+    contains(className) {
+      return classes.has(className)
+    },
+    add(...names) {
+      names.forEach((name) => classes.add(name))
+    },
+    remove(...names) {
+      names.forEach((name) => classes.delete(name))
+    },
+    toggle(className, force) {
+      if (force === true) {
+        classes.add(className)
+      } else if (force === false) {
+        classes.delete(className)
+      } else if (classes.has(className)) {
+        classes.delete(className)
+      } else {
+        classes.add(className)
+      }
+    }
+  }
+}
+
+function fakeElement(...initialClasses) {
+  const attributes = new Map()
+
+  return {
+    classList: classListWith(...initialClasses),
+    textContent: "",
+    focusOptions: null,
+    focusTarget: null,
+    setAttribute(name, value) {
+      attributes.set(name, value)
+    },
+    getAttribute(name) {
+      return attributes.get(name)
+    },
+    querySelector(selector) {
+      if (selector === "[data-activity-stream-focus-target]") return this.focusTarget
+
+      return null
+    },
+    focus(options) {
+      this.focusOptions = options
+    }
+  }
+}
+
+function fakeTab(name, ...initialClasses) {
+  return {
+    classList: classListWith(...initialClasses),
+    dataset: { tab: name }
+  }
+}
+
+function fakePanel(name, ...initialClasses) {
+  return {
+    classList: classListWith(...initialClasses),
+    dataset: { tab: name }
+  }
+}
+
+function fakeRow({ text = "", logViewerFilterMatch } = {}) {
+  const dataset = {}
+  if (logViewerFilterMatch !== undefined) {
+    dataset.logViewerFilterMatch = logViewerFilterMatch
+  }
+  return {
+    textContent: text,
+    style: { display: "" },
+    dataset
+  }
+}
+
+function fakeGroup(rows, emptyState) {
+  return {
+    rows,
+    emptyState,
+    querySelector(selector) {
+      if (selector.includes("emptyState")) return emptyState
+      return null
+    },
+    querySelectorAll(selector) {
+      if (selector.includes("row")) return rows
+      return []
+    }
+  }
+}
+
+async function testDebugStreamLeaseController() {
+  const { ControllerClass, context } = loadDebugStreamLeaseController()
+
+  const controller = new ControllerClass()
+  assert.equal(controller.intervalMs, 30000)
+
+  controller.hasIntervalValue = true
+  controller.intervalValue = 2500
+  assert.equal(controller.intervalMs, 2500)
+
+  controller.intervalValue = 0
+  assert.equal(controller.intervalMs, 30000)
+
+  const requests = []
+  context.document = {
+    querySelector(selector) {
+      assert.equal(selector, "meta[name='csrf-token']")
+      return { content: "csrf-token" }
+    }
+  }
+  context.fetch = async (url, options) => {
+    requests.push({ url, options })
+    return { ok: true, status: 204 }
+  }
+
+  controller.urlValue = "/reports/1/debug_stream/lease"
+  await controller.refreshLease()
+
+  assert.equal(requests.length, 1)
+  assert.equal(requests[0].url, "/reports/1/debug_stream/lease")
+  assert.equal(requests[0].options.method, "POST")
+  assert.equal(requests[0].options.credentials, "same-origin")
+  assert.equal(requests[0].options.headers.Accept, "text/plain")
+  assert.equal(requests[0].options.headers["X-CSRF-Token"], "csrf-token")
+  assert.equal(requests[0].options.headers["X-Requested-With"], "XMLHttpRequest")
+
+  let resolveFetch
+  context.fetch = async (url, options) => {
+    requests.push({ url, options })
+    return new Promise((resolve) => {
+      resolveFetch = resolve
+    })
+  }
+
+  const firstRefresh = controller.refreshLease()
+  const overlappingRefresh = controller.refreshLease()
+  assert.equal(requests.length, 2)
+
+  resolveFetch({ ok: true, status: 204 })
+  await firstRefresh
+  await overlappingRefresh
+
+  context.fetch = async (url, options) => {
+    requests.push({ url, options })
+    return { ok: true, status: 204 }
+  }
+
+  await controller.refreshLease()
+  assert.equal(requests.length, 3)
+
+  const noUrlController = new ControllerClass()
+  noUrlController.hasUrlValue = false
+  noUrlController.connect()
+  assert.equal(requests.length, 3)
+
+  const scheduled = []
+  const cleared = []
+  context.window = {
+    setInterval(callback, interval) {
+      scheduled.push({ callback, interval })
+      return "timer-1"
+    },
+    clearInterval(timer) {
+      cleared.push(timer)
+    }
+  }
+
+  controller.hasUrlValue = true
+  controller.hasIntervalValue = true
+  controller.intervalValue = 5000
+  controller.connect()
+
+  assert.equal(scheduled.length, 1)
+  assert.equal(scheduled[0].interval, 5000)
+  assert.equal(controller.timer, "timer-1")
+
+  controller.disconnect()
+
+  assert.deepEqual(cleared, [ "timer-1" ])
+  assert.equal(controller.timer, null)
+}
+
+function testActivityStreamController() {
+  const { ControllerClass } = loadActivityStreamController()
+  const controller = new ControllerClass()
+  const details = fakeElement("hidden")
+  const button = fakeElement()
+  const buttonLabel = fakeElement()
+  const focusTarget = fakeElement()
+
+  buttonLabel.textContent = "View activity"
+  details.focusTarget = focusTarget
+
+  controller.hasDetailsTarget = true
+  controller.hasButtonTarget = true
+  controller.hasButtonLabelTarget = true
+  controller.detailsTarget = details
+  controller.buttonTarget = button
+  controller.buttonLabelTarget = buttonLabel
+
+  controller.connect()
+
+  assert.equal(details.classList.contains("hidden"), true)
+  assert.equal(button.getAttribute("aria-expanded"), "false")
+  assert.equal(buttonLabel.textContent, "View activity")
+
+  controller.toggle()
+
+  assert.equal(details.classList.contains("hidden"), false)
+  assert.equal(button.getAttribute("aria-expanded"), "true")
+  assert.equal(buttonLabel.textContent, "Hide activity")
+  assert.equal(focusTarget.focusOptions.preventScroll, true)
+
+  controller.toggle()
+
+  assert.equal(details.classList.contains("hidden"), true)
+  assert.equal(button.getAttribute("aria-expanded"), "false")
+  assert.equal(buttonLabel.textContent, "View activity")
+}
+
+function testDebugTabsController() {
+  const { ControllerClass, context, sessionStore } = loadDebugTabsController()
+
+  const tabs = [
+    fakeTab("timeline", "text-zinc-400", "hover:text-zinc-200"),
+    fakeTab("raw", "text-zinc-400", "hover:text-zinc-200"),
+    fakeTab("logs", "text-zinc-400", "hover:text-zinc-200")
+  ]
+  const panels = [
+    fakePanel("timeline"),
+    fakePanel("raw", "hidden"),
+    fakePanel("logs", "hidden")
+  ]
+
+  const controller = new ControllerClass()
+  controller.tabTargets = tabs
+  controller.panelTargets = panels
+  controller.hasStorageKeyValue = true
+  controller.storageKeyValue = "report-debug-tab-42"
+
+  controller.panelTargetConnected()
+  // default tab = timeline
+  assert.equal(tabs[0].classList.contains("bg-zinc-800"), true)
+  assert.equal(tabs[0].classList.contains("text-white"), true)
+  assert.equal(panels[0].classList.contains("hidden"), false)
+  assert.equal(panels[1].classList.contains("hidden"), true)
+  assert.equal(panels[2].classList.contains("hidden"), true)
+
+  // switch to raw
+  controller.switch({ currentTarget: tabs[1] })
+  assert.equal(tabs[1].classList.contains("bg-zinc-800"), true)
+  assert.equal(tabs[0].classList.contains("bg-zinc-800"), false)
+  assert.equal(panels[0].classList.contains("hidden"), true)
+  assert.equal(panels[1].classList.contains("hidden"), false)
+  assert.equal(panels[2].classList.contains("hidden"), true)
+  assert.equal(sessionStore.get("report-debug-tab-42"), "raw")
+
+  // reconnect — restores raw
+  const tabs2 = [fakeTab("timeline"), fakeTab("raw"), fakeTab("logs")]
+  const panels2 = [fakePanel("timeline"), fakePanel("raw"), fakePanel("logs")]
+  const controller2 = new ControllerClass()
+  controller2.tabTargets = tabs2
+  controller2.panelTargets = panels2
+  controller2.hasStorageKeyValue = true
+  controller2.storageKeyValue = "report-debug-tab-42"
+  controller2.panelTargetConnected()
+  assert.equal(panels2[0].classList.contains("hidden"), true)
+  assert.equal(panels2[1].classList.contains("hidden"), false)
+  assert.equal(panels2[2].classList.contains("hidden"), true)
+
+  // explicit "logs" works
+  controller.switch({ currentTarget: tabs[2] })
+  assert.equal(panels[2].classList.contains("hidden"), false)
+  assert.equal(sessionStore.get("report-debug-tab-42"), "logs")
+
+  // stored tab id that doesn't exist falls back to "timeline"
+  sessionStore.set("report-debug-tab-99", "old_renamed_tab")
+  const tabs3 = [fakeTab("timeline"), fakeTab("raw"), fakeTab("logs")]
+  const panels3 = [fakePanel("timeline"), fakePanel("raw"), fakePanel("logs")]
+  const controller3 = new ControllerClass()
+  controller3.tabTargets = tabs3
+  controller3.panelTargets = panels3
+  controller3.hasStorageKeyValue = true
+  controller3.storageKeyValue = "report-debug-tab-99"
+  controller3.panelTargetConnected()
+  assert.equal(panels3[0].classList.contains("hidden"), false,
+    "stale stored id should fall back to timeline")
+  assert.equal(panels3[1].classList.contains("hidden"), true)
+  assert.equal(panels3[2].classList.contains("hidden"), true)
+  assert.equal(tabs3[0].classList.contains("bg-zinc-800"), true,
+    "timeline tab button should show active styling after fallback")
+
+  // missing storage value — no read/write
+  const noStorageController = new ControllerClass()
+  noStorageController.tabTargets = [fakeTab("timeline"), fakeTab("raw")]
+  noStorageController.panelTargets = [fakePanel("timeline"), fakePanel("raw")]
+  noStorageController.hasStorageKeyValue = false
+  noStorageController.panelTargetConnected()
+  assert.equal(noStorageController.tabTargets[0].classList.contains("bg-zinc-800"), true)
+
+  // throwing sessionStorage does not break the controller
+  const throwingStorage = {
+    getItem() { throw new Error("SecurityError") },
+    setItem() { throw new Error("SecurityError") }
+  }
+  const tabs4 = [fakeTab("timeline"), fakeTab("raw"), fakeTab("logs")]
+  const panels4 = [fakePanel("timeline"), fakePanel("raw"), fakePanel("logs")]
+  const controller4 = new ControllerClass()
+  controller4.tabTargets = tabs4
+  controller4.panelTargets = panels4
+  controller4.hasStorageKeyValue = true
+  controller4.storageKeyValue = "report-debug-tab-77"
+  // Override the controller's sessionStorage reference for this test
+  const originalSessionStorage = context.sessionStorage
+  context.sessionStorage = throwingStorage
+
+  let connectError = null
+  try {
+    controller4.panelTargetConnected()
+  } catch (err) {
+    connectError = err
+  }
+  assert.equal(connectError, null, "connect() should not throw when sessionStorage throws")
+  assert.equal(panels4[0].classList.contains("hidden"), false,
+    "controller should still default to timeline when storage is unavailable")
+
+  let switchError = null
+  try {
+    controller4.switch({ currentTarget: tabs4[1] })
+  } catch (err) {
+    switchError = err
+  }
+  assert.equal(switchError, null, "switch() should not throw when sessionStorage throws")
+  assert.equal(panels4[1].classList.contains("hidden"), false,
+    "switch should still apply tab even when persistence fails")
+
+  context.sessionStorage = originalSessionStorage
+}
+
+function testDebugStreamFilterController() {
+  const { ControllerClass } = loadDebugStreamFilterController()
+
+  const rows = [
+    fakeRow({ text: "ATTEMPT prompt_injection probe" }),
+    fakeRow({ text: "EVAL detector misleading" }),
+    fakeRow({ text: "INIT 12:00:00" })
+  ]
+  const emptyState = { hidden: true }
+  const group = fakeGroup(rows, emptyState)
+
+  const controller = new ControllerClass()
+  controller.rowTargets = rows
+  controller.groupTargets = [group]
+  controller.hasQueryTarget = true
+  controller.queryTarget = { value: "" }
+
+  // empty filter — all visible, empty state hidden
+  controller.filter()
+  assert.equal(rows[0].style.display, "")
+  assert.equal(rows[1].style.display, "")
+  assert.equal(rows[2].style.display, "")
+  assert.equal(emptyState.hidden, true)
+
+  // filter "probe" — only row 0 matches
+  controller.queryTarget.value = "probe"
+  controller.filter()
+  assert.equal(rows[0].style.display, "")
+  assert.equal(rows[1].style.display, "none")
+  assert.equal(rows[2].style.display, "none")
+  assert.equal(emptyState.hidden, true)
+
+  // filter no matches — empty state shown
+  controller.queryTarget.value = "zzz_nomatch_zzz"
+  controller.filter()
+  assert.equal(rows[0].style.display, "none")
+  assert.equal(rows[1].style.display, "none")
+  assert.equal(rows[2].style.display, "none")
+  assert.equal(emptyState.hidden, false)
+
+  // composition: row with logViewerFilterMatch=false stays hidden even if text matches
+  const composedRow = fakeRow({ text: "ATTEMPT", logViewerFilterMatch: "false" })
+  const composedGroup = fakeGroup([composedRow], { hidden: true })
+  const controller2 = new ControllerClass()
+  controller2.rowTargets = [composedRow]
+  controller2.groupTargets = [composedGroup]
+  controller2.hasQueryTarget = true
+  controller2.queryTarget = { value: "" }
+  controller2.filter()
+  assert.equal(composedRow.style.display, "none")
+  // empty state shown because there's an active filter (logViewer side) and no visible rows
+  assert.equal(composedGroup.emptyState.hidden, false)
+
+  // missing query target — query returns ""
+  const noQueryController = new ControllerClass()
+  noQueryController.hasQueryTarget = false
+  assert.equal(noQueryController.query, "")
+
+  // clearQuery clears the input value and re-runs filter
+  const queryInput = { value: "probe" }
+  const filterRows = [fakeRow({ text: "ATTEMPT probe foo" }), fakeRow({ text: "EVAL detector bar" })]
+  const filterGroup = fakeGroup(filterRows, { hidden: true })
+  const ctrl3 = new ControllerClass()
+  ctrl3.rowTargets = filterRows
+  ctrl3.groupTargets = [filterGroup]
+  ctrl3.hasQueryTarget = true
+  ctrl3.queryTarget = queryInput
+  ctrl3.filter()
+  assert.equal(filterRows[0].style.display, "")
+  assert.equal(filterRows[1].style.display, "none")
+
+  ctrl3.clearQuery()
+  assert.equal(queryInput.value, "", "clearQuery should empty the query input")
+  assert.equal(filterRows[0].style.display, "")
+  assert.equal(filterRows[1].style.display, "", "rows hidden by query should be visible after clearQuery")
+}
+
+function testLogViewerController() {
+  const { ControllerClass } = loadLogViewerController()
+
+  const passLine = {
+    classList: classListWith("log-line", "pass-line"),
+    textContent: "ok on 5/10 PASS",
+    style: { display: "" },
+    dataset: {}
+  }
+  const failLine = {
+    classList: classListWith("log-line", "fail-line"),
+    textContent: "FAIL probe failed",
+    style: { display: "" },
+    dataset: {}
+  }
+  const events = []
+  const element = {
+    dispatchEvent(evt) { events.push(evt) }
+  }
+
+  const controller = new ControllerClass()
+  controller.element = element
+  controller.contentTarget = {
+    contains() { return false },
+    querySelectorAll(selector) {
+      assert.equal(selector, ".log-line")
+      return [passLine, failLine]
+    }
+  }
+  controller.hasSearchTarget = true
+  controller.searchTarget = { value: "" }
+
+  // PASS filter — pass line stays visible, fail line hides, info line stays visible
+  const infoLine = {
+    classList: classListWith("log-line"),
+    textContent: "INFO module loaded",
+    style: { display: "" },
+    dataset: {}
+  }
+  controller.contentTarget = {
+    contains() { return false },
+    querySelectorAll(selector) {
+      assert.equal(selector, ".log-line")
+      return [passLine, failLine, infoLine]
+    }
+  }
+
+  controller.filter({ currentTarget: { dataset: { filterType: "pass" } } })
+  assert.equal(passLine.dataset.logViewerStatusMatch, "true")
+  assert.equal(failLine.dataset.logViewerStatusMatch, "false")
+  assert.equal(infoLine.dataset.logViewerStatusMatch, "true",
+    "info lines should remain visible under PASS filter (only opposite-type lines hide)")
+  assert.equal(passLine.style.display, "")
+  assert.equal(failLine.style.display, "none")
+  assert.equal(infoLine.style.display, "")
+  assert.equal(events.at(-1).type, "log-viewer:filter-change")
+  assert.equal(events.at(-1).bubbles, true)
+
+  // FAIL filter — fail line stays visible, pass line hides, info line stays visible
+  controller.filter({ currentTarget: { dataset: { filterType: "fail" } } })
+  assert.equal(failLine.dataset.logViewerStatusMatch, "true")
+  assert.equal(passLine.dataset.logViewerStatusMatch, "false")
+  assert.equal(infoLine.dataset.logViewerStatusMatch, "true")
+
+  // re-apply PASS filter so downstream search/composition assertions match the original setup
+  controller.filter({ currentTarget: { dataset: { filterType: "pass" } } })
+
+  // search "FAIL" — only fail line matches; combined with pass-only status, fail line still hidden
+  controller.searchTarget.value = "FAIL"
+  controller.search()
+  assert.equal(passLine.dataset.logViewerSearchMatch, "false")
+  assert.equal(failLine.dataset.logViewerSearchMatch, "true")
+  // pass: status=true, search=false -> filterMatch=false -> hidden
+  assert.equal(passLine.style.display, "none")
+  // fail: status=false, search=true -> filterMatch=false -> hidden
+  assert.equal(failLine.style.display, "none")
+
+  // resetFilter — both lines back to visible, search cleared
+  controller.resetFilter()
+  assert.equal(controller.searchTarget.value, "")
+  assert.equal(passLine.dataset.logViewerStatusMatch, "true")
+  assert.equal(failLine.dataset.logViewerStatusMatch, "true")
+  assert.equal(passLine.dataset.logViewerSearchMatch, "true")
+  assert.equal(failLine.dataset.logViewerSearchMatch, "true")
+  assert.equal(passLine.style.display, "")
+  assert.equal(failLine.style.display, "")
+
+  // resetFilter dispatches log-viewer:reset event for the cross-panel filter
+  const resetEvents = events.filter(e => e.type === "log-viewer:reset")
+  assert.equal(resetEvents.length, 1, "resetFilter should dispatch exactly one log-viewer:reset event")
+  assert.equal(resetEvents[0].bubbles, true)
+
+  // composition with debug-stream filter — line hidden if either side false
+  passLine.dataset.debugStreamFilterMatch = "false"
+  controller.search()
+  assert.equal(passLine.style.display, "none")
+
+  // notifyFilterChange always dispatches an event
+  const eventCountBefore = events.length
+  controller.notifyFilterChange()
+  assert.equal(events.length, eventCountBefore + 1)
+}
+
+await testDebugStreamLeaseController()
+testActivityStreamController()
+testDebugTabsController()
+testDebugStreamFilterController()
+testLogViewerController()
+console.log("JavaScript controller tests passed")

--- a/script/tests/test_db_notifier_broadcast_job.py
+++ b/script/tests/test_db_notifier_broadcast_job.py
@@ -49,7 +49,7 @@ class TestNotifyReportRunningBroadcastJob(unittest.TestCase):
     def test_notify_report_running_enqueues_company_scoped_broadcast_job(self, mock_pooled):
         primary_conn, primary_cur = self._make_mock_conn(
             rowcount=1,
-            fetchone_result=(17,),
+            fetchone_result=(33, 17),
         )
         queue_conn, queue_cur = self._make_mock_conn(fetchone_result=(123,))
         mock_pooled.side_effect = [primary_conn, queue_conn]
@@ -58,9 +58,14 @@ class TestNotifyReportRunningBroadcastJob(unittest.TestCase):
 
         self.assertTrue(result)
 
-        update_sql, update_params = primary_cur.execute.call_args[0]
-        self.assertIn("RETURNING company_id", update_sql)
+        update_sql, update_params = primary_cur.execute.call_args_list[0][0]
+        self.assertIn("RETURNING id, company_id", update_sql)
         self.assertEqual(update_params, (db_notifier.REPORT_STATUS_RUNNING, 456, "report-uuid"))
+
+        tail_reset_sql, tail_reset_params = primary_cur.execute.call_args_list[1][0]
+        self.assertIn("UPDATE report_debug_logs", tail_reset_sql)
+        self.assertIn("tail = NULL", tail_reset_sql)
+        self.assertEqual(tail_reset_params, (33,))
 
         insert_sql, insert_params = queue_cur.execute.call_args_list[0][0]
         arguments_payload = json.loads(insert_params[1])

--- a/script/tests/test_db_notifier_debug_log_tail.py
+++ b/script/tests/test_db_notifier_debug_log_tail.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""
+Tests for JournalSyncThread live execution log tail syncing.
+"""
+
+import importlib
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+# Stub psycopg2 before importing db_notifier.
+_mock_psycopg2 = ModuleType("psycopg2")
+_mock_psycopg2.OperationalError = type("OperationalError", (Exception,), {})
+_mock_psycopg2.pool = ModuleType("psycopg2.pool")
+_mock_psycopg2.pool.ThreadedConnectionPool = MagicMock
+sys.modules["psycopg2"] = _mock_psycopg2
+sys.modules["psycopg2.pool"] = _mock_psycopg2.pool
+
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__), "..")
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
+cached_db_notifier = sys.modules.get("db_notifier")
+if cached_db_notifier is not None and (
+    isinstance(cached_db_notifier, MagicMock)
+    or not hasattr(cached_db_notifier, "JournalSyncThread")
+):
+    del sys.modules["db_notifier"]
+
+import db_notifier  # noqa: E402
+
+
+class TestDebugLogTailBytesConfig(unittest.TestCase):
+    def setUp(self):
+        self.original_tail_bytes_env = os.environ.get("DEBUG_LOG_TAIL_BYTES")
+
+    def tearDown(self):
+        if self.original_tail_bytes_env is None:
+            os.environ.pop("DEBUG_LOG_TAIL_BYTES", None)
+        else:
+            os.environ["DEBUG_LOG_TAIL_BYTES"] = self.original_tail_bytes_env
+        self._reload_db_notifier()
+
+    def _reload_with_tail_bytes(self, value):
+        if value is None:
+            os.environ.pop("DEBUG_LOG_TAIL_BYTES", None)
+        else:
+            os.environ["DEBUG_LOG_TAIL_BYTES"] = value
+        return self._reload_db_notifier()
+
+    def _reload_db_notifier(self):
+        sys.modules["psycopg2"] = _mock_psycopg2
+        sys.modules["psycopg2.pool"] = _mock_psycopg2.pool
+        sys.modules["db_notifier"] = db_notifier
+        return importlib.reload(db_notifier)
+
+    def test_import_defaults_for_malformed_tail_byte_values(self):
+        for value in ("", "128k", "-1"):
+            with self.subTest(value=value):
+                with self.assertLogs("db_notifier", level="WARNING"):
+                    module = self._reload_with_tail_bytes(value)
+
+                self.assertEqual(
+                    module.DEBUG_LOG_TAIL_BYTES,
+                    module.DEFAULT_DEBUG_LOG_TAIL_BYTES,
+                )
+
+    def test_import_defaults_when_tail_byte_value_is_missing(self):
+        module = self._reload_with_tail_bytes(None)
+
+        self.assertEqual(
+            module.DEBUG_LOG_TAIL_BYTES,
+            module.DEFAULT_DEBUG_LOG_TAIL_BYTES,
+        )
+
+    def test_import_preserves_zero_tail_byte_value(self):
+        module = self._reload_with_tail_bytes("0")
+
+        self.assertEqual(module.DEBUG_LOG_TAIL_BYTES, 0)
+
+
+class RecordingCursor:
+    def __init__(self, report_id=42):
+        self.report_id = report_id
+        self.execute_calls = []
+        self._last_sql = ""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=None):
+        self.execute_calls.append((sql, params))
+        self._last_sql = sql
+
+    def fetchone(self):
+        if "SELECT id FROM reports" in self._last_sql:
+            return (self.report_id,)
+        if "SELECT 1 FROM raw_report_data" in self._last_sql:
+            return (1,)
+        if "UPDATE reports" in self._last_sql and "RETURNING id, company_id" in self._last_sql:
+            return (self.report_id, 7)
+        return None
+
+    def reset(self):
+        self.execute_calls = []
+        self._last_sql = ""
+
+
+class FailingTailCursor(RecordingCursor):
+    def execute(self, sql, params=None):
+        if "INSERT INTO report_debug_logs" in sql:
+            self.execute_calls.append((sql, params))
+            self._last_sql = sql
+            raise RuntimeError("tail table unavailable")
+
+        super().execute(sql, params)
+
+
+class RecordingConnection:
+    def __init__(self, cursor):
+        self.cursor_obj = cursor
+        self.autocommit = True
+        self.commit_count = 0
+        self.rollback_count = 0
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.commit_count += 1
+
+    def rollback(self):
+        self.rollback_count += 1
+
+    def reset(self):
+        self.cursor_obj.reset()
+        self.commit_count = 0
+        self.rollback_count = 0
+
+
+class TestJournalSyncDebugLogTail(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.root = Path(self.tmpdir.name)
+        self.jsonl_path = self.root / "report.report.jsonl"
+        self.log_path = self.root / "report.log"
+        self.old_tail_bytes = db_notifier.DEBUG_LOG_TAIL_BYTES
+        db_notifier.DEBUG_LOG_TAIL_BYTES = 1024
+
+    def tearDown(self):
+        db_notifier.DEBUG_LOG_TAIL_BYTES = self.old_tail_bytes
+
+    def _thread(self):
+        return db_notifier.JournalSyncThread(
+            "report-uuid",
+            self.jsonl_path,
+            log_path=self.log_path,
+        )
+
+    def _patch_pooled_connection(self, conn):
+        @contextmanager
+        def fake_pooled_connection(database="primary"):
+            yield conn
+
+        return patch.object(db_notifier, "pooled_connection", fake_pooled_connection)
+
+    def _sql_calls_containing(self, cursor, fragment):
+        return [
+            (sql, params)
+            for sql, params in cursor.execute_calls
+            if fragment in sql
+        ]
+
+    def test_missing_log_file_keeps_jsonl_sync_without_debug_log_upsert(self):
+        self.jsonl_path.write_text('{"entry_type":"init"}\n', encoding="utf-8")
+        sync = self._thread()
+        cursor = RecordingCursor()
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn):
+            self.assertTrue(sync._sync())
+
+        self.assertEqual(len(self._sql_calls_containing(cursor, "INSERT INTO raw_report_data")), 1)
+        self.assertEqual(len(self._sql_calls_containing(cursor, "INSERT INTO report_debug_logs")), 0)
+
+    def test_first_tail_sync_upserts_report_debug_logs_without_jsonl(self):
+        self.log_path.write_text("line one\n", encoding="utf-8")
+        sync = self._thread()
+        cursor = RecordingCursor(report_id=123)
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn):
+            self.assertTrue(sync._sync())
+
+        debug_calls = self._sql_calls_containing(cursor, "INSERT INTO report_debug_logs")
+        self.assertEqual(len(debug_calls), 1)
+        self.assertEqual(len(self._sql_calls_containing(cursor, "INSERT INTO raw_report_data")), 0)
+
+        normalized_sql = " ".join(debug_calls[0][0].split())
+        self.assertIn("(report_id, tail, tail_offset, tail_digest,", normalized_sql)
+        self.assertNotIn("logs = EXCLUDED.logs", normalized_sql)
+        self.assertNotIn(" logs,", normalized_sql)
+
+        params = debug_calls[0][1]
+        self.assertEqual(params[0], 123)
+        self.assertEqual(params[1], "line one\n")
+        self.assertEqual(params[2], 0)
+        self.assertIsInstance(params[3], str)
+        self.assertFalse(params[5])
+
+    def test_unchanged_tail_digest_skips_database_write(self):
+        self.log_path.write_text("same tail\n", encoding="utf-8")
+        sync = self._thread()
+        cursor = RecordingCursor()
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn):
+            self.assertTrue(sync._sync())
+
+        conn.reset()
+
+        with self._patch_pooled_connection(conn):
+            self.assertTrue(sync._sync())
+
+        self.assertEqual(cursor.execute_calls, [])
+        self.assertEqual(conn.commit_count, 0)
+
+    def test_changed_tail_updates_when_jsonl_is_unchanged(self):
+        self.jsonl_path.write_text('{"entry_type":"init"}\n', encoding="utf-8")
+        self.log_path.write_text("first\n", encoding="utf-8")
+        sync = self._thread()
+        cursor = RecordingCursor()
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn):
+            self.assertTrue(sync._sync())
+
+        conn.reset()
+        self.log_path.write_text("first\nsecond\n", encoding="utf-8")
+
+        with self._patch_pooled_connection(conn):
+            self.assertTrue(sync._sync())
+
+        debug_calls = self._sql_calls_containing(cursor, "INSERT INTO report_debug_logs")
+        raw_calls = self._sql_calls_containing(cursor, "INSERT INTO raw_report_data")
+        self.assertEqual(len(debug_calls), 1)
+        self.assertEqual(len(raw_calls), 0)
+        self.assertEqual(debug_calls[0][1][1], "first\nsecond\n")
+
+    def test_tail_sync_failure_does_not_rollback_jsonl_sync(self):
+        self.jsonl_path.write_text('{"entry_type":"init"}\n', encoding="utf-8")
+        self.log_path.write_text("live tail\n", encoding="utf-8")
+        sync = self._thread()
+        cursor = FailingTailCursor()
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn), \
+             self.assertLogs("db_notifier", level="WARNING") as logs:
+            self.assertTrue(sync._sync())
+
+        self.assertEqual(len(self._sql_calls_containing(cursor, "INSERT INTO raw_report_data")), 1)
+        self.assertEqual(len(self._sql_calls_containing(cursor, "INSERT INTO report_debug_logs")), 1)
+        self.assertEqual(conn.commit_count, 1)
+        self.assertEqual(conn.rollback_count, 1)
+        self.assertEqual(sync._last_synced_content, '{"entry_type":"init"}\n')
+        self.assertIsNone(sync._last_synced_tail_digest)
+        self.assertIn("failed to sync log tail", "\n".join(logs.output))
+
+    def test_tail_only_sync_failure_counts_as_failed_sync(self):
+        self.log_path.write_text("tail without jsonl\n", encoding="utf-8")
+        sync = self._thread()
+        cursor = FailingTailCursor()
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn), \
+             self.assertLogs("db_notifier", level="WARNING") as logs:
+            self.assertFalse(sync._sync())
+
+        self.assertEqual(len(self._sql_calls_containing(cursor, "INSERT INTO raw_report_data")), 0)
+        self.assertEqual(len(self._sql_calls_containing(cursor, "INSERT INTO report_debug_logs")), 1)
+        self.assertEqual(conn.commit_count, 0)
+        self.assertEqual(conn.rollback_count, 1)
+        self.assertIsNone(sync._last_synced_tail_digest)
+        self.assertIn("failed to sync log tail", "\n".join(logs.output))
+
+    def test_tail_reader_truncates_to_last_configured_bytes_and_reports_offset(self):
+        db_notifier.DEBUG_LOG_TAIL_BYTES = 10
+        self.log_path.write_bytes(b"0123456789abcdef")
+        sync = self._thread()
+
+        payload = sync._read_debug_log_tail()
+
+        self.assertEqual(payload["tail"], "6789abcdef")
+        self.assertEqual(payload["offset"], 6)
+        self.assertTrue(payload["truncated"])
+        self.assertIsInstance(payload["digest"], str)
+
+    def test_tail_reader_strips_nul_bytes_and_decodes_with_replacement(self):
+        self.log_path.write_bytes(b"a\x00b\xffc")
+        sync = self._thread()
+
+        payload = sync._read_debug_log_tail()
+
+        self.assertEqual(payload["tail"], "ab\ufffdc")
+        self.assertFalse(payload["truncated"])
+
+    def test_tail_reader_zero_limit_does_not_read_tail_bytes(self):
+        db_notifier.DEBUG_LOG_TAIL_BYTES = 0
+        self.log_path.write_text("hidden live output", encoding="utf-8")
+        sync = self._thread()
+
+        payload = sync._read_debug_log_tail()
+
+        self.assertIsNone(payload)
+
+    def test_zero_tail_limit_disables_debug_log_upsert(self):
+        db_notifier.DEBUG_LOG_TAIL_BYTES = 0
+        self.log_path.write_text("hidden live output", encoding="utf-8")
+        sync = self._thread()
+        cursor = RecordingCursor()
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn):
+            self.assertTrue(sync._sync())
+
+        self.assertEqual(len(self._sql_calls_containing(cursor, "INSERT INTO report_debug_logs")), 0)
+        self.assertEqual(cursor.execute_calls, [])
+        self.assertEqual(conn.commit_count, 0)
+
+    def test_notify_report_running_clears_live_tail_without_erasing_final_logs(self):
+        cursor = RecordingCursor(report_id=123)
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn), \
+             patch.object(db_notifier, "_enqueue_broadcast_stats_job", return_value="job-id"):
+            self.assertTrue(db_notifier.notify_report_running("report-uuid", 456))
+
+        tail_reset_calls = self._sql_calls_containing(cursor, "UPDATE report_debug_logs")
+        self.assertEqual(len(tail_reset_calls), 1)
+        normalized_sql = " ".join(tail_reset_calls[0][0].split())
+        self.assertNotIn("logs = NULL", normalized_sql)
+        self.assertIn("tail = NULL", normalized_sql)
+        self.assertIn("tail_offset = 0", normalized_sql)
+        self.assertIn("tail_digest = NULL", normalized_sql)
+        self.assertIn("tail_synced_at = NULL", normalized_sql)
+        self.assertIn("tail_truncated = FALSE", normalized_sql)
+        self.assertEqual(tail_reset_calls[0][1], (123,))
+
+    def test_notify_report_ready_from_synced_clears_raw_logs_when_log_file_missing(self):
+        cursor = RecordingCursor(report_id=123)
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn), \
+             patch.object(db_notifier, "get_log_file_path", return_value=self.log_path), \
+             patch.object(db_notifier, "_enqueue_process_report_job", return_value="job-id"), \
+             patch.object(db_notifier, "cleanup_scan_files"):
+            self.assertTrue(db_notifier.notify_report_ready_from_synced("report-uuid"))
+
+        raw_log_updates = self._sql_calls_containing(cursor, "UPDATE raw_report_data")
+        self.assertEqual(len(raw_log_updates), 1)
+        self.assertIsNone(raw_log_updates[0][1][0])
+        self.assertEqual(raw_log_updates[0][1][2], 123)
+
+    def test_notify_report_ready_from_synced_reads_and_sanitizes_log_file(self):
+        self.log_path.write_bytes(b"first line\nnul\x00 stripped\n")
+        cursor = RecordingCursor(report_id=123)
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn), \
+             patch.object(db_notifier, "get_log_file_path", return_value=self.log_path), \
+             patch.object(db_notifier, "_enqueue_process_report_job", return_value="job-id"), \
+             patch.object(db_notifier, "cleanup_scan_files"):
+            self.assertTrue(db_notifier.notify_report_ready_from_synced("report-uuid"))
+
+        raw_log_updates = self._sql_calls_containing(cursor, "UPDATE raw_report_data")
+        self.assertEqual(len(raw_log_updates), 1)
+        params = raw_log_updates[0][1]
+        self.assertEqual(params[0], "first line\nnul stripped\n")
+        self.assertIsNotNone(params[1])
+        self.assertEqual(params[2], 123)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/script/tests/test_run_garak_log_path.py
+++ b/script/tests/test_run_garak_log_path.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Tests for run_garak JournalSyncThread setup.
+"""
+
+import os
+import signal
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_mock_db = ModuleType("db_notifier")
+_mock_db.notify_report_running = MagicMock(return_value=True)
+_mock_db.notify_report_ready = MagicMock(return_value=True)
+_mock_db.notify_report_ready_from_synced = MagicMock(return_value=True)
+_mock_db.notify_report_stopped = MagicMock(return_value=True)
+_mock_db.load_existing_jsonl_prefix = MagicMock(return_value="")
+_mock_db.get_log_file_path = MagicMock(return_value=Path("/tmp/fake_reports/report.log"))
+_mock_db.HeartbeatThread = MagicMock
+_mock_db.JournalSyncThread = MagicMock
+_mock_db.REPORTS_PATH = Path("/tmp/fake_reports")
+
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__), "..")
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
+_original_db_notifier = sys.modules.get("db_notifier")
+_original_run_garak = sys.modules.pop("run_garak", None)
+_orig_sigterm = signal.getsignal(signal.SIGTERM)
+_orig_sigint = signal.getsignal(signal.SIGINT)
+sys.modules["db_notifier"] = _mock_db
+
+try:
+    import run_garak as _run_garak  # noqa: E402
+finally:
+    if _original_db_notifier is None:
+        sys.modules.pop("db_notifier", None)
+    else:
+        sys.modules["db_notifier"] = _original_db_notifier
+
+    if _original_run_garak is None:
+        sys.modules.pop("run_garak", None)
+    else:
+        sys.modules["run_garak"] = _original_run_garak
+
+    signal.signal(signal.SIGTERM, _orig_sigterm)
+    signal.signal(signal.SIGINT, _orig_sigint)
+
+run_garak = _run_garak
+
+
+class TestRunGarakJournalSyncLogPath(unittest.TestCase):
+    def setUp(self):
+        self._saved_uuid = run_garak.current_report_uuid
+        self._saved_hb = run_garak.current_heartbeat
+        self._saved_js = run_garak.current_journal_sync
+
+    def tearDown(self):
+        run_garak.current_report_uuid = self._saved_uuid
+        run_garak.current_heartbeat = self._saved_hb
+        run_garak.current_journal_sync = self._saved_js
+
+    def test_main_passes_log_path_to_journal_sync_for_non_validation_runs(self):
+        argv = [
+            "run_garak.py",
+            "report-uuid",
+            "--target_type",
+            "rest.RestGenerator",
+            "--target_name",
+            "rest",
+        ]
+        log_path = Path("/tmp/report-uuid.log")
+        journal_sync = MagicMock()
+        journal_sync.stop.return_value = True
+        heartbeat = MagicMock()
+
+        with patch.object(sys, "argv", argv), \
+             patch.object(run_garak, "notify_report_running", return_value=True), \
+             patch.object(run_garak, "HeartbeatThread", return_value=heartbeat), \
+             patch.object(run_garak, "load_existing_jsonl_prefix", return_value="prefix-data"), \
+             patch.object(run_garak, "get_log_file_path", return_value=log_path), \
+             patch.object(run_garak, "JournalSyncThread", return_value=journal_sync) as mock_journal_sync, \
+             patch.object(run_garak, "run_garak_scan", return_value=0), \
+             patch.object(run_garak, "notify_report_ready_from_synced", return_value=True), \
+             patch.object(run_garak, "notify_report_stopped", return_value=True), \
+             patch("sys.exit") as mock_exit:
+            run_garak.main()
+
+        mock_journal_sync.assert_called_once_with(
+            "report-uuid",
+            run_garak.REPORTS_PATH / "report-uuid.report.jsonl",
+            prefix="prefix-data",
+            log_path=log_path,
+        )
+        journal_sync.start.assert_called_once()
+        journal_sync.stop.assert_called_once()
+        heartbeat.start.assert_called_once()
+        heartbeat.stop.assert_called_once()
+        mock_exit.assert_called_once_with(0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/script/tests/test_run_garak_signal_handler.py
+++ b/script/tests/test_run_garak_signal_handler.py
@@ -18,6 +18,7 @@ import signal
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
@@ -34,6 +35,7 @@ _mock_db.notify_report_ready = MagicMock(return_value=True)
 _mock_db.notify_report_ready_from_synced = MagicMock(return_value=True)
 _mock_db.notify_report_stopped = MagicMock(return_value=True)
 _mock_db.load_existing_jsonl_prefix = MagicMock(return_value="")
+_mock_db.get_log_file_path = MagicMock(return_value=Path("/tmp/fake_reports/report.log"))
 _mock_db.HeartbeatThread = MagicMock
 _mock_db.JournalSyncThread = MagicMock
 _mock_db.REPORTS_PATH = "/tmp/fake_reports"
@@ -42,9 +44,11 @@ _mock_db.REPORTS_PATH = "/tmp/fake_reports"
 _mock_psycopg2 = ModuleType("psycopg2")
 _mock_psycopg2.OperationalError = Exception
 _mock_psycopg2.pool = ModuleType("psycopg2.pool")
+_mock_psycopg2.pool.ThreadedConnectionPool = MagicMock
 sys.modules["psycopg2"] = _mock_psycopg2
 sys.modules["psycopg2.pool"] = _mock_psycopg2.pool
 
+_original_db_notifier = sys.modules.get("db_notifier")
 sys.modules["db_notifier"] = _mock_db
 
 # Add script/ to sys.path so `import run_garak` resolves
@@ -55,7 +59,13 @@ sys.path.insert(0, SCRIPT_DIR)
 _orig_sigterm = signal.getsignal(signal.SIGTERM)
 _orig_sigint = signal.getsignal(signal.SIGINT)
 
-import run_garak  # noqa: E402  (registers global SIGTERM/SIGINT handlers)
+try:
+    import run_garak  # noqa: E402  (registers global SIGTERM/SIGINT handlers)
+finally:
+    if _original_db_notifier is None:
+        sys.modules.pop("db_notifier", None)
+    else:
+        sys.modules["db_notifier"] = _original_db_notifier
 
 
 class TestParentSignalHandler(unittest.TestCase):

--- a/spec/factories/report_debug_logs.rb
+++ b/spec/factories/report_debug_logs.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :report_debug_log do
+    report
+    logs { nil }
+    tail { nil }
+    tail_offset { 0 }
+    tail_digest { nil }
+    tail_synced_at { nil }
+    tail_truncated { false }
+  end
+end

--- a/spec/helpers/reports_helper_spec.rb
+++ b/spec/helpers/reports_helper_spec.rb
@@ -275,4 +275,77 @@ RSpec.describe ReportsHelper, type: :helper do
       end
     end
   end
+
+  describe '#activity_stream_active_status_for_report?' do
+    it 'returns true for pending and debug broadcast active statuses' do
+      statuses = (Report::DEBUG_BROADCAST_ACTIVE_STATUSES + %w[pending]).uniq
+
+      statuses.each do |status|
+        report = build_stubbed(:report, status: status)
+
+        expect(helper.activity_stream_active_status_for_report?(report)).to be(true)
+      end
+    end
+
+    it 'returns false for terminal statuses' do
+      statuses = Report.statuses.keys - (Report::DEBUG_BROADCAST_ACTIVE_STATUSES + %w[pending]).uniq
+
+      statuses.each do |status|
+        report = build_stubbed(:report, status: status)
+
+        expect(helper.activity_stream_active_status_for_report?(report)).to be(false)
+      end
+    end
+
+    it 'returns false without a report' do
+      expect(helper.activity_stream_active_status_for_report?(nil)).to be(false)
+    end
+  end
+
+  describe '#show_activity_stream_for_report?' do
+    let(:user) { build_stubbed(:user) }
+    let(:params) { ActionController::Parameters.new }
+
+    it 'returns true for active reports without a debug query' do
+      report = build_stubbed(:report, :running)
+
+      expect(helper.show_activity_stream_for_report?(report, params: params, user: user)).to be(true)
+    end
+
+    it 'returns true for pending reports without a debug query' do
+      report = build_stubbed(:report, status: :pending)
+
+      expect(helper.show_activity_stream_for_report?(report, params: params, user: user)).to be(true)
+    end
+
+    it 'returns false for terminal reports by default' do
+      report = build_stubbed(:report, :completed)
+
+      expect(helper.show_activity_stream_for_report?(report, params: params, user: user)).to be(false)
+    end
+
+    it 'keeps the optional debug query fallback for terminal reports' do
+      report = build_stubbed(:report, :completed)
+      debug_params = ActionController::Parameters.new(debug: 'true')
+
+      expect(helper.show_activity_stream_for_report?(report, params: debug_params, user: user)).to be(true)
+    end
+
+    it 'returns false without an authenticated user' do
+      report = build_stubbed(:report, :running)
+
+      expect(helper.show_activity_stream_for_report?(report, params: params, user: nil)).to be(false)
+    end
+
+    it 'returns false in PDF mode even when debug fallback is requested' do
+      report = build_stubbed(:report, :running)
+      debug_params = ActionController::Parameters.new(debug: 'true')
+
+      expect(helper.show_activity_stream_for_report?(report, params: debug_params, user: user, pdf_mode: true)).to be(false)
+    end
+
+    it 'returns false without a report' do
+      expect(helper.show_activity_stream_for_report?(nil, params: params, user: user)).to be(false)
+    end
+  end
 end

--- a/spec/jobs/broadcast_report_debug_job_spec.rb
+++ b/spec/jobs/broadcast_report_debug_job_spec.rb
@@ -1,0 +1,384 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BroadcastReportDebugJob, type: :job do
+  let(:company) { create(:company) }
+  let(:target) { create(:target, company: company) }
+  let(:scan) { create(:complete_scan, company: company) }
+  let(:report) { create(:report, :running, company: company, target: target, scan: scan) }
+
+  before do
+    @original_cache_store = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    allow_any_instance_of(ToastNotifier).to receive(:call)
+    allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
+  end
+
+  after do
+    Rails.cache = @original_cache_store
+  end
+
+  def raw_jsonl(probe_name = "probe.Alpha")
+    JSON.generate(entry_type: "attempt", probe_classname: probe_name, uuid: SecureRandom.uuid)
+  end
+
+  def cache_digest(report)
+    payload = Reports::DebugStreamPayload.new(report.reload).call
+    Rails.cache.write(
+      described_class.digest_cache_key(report.id),
+      described_class.new.send(:broadcast_digest, report, payload),
+      expires_in: 5.minutes
+    )
+  end
+
+  def cache_fingerprint(report)
+    fingerprint = Reports::DebugStreamFingerprint.new(report.reload).call
+
+    Rails.cache.write(
+      described_class.fingerprint_cache_key(report.id),
+      fingerprint[:digest],
+      expires_in: 5.minutes
+    )
+  end
+
+  def clear_test_jobs
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    ActiveJob::Base.queue_adapter.performed_jobs.clear
+  end
+
+  def render_partial(partial, payload)
+    ActsAsTenant.with_tenant(company) do
+      ApplicationController.render(
+        partial: partial,
+        locals: { report: report, payload: payload }
+      )
+    end
+  end
+
+  describe "#perform" do
+    it "only enqueues one poller while a poller lease is active" do
+      expect(Reports::DebugWatcher.refresh_and_enqueue(report)).to be(true)
+      expect(Reports::DebugWatcher.refresh_and_enqueue(report)).to be(false)
+
+      jobs = ActiveJob::Base.queue_adapter.enqueued_jobs
+      expect(jobs.count { |job| job[:job] == described_class }).to eq(1)
+    end
+
+    it "exits without broadcasting or re-enqueuing when no watcher exists" do
+      create(:raw_report_data, report: report, jsonl_data: raw_jsonl)
+
+      expect {
+        described_class.new.perform(report.id)
+      }.not_to have_enqueued_job(described_class)
+
+      expect(Turbo::StreamsChannel).not_to have_received(:broadcast_replace_to)
+    end
+
+    it "broadcasts a changed payload and caches the digest" do
+      Reports::DebugWatcher.refresh(report.id)
+      create(:raw_report_data, report: report, jsonl_data: raw_jsonl)
+
+      described_class.new.perform(report.id)
+
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to).with(
+        Reports::DebugWatcher.stream_name(report),
+        target: "report-debug-stream-content",
+        partial: "admin/reports/debug_panel_stream",
+        locals: hash_including(report: report, payload: hash_including(:timeline, :logs, :log_metadata, :activity, :digest))
+      )
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to).with(
+        Reports::DebugWatcher.stream_name(report),
+        target: "report-activity-stream-summary",
+        partial: "admin/reports/activity_stream_summary",
+        locals: hash_including(report: report, payload: hash_including(:activity))
+      )
+      expect(Rails.cache.read(described_class.digest_cache_key(report.id))).to be_present
+      expect(Rails.cache.read(described_class.fingerprint_cache_key(report.id))).to be_present
+    end
+
+    it "does not advance caches when payload construction fails" do
+      Reports::DebugWatcher.refresh(report.id)
+      create(:raw_report_data, report: report, jsonl_data: raw_jsonl)
+      payload_builder = instance_double(Reports::DebugStreamPayload)
+
+      allow(Reports::DebugStreamPayload).to receive(:new).and_return(payload_builder)
+      allow(payload_builder).to receive(:call).and_raise(StandardError, "payload failed")
+
+      expect {
+        described_class.new.perform(report.id)
+      }.to raise_error(StandardError, "payload failed")
+
+      expect(Rails.cache.read(described_class.digest_cache_key(report.id))).to be_nil
+      expect(Rails.cache.read(described_class.fingerprint_cache_key(report.id))).to be_nil
+    end
+
+    it "does not advance caches when broadcasting fails" do
+      Reports::DebugWatcher.refresh(report.id)
+      create(:raw_report_data, report: report, jsonl_data: raw_jsonl)
+
+      allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to).and_raise(StandardError, "broadcast failed")
+
+      expect {
+        described_class.new.perform(report.id)
+      }.to raise_error(StandardError, "broadcast failed")
+
+      expect(Rails.cache.read(described_class.digest_cache_key(report.id))).to be_nil
+      expect(Rails.cache.read(described_class.fingerprint_cache_key(report.id))).to be_nil
+    end
+
+    it "skips broadcast when the digest has not changed" do
+      Reports::DebugWatcher.refresh(report.id)
+      create(:raw_report_data, report: report, jsonl_data: raw_jsonl)
+      cache_digest(report)
+
+      expect(Reports::DebugStreamPayload).to receive(:new).and_call_original
+
+      described_class.new.perform(report.id)
+
+      expect(Turbo::StreamsChannel).not_to have_received(:broadcast_replace_to)
+    end
+
+    it "skips payload construction for unchanged fingerprints but still re-enqueues polling reports" do
+      Reports::DebugWatcher.refresh(report.id)
+      create(:raw_report_data, report: report, jsonl_data: raw_jsonl)
+      cache_fingerprint(report)
+
+      expect(Reports::DebugStreamPayload).not_to receive(:new)
+
+      expect {
+        described_class.new.perform(report.id)
+      }.to have_enqueued_job(described_class).with(report.id)
+
+      expect(Turbo::StreamsChannel).not_to have_received(:broadcast_replace_to)
+    end
+
+    it "broadcasts when raw JSONL content changes" do
+      Reports::DebugWatcher.refresh(report.id)
+      raw_data = create(:raw_report_data, report: report, jsonl_data: raw_jsonl("probe.Before"))
+      cache_digest(report)
+      cache_fingerprint(report)
+      raw_data.update!(jsonl_data: raw_jsonl("probe.After"))
+
+      described_class.new.perform(report.id)
+
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to).at_least(:once)
+    end
+
+    it "broadcasts when only the report debug-log tail changes" do
+      Reports::DebugWatcher.refresh(report.id)
+      create(:raw_report_data, report: report, jsonl_data: raw_jsonl)
+      debug_log = create(:report_debug_log, report: report, tail: "first tail\n", tail_digest: "tail-1")
+      cache_digest(report)
+      cache_fingerprint(report)
+      debug_log.update!(tail: "first tail\nsecond tail\n", tail_digest: "tail-2", tail_synced_at: Time.current)
+
+      described_class.new.perform(report.id)
+
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to).with(
+        Reports::DebugWatcher.stream_name(report),
+        hash_including(
+          target: "report-debug-stream-content",
+          locals: hash_including(
+            payload: hash_including(
+              logs: "first tail\nsecond tail\n",
+              log_metadata: hash_including(source: "live_tail")
+            )
+          )
+        )
+      )
+    end
+
+    it "does not rebroadcast when only the report_debug_log row timestamp changes" do
+      Reports::DebugWatcher.refresh(report.id)
+      create(:raw_report_data, report: report, jsonl_data: raw_jsonl)
+      debug_log = create(:report_debug_log, report: report, tail: "stable tail\n", tail_digest: "tail-stable")
+      cache_digest(report)
+      cache_fingerprint(report)
+      debug_log.touch
+
+      expect(Reports::DebugStreamPayload).not_to receive(:new)
+
+      described_class.new.perform(report.id)
+
+      expect(Turbo::StreamsChannel).not_to have_received(:broadcast_replace_to)
+    end
+
+    it "broadcasts final full logs after a report leaves a polling status" do
+      Reports::DebugWatcher.refresh(report.id)
+      create(:raw_report_data, report: report, jsonl_data: raw_jsonl)
+      create(:report_debug_log, report: report, logs: "final full logs\n", tail: "live tail\n", tail_digest: "tail-live")
+      cache_digest(report)
+      cache_fingerprint(report)
+
+      clear_test_jobs
+      report.update!(status: :completed)
+      described_class.new.perform(report.id)
+
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to).with(
+        Reports::DebugWatcher.stream_name(report),
+        hash_including(
+          target: "report-debug-stream-content",
+          locals: hash_including(
+            payload: hash_including(
+              logs: "final full logs\n",
+              log_metadata: hash_including(source: "full_logs")
+            )
+          )
+        )
+      )
+    end
+
+    it "renders broadcast partials with the same locals used by the job" do
+      create(:raw_report_data, report: report, jsonl_data: raw_jsonl("probe.Rendered"))
+      create(:report_debug_log, report: report, tail: "rendered live tail\n", tail_digest: "tail-render")
+      payload = Reports::DebugStreamPayload.new(report.reload).call
+
+      debug_html = render_partial("admin/reports/debug_panel_stream", payload)
+      summary_html = render_partial("admin/reports/activity_stream_summary", payload)
+
+      expect(debug_html).to include("report-debug-stream-content")
+      expect(debug_html).to include('data-debug-tabs-target="panel"')
+      expect(debug_html).to include('data-tab="timeline"')
+      expect(debug_html).to include('data-tab="raw"')
+      expect(debug_html).to include('data-tab="logs"')
+      expect(debug_html).to include("probe.Rendered")
+      expect(debug_html).to include("rendered live tail")
+      expect(summary_html).to include("report-activity-stream-summary")
+      expect(summary_html).to include("Activity Stream")
+      expect(summary_html).to include("1 attempt so far")
+    end
+
+    it "broadcasts status-only activity and re-enqueues when raw_report_data is missing" do
+      Reports::DebugWatcher.refresh(report.id)
+
+      expect {
+        described_class.new.perform(report.id)
+      }.to have_enqueued_job(described_class).with(report.id)
+
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to).with(
+        Reports::DebugWatcher.stream_name(report),
+        hash_including(
+          target: "report-activity-stream-summary",
+          locals: hash_including(payload: hash_including(activity: hash_including(active: true)))
+        )
+      )
+    end
+
+    it "polls pending, starting, running, and processing reports" do
+      Report::DEBUG_STREAM_POLLING_STATUSES.each do |status|
+        polling_report = create(:report, company: company, target: target, scan: scan, status: status)
+        Reports::DebugWatcher.refresh(polling_report.id)
+
+        expect {
+          described_class.new.perform(polling_report.id)
+        }.to have_enqueued_job(described_class).with(polling_report.id)
+
+        clear_test_jobs
+      end
+    end
+
+    it "does not re-enqueue terminal reports" do
+      terminal_report = create(:report, :completed, company: company, target: target, scan: scan)
+      Reports::DebugWatcher.refresh(terminal_report.id)
+
+      expect {
+        described_class.new.perform(terminal_report.id)
+      }.not_to have_enqueued_job(described_class)
+    end
+
+    it "exits cleanly if the report disappears during reload" do
+      Reports::DebugWatcher.refresh(report.id)
+      create(:raw_report_data, report: report, jsonl_data: raw_jsonl)
+      report_id = report.id
+
+      allow_any_instance_of(Report).to receive(:reload) do |record|
+        record.destroy! if record.id == report_id && !record.destroyed?
+        raise ActiveRecord::RecordNotFound, "Couldn't find Report with id=#{report_id}" if record.id == report_id
+
+        record
+      end
+
+      expect {
+        expect {
+          described_class.new.perform(report_id)
+        }.not_to raise_error
+      }.not_to have_enqueued_job(described_class)
+
+      expect(Turbo::StreamsChannel).not_to have_received(:broadcast_replace_to)
+    end
+  end
+
+  describe "status-change wiring" do
+    it "enqueues a broadcast when a watched report status changes" do
+      Reports::DebugWatcher.refresh(report.id)
+      clear_test_jobs
+
+      expect {
+        report.update!(status: :processing)
+      }.to have_enqueued_job(described_class).with(report.id)
+    end
+
+    it "enqueues a terminal broadcast even while the poller lease is active" do
+      Reports::DebugWatcher.refresh(report.id)
+      described_class.mark_poller_active(report.id)
+      clear_test_jobs
+
+      expect {
+        report.update!(status: :completed)
+      }.to have_enqueued_job(described_class).with(report.id)
+    end
+
+    it "does not enqueue when no watcher exists" do
+      expect {
+        report.update!(status: :processing)
+      }.not_to have_enqueued_job(described_class)
+    end
+
+    it "schedules a delayed follow-up broadcast for stopped transitions" do
+      Reports::DebugWatcher.refresh(report.id)
+
+      expect {
+        described_class.enqueue_status_change(report.id, "stopped")
+      }.to have_enqueued_job(described_class).with(report.id).twice
+    end
+
+    it "schedules a delayed follow-up broadcast for failed transitions" do
+      Reports::DebugWatcher.refresh(report.id)
+
+      expect {
+        described_class.enqueue_status_change(report.id, "failed")
+      }.to have_enqueued_job(described_class).with(report.id).twice
+    end
+
+    it "schedules a delayed follow-up broadcast for interrupted transitions" do
+      Reports::DebugWatcher.refresh(report.id)
+
+      expect {
+        described_class.enqueue_status_change(report.id, "interrupted")
+      }.to have_enqueued_job(described_class).with(report.id).twice
+    end
+
+    it "does not schedule a follow-up broadcast for completed transitions" do
+      Reports::DebugWatcher.refresh(report.id)
+
+      expect {
+        described_class.enqueue_status_change(report.id, "completed")
+      }.to have_enqueued_job(described_class).with(report.id).once
+    end
+
+    it "schedules the follow-up broadcast with FINAL_TAIL_FOLLOWUP_DELAY" do
+      Reports::DebugWatcher.refresh(report.id)
+
+      described_class.enqueue_status_change(report.id, "stopped")
+
+      delayed_jobs = ActiveJob::Base.queue_adapter.enqueued_jobs.select do |job|
+        job[:job] == described_class && job[:args].first == report.id && job[:at].present?
+      end
+
+      expect(delayed_jobs.size).to eq(1)
+      expected_at = (Time.current + described_class::FINAL_TAIL_FOLLOWUP_DELAY).to_f
+      expect(delayed_jobs.first[:at]).to be_within(2.0).of(expected_at)
+    end
+  end
+end

--- a/spec/jobs/check_stale_reports_job_spec.rb
+++ b/spec/jobs/check_stale_reports_job_spec.rb
@@ -98,6 +98,81 @@ RSpec.describe CheckStaleReportsJob, type: :job do
         expect(report.logs).not_to start_with("\n")
       end
 
+      it "leaves existing logs intact when the live tail is blank" do
+        stale_time = 3.minutes.ago
+        report = create(:report, target: target, scan: scan, status: :running, pid: 12345, heartbeat_at: stale_time, logs: "Previous log entry", retry_count: 0)
+        report.report_debug_log.update!(tail: "")
+
+        described_class.new.perform
+
+        report.reload
+        expect(report.status).to eq("interrupted")
+        expect(report.logs).to start_with("Previous log entry")
+        expect(report.logs).to include("Interrupted:")
+      end
+
+      it "promotes live tail before marking stale reports interrupted when logs are blank" do
+        stale_time = 3.minutes.ago
+        report = create(:report, target: target, scan: scan, status: :running, pid: 12345, heartbeat_at: stale_time, logs: nil, retry_count: 0)
+        report.report_debug_log.update!(tail: "garak line 1\ngarak line 2\n")
+
+        described_class.new.perform
+
+        report.reload
+        expect(report.status).to eq("interrupted")
+        expect(report.logs).to start_with("garak line 1\ngarak line 2")
+        expect(report.logs.index("garak line 2")).to be < report.logs.index("Interrupted:")
+      end
+
+      it "appends live tail when the same tail text appears earlier but not at the end" do
+        stale_time = 3.minutes.ago
+        tail = "repeated garak output\nretry detail\n"
+        existing_logs = "previous attempt\n#{tail}newer persisted line"
+        report = create(
+          :report,
+          target: target,
+          scan: scan,
+          status: :running,
+          pid: 12345,
+          heartbeat_at: stale_time,
+          logs: existing_logs,
+          retry_count: 0
+        )
+        report.report_debug_log.update!(tail: tail)
+
+        described_class.new.perform
+
+        report.reload
+        expect(report.status).to eq("interrupted")
+        expect(report.logs.scan(tail).size).to eq(2)
+        expect(report.logs).to include("newer persisted line\n#{tail}")
+        expect(report.logs).to include("Interrupted:")
+      end
+
+      it "does not duplicate live tail when logs already end with it" do
+        stale_time = 3.minutes.ago
+        tail = "garak line 1\ngarak line 2\n"
+        existing_logs = "previous log\n#{tail.rstrip}"
+        report = create(
+          :report,
+          target: target,
+          scan: scan,
+          status: :running,
+          pid: 12345,
+          heartbeat_at: stale_time,
+          logs: existing_logs,
+          retry_count: 0
+        )
+        report.report_debug_log.update!(tail: tail)
+
+        described_class.new.perform
+
+        report.reload
+        expect(report.status).to eq("interrupted")
+        expect(report.logs.scan(tail.rstrip).size).to eq(1)
+        expect(report.logs).to include("Interrupted:")
+      end
+
       it "skips report if status changed during processing" do
         stale_time = 3.minutes.ago
         report = create(:report, target: target, scan: scan, status: :running, pid: 12345, heartbeat_at: stale_time)
@@ -137,6 +212,19 @@ RSpec.describe CheckStaleReportsJob, type: :job do
         report.reload
         expect(report.status).to eq("failed")
         expect(report.logs).to include("after 3 retry attempts")
+      end
+
+      it "promotes live tail before marking never-started reports failed" do
+        old_time = 3.minutes.ago
+        report = create(:report, target: target, scan: scan, status: :running, heartbeat_at: nil, updated_at: old_time, retry_count: 3)
+        create(:report_debug_log, report: report, tail: "startup stderr\n")
+
+        described_class.new.perform
+
+        report.reload
+        expect(report.status).to eq("failed")
+        expect(report.logs).to include("startup stderr")
+        expect(report.logs.index("startup stderr")).to be < report.logs.index("after 3 retry attempts")
       end
 
       it "does not affect recent reports with nil heartbeat" do
@@ -212,6 +300,19 @@ RSpec.describe CheckStaleReportsJob, type: :job do
         report.reload
         expect(report.status).to eq("failed")
         expect(report.logs).to include("after 3 retry attempts")
+      end
+
+      it "promotes live tail before marking orphaned reports interrupted" do
+        report = create(:report, target: target, scan: scan, status: :running,
+                        pid: nil, heartbeat_at: 1.minute.ago, updated_at: 3.minutes.ago, retry_count: 0)
+        create(:report_debug_log, report: report, tail: "orphan stderr\n")
+
+        described_class.new.perform
+
+        report.reload
+        expect(report.status).to eq("interrupted")
+        expect(report.logs).to include("orphan stderr")
+        expect(report.logs.index("orphan stderr")).to be < report.logs.index("Interrupted:")
       end
 
       it "does not affect running reports with a pid still set" do
@@ -310,6 +411,33 @@ RSpec.describe CheckStaleReportsJob, type: :job do
         expect(report.logs).to include("Retry 2:")
       end
 
+      it "does not append stale live tail when retrying a stuck starting report" do
+        stuck_time = 3.minutes.ago
+        report = create(
+          :report,
+          target: target,
+          scan: scan,
+          status: :starting,
+          logs: "previous retry audit",
+          retry_count: 0,
+          updated_at: stuck_time
+        )
+        debug_log = report.report_debug_log
+        debug_log.update!(tail: "stale previous tail\n", tail_offset: 512, tail_digest: "stale")
+
+        described_class.new.perform
+
+        report.reload
+        debug_log.reload
+        expect(report.status).to eq("pending")
+        expect(report.logs).to include("previous retry audit")
+        expect(report.logs).to include("Retry 1:")
+        expect(report.logs).not_to include("stale previous tail")
+        expect(debug_log.tail).to be_nil
+        expect(debug_log.tail_offset).to eq(0)
+        expect(debug_log.tail_digest).to be_nil
+      end
+
       it "marks as failed after max retries" do
         stuck_time = 3.minutes.ago
         report = create(:report, target: target, scan: scan, status: :starting, retry_count: 3, updated_at: stuck_time)
@@ -318,6 +446,19 @@ RSpec.describe CheckStaleReportsJob, type: :job do
 
         report.reload
         expect(report.status).to eq("failed")
+        expect(report.logs).to include("Failed after 3 start attempts")
+      end
+
+      it "does not append stale live tail before marking start-timeout reports failed" do
+        stuck_time = 3.minutes.ago
+        report = create(:report, target: target, scan: scan, status: :starting, retry_count: 3, updated_at: stuck_time)
+        create(:report_debug_log, report: report, tail: "start timeout stderr\n")
+
+        described_class.new.perform
+
+        report.reload
+        expect(report.status).to eq("failed")
+        expect(report.logs).not_to include("start timeout stderr")
         expect(report.logs).to include("Failed after 3 start attempts")
       end
 

--- a/spec/jobs/retry_interrupted_reports_job_spec.rb
+++ b/spec/jobs/retry_interrupted_reports_job_spec.rb
@@ -52,6 +52,21 @@ RSpec.describe RetryInterruptedReportsJob, type: :job do
         expect(report.pid).to be_nil
       end
 
+      it "clears stale live tail on retry" do
+        report = create(:report, target: target, scan: scan, status: :interrupted, updated_at: 1.minute.ago)
+        debug_log = create(:report_debug_log, report: report, tail: "previous attempt tail\n", tail_offset: 256, tail_digest: "old-tail", tail_synced_at: 1.minute.ago, tail_truncated: true)
+
+        described_class.new.perform
+
+        debug_log.reload
+        expect(report.reload.status).to eq("pending")
+        expect(debug_log.tail).to be_nil
+        expect(debug_log.tail_offset).to eq(0)
+        expect(debug_log.tail_digest).to be_nil
+        expect(debug_log.tail_synced_at).to be_nil
+        expect(debug_log.tail_truncated).to be(false)
+      end
+
       it "appends retry log message" do
         report = create(:report, target: target, scan: scan, status: :interrupted, logs: "Previous log", retry_count: 0, updated_at: 1.minute.ago)
 

--- a/spec/jobs/start_pending_scans_job_spec.rb
+++ b/spec/jobs/start_pending_scans_job_spec.rb
@@ -165,6 +165,21 @@ RSpec.describe StartPendingScansJob, type: :job do
         expect(report.status).to eq("starting")
       end
 
+      it "clears stale live tail when claiming a retry for starting" do
+        report = create(:report, target: target, scan: scan, status: :pending, retry_count: 1)
+        debug_log = create(:report_debug_log, report: report, tail: "previous attempt tail\n", tail_offset: 128, tail_digest: "old-tail", tail_synced_at: 1.minute.ago, tail_truncated: true)
+
+        described_class.new.perform
+
+        debug_log.reload
+        expect(report.reload.status).to eq("starting")
+        expect(debug_log.tail).to be_nil
+        expect(debug_log.tail_offset).to eq(0)
+        expect(debug_log.tail_digest).to be_nil
+        expect(debug_log.tail_synced_at).to be_nil
+        expect(debug_log.tail_truncated).to be(false)
+      end
+
       it "does not start scan if claim fails (status changed)" do
         report = create(:report, target: target, scan: scan, status: :pending)
 

--- a/spec/migrations/create_report_debug_logs_and_move_report_logs_spec.rb
+++ b/spec/migrations/create_report_debug_logs_and_move_report_logs_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260427000000_create_report_debug_logs_and_move_report_logs")
+
+RSpec.describe CreateReportDebugLogsAndMoveReportLogs do
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:migration) { described_class.new }
+
+  around do |example|
+    restore_current_schema
+    example.run
+  ensure
+    restore_current_schema
+  end
+
+  it "backfills nonblank reports.logs and restores them on rollback" do
+    report_with_logs = create(:report)
+    blank_report = create(:report)
+    whitespace_report = create(:report)
+
+    migrate_down
+
+    update_report_logs(report_with_logs.id, "legacy log line")
+    update_report_logs(blank_report.id, "")
+    update_report_logs(whitespace_report.id, "   ")
+
+    migrate_up
+
+    expect(connection.column_exists?(:reports, :logs)).to be(false)
+    expect(moved_report_logs).to eq(report_with_logs.id => "legacy log line")
+
+    migrate_down
+
+    expect(connection.column_exists?(:reports, :logs)).to be(true)
+    expect(report_logs(report_with_logs.id)).to eq("legacy log line")
+    expect(report_logs(blank_report.id)).to be_nil
+    expect(report_logs(whitespace_report.id)).to be_nil
+  end
+
+  it "keeps Report#logs compatible while the legacy column still exists" do
+    report = create(:report)
+
+    migrate_down
+    update_report_logs(report.id, "legacy only")
+    Report.reset_column_information
+
+    expect(report.reload.logs).to eq("legacy only")
+  end
+
+  private
+
+  def moved_report_logs
+    connection.select_rows(<<~SQL.squish).to_h
+      SELECT report_id, logs
+      FROM report_debug_logs
+      ORDER BY report_id
+    SQL
+  end
+
+  def report_logs(report_id)
+    connection.select_value("SELECT logs FROM reports WHERE id = #{report_id}")
+  end
+
+  def update_report_logs(report_id, logs)
+    connection.execute(<<~SQL.squish)
+      UPDATE reports
+      SET logs = #{connection.quote(logs)}
+      WHERE id = #{report_id}
+    SQL
+  end
+
+  def migrate_down
+    return if connection.column_exists?(:reports, :logs) && !connection.table_exists?(:report_debug_logs)
+
+    ActiveRecord::Migration.suppress_messages { migration.down }
+    reset_schema_cache
+  end
+
+  def migrate_up
+    return if current_schema?
+
+    ActiveRecord::Migration.suppress_messages { migration.up }
+    reset_schema_cache
+  end
+
+  def restore_current_schema
+    reset_schema_cache
+
+    if !connection.table_exists?(:report_debug_logs)
+      migrate_up
+    elsif connection.column_exists?(:reports, :logs)
+      connection.remove_column(:reports, :logs)
+      reset_schema_cache
+    end
+  end
+
+  def current_schema?
+    connection.table_exists?(:report_debug_logs) && !connection.column_exists?(:reports, :logs)
+  end
+
+  def reset_schema_cache
+    connection.schema_cache.clear!
+    Report.reset_column_information
+    ReportDebugLog.reset_column_information if connection.table_exists?(:report_debug_logs)
+  end
+end

--- a/spec/models/report_debug_log_spec.rb
+++ b/spec/models/report_debug_log_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe ReportDebugLog, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:report) }
+  end
+
+  describe "validations" do
+    subject { create(:report_debug_log) }
+
+    it { is_expected.to validate_uniqueness_of(:report_id) }
+  end
+
+  describe "schema" do
+    it "stores final logs and live tail fields" do
+      expect(described_class.column_names).to include(
+        "logs",
+        "tail",
+        "tail_offset",
+        "tail_digest",
+        "tail_synced_at",
+        "tail_truncated"
+      )
+    end
+
+    it "allows logs and tail to be blank" do
+      debug_log = build(:report_debug_log, logs: nil, tail: nil)
+
+      expect(debug_log).to be_valid
+    end
+
+    it "enforces one debug log row per report at the database layer" do
+      index = ActiveRecord::Base.connection.indexes(:report_debug_logs).find do |candidate|
+        candidate.columns == [ "report_id" ] && candidate.unique
+      end
+
+      expect(index).to be_present
+    end
+  end
+
+  describe "report lifecycle" do
+    it "is destroyed with its report" do
+      report = create(:report)
+      debug_log = create(:report_debug_log, report: report, logs: "stored logs")
+
+      expect { report.destroy }.to change(described_class, :count).by(-1)
+      expect(described_class.exists?(debug_log.id)).to be(false)
+    end
+  end
+
+  describe ".clear_tail_for_report" do
+    it "clears live tail fields without erasing final logs" do
+      debug_log = create(
+        :report_debug_log,
+        logs: "final logs",
+        tail: "live tail\n",
+        tail_offset: 128,
+        tail_digest: "tail-digest",
+        tail_synced_at: 1.minute.ago,
+        tail_truncated: true
+      )
+
+      described_class.clear_tail_for_report(debug_log.report_id)
+
+      debug_log.reload
+      expect(debug_log.logs).to eq("final logs")
+      expect(debug_log.tail).to be_nil
+      expect(debug_log.tail_offset).to eq(0)
+      expect(debug_log.tail_digest).to be_nil
+      expect(debug_log.tail_synced_at).to be_nil
+      expect(debug_log.tail_truncated).to be(false)
+    end
+  end
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe Report, type: :model do
     it { is_expected.to have_many(:probe_results).dependent(:destroy) }
     it { is_expected.to have_many(:detector_results).dependent(:destroy) }
     it { is_expected.to have_many(:detectors).through(:detector_results) }
+    it { is_expected.to have_one(:report_debug_log).dependent(:destroy) }
+
+    it "autosaves report_debug_log changes" do
+      association = Report.reflect_on_association(:report_debug_log)
+
+      expect(association.options[:autosave]).to be(true)
+    end
   end
 
   describe 'validations' do
@@ -215,6 +222,92 @@ RSpec.describe Report, type: :model do
 
   describe 'status enum' do
     it { is_expected.to define_enum_for(:status).with_values(pending: 0, running: 1, processing: 2, completed: 3, failed: 4, stopped: 5, starting: 6, interrupted: 7) }
+  end
+
+  describe "#logs compatibility" do
+    it "reads logs from report_debug_logs" do
+      report = create(:report)
+      create(:report_debug_log, report: report, logs: "stored logs")
+
+      expect(report.reload.logs).to eq("stored logs")
+    end
+
+    it "persists logs assigned before saving" do
+      report = build(:report)
+
+      report.logs = "assigned logs"
+      report.save!
+
+      expect(report.reload.logs).to eq("assigned logs")
+      expect(report.report_debug_log.logs).to eq("assigned logs")
+    end
+
+    it "persists logs assigned to an existing report" do
+      report = create(:report)
+
+      report.logs = "updated logs"
+      report.save!
+
+      expect(report.reload.logs).to eq("updated logs")
+      expect(report.report_debug_log.logs).to eq("updated logs")
+    end
+
+    it "supports update! with logs" do
+      report = create(:report)
+
+      report.update!(logs: "updated through attributes")
+
+      expect(report.reload.logs).to eq("updated through attributes")
+      expect(report.report_debug_log.logs).to eq("updated through attributes")
+    end
+
+    it "preserves live tail metadata when assigning final logs" do
+      report = create(:report)
+      create(
+        :report_debug_log,
+        report: report,
+        tail: "live tail\n",
+        tail_offset: 12,
+        tail_digest: "tail-digest",
+        tail_truncated: true
+      )
+
+      report.logs = "final logs"
+      report.save!
+
+      debug_log = report.reload.report_debug_log
+      expect(debug_log.logs).to eq("final logs")
+      expect(debug_log.tail).to eq("live tail\n")
+      expect(debug_log.tail_offset).to eq(12)
+      expect(debug_log.tail_digest).to eq("tail-digest")
+      expect(debug_log.tail_truncated).to be(true)
+    end
+
+    it "uses an existing row when the association cache was loaded empty" do
+      report = create(:report)
+      expect(report.report_debug_log).to be_nil
+
+      now = Time.current
+      ReportDebugLog.insert_all!(
+        [
+          {
+            report_id: report.id,
+            tail: "live tail\n",
+            tail_offset: 10,
+            tail_truncated: false,
+            created_at: now,
+            updated_at: now
+          }
+        ]
+      )
+      debug_log = ReportDebugLog.find_by!(report_id: report.id)
+
+      report.logs = "final logs"
+      report.save!
+
+      expect(debug_log.reload.logs).to eq("final logs")
+      expect(report.reload.report_debug_log.id).to eq(debug_log.id)
+    end
   end
 
   describe 'status transitions' do

--- a/spec/requests/report_debug_stream_spec.rb
+++ b/spec/requests/report_debug_stream_spec.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Report debug stream watcher", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, company: company) }
+  let(:report) { create(:report, :running, company: company) }
+  let(:polling_statuses) { %i[pending starting running processing] }
+
+  before do
+    @original_cache_store = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    sign_in user
+  end
+
+  after do
+    Rails.cache = @original_cache_store
+    ActsAsTenant.current_tenant = nil
+  end
+
+  def expect_activity_stream_structure(activity_report, lease_url)
+    expect(response.body).to include('id="report-activity-stream"')
+    expect(response.body).to include('id="report-activity-stream-summary"')
+    expect(response.body).to include('id="report-debug-stream-content"')
+    expect(response.body).to include('data-controller="debug-stream-lease"')
+    expect(response.body).to include(%(data-debug-stream-lease-url-value="#{lease_url}"))
+    expect(response.body).to include('data-debug-stream-lease-interval-value="30000"')
+    expect(response.body).to include(%(signed-stream-name="#{debug_stream_name_for(activity_report)}"))
+  end
+
+  def expect_no_activity_stream
+    expect(response.body).not_to include("report-activity-stream")
+    expect(response.body).not_to include("report-activity-stream-summary")
+    expect(response.body).not_to include("report-debug-stream-content")
+    expect(response.body).not_to include('data-controller="debug-stream-lease"')
+  end
+
+  def expect_static_activity_stream(activity_report)
+    expect(response.body).to include('id="report-activity-stream"')
+    expect(response.body).to include('id="report-activity-stream-summary"')
+    expect(response.body).to include('id="report-debug-stream-content"')
+    expect(response.body).not_to include('data-controller="debug-stream-lease"')
+    expect(response.body).not_to include(%(signed-stream-name="#{debug_stream_name_for(activity_report)}"))
+  end
+
+  def debug_stream_name_for(activity_report)
+    Turbo::StreamsChannel.signed_stream_name(Reports::DebugWatcher.stream_name(activity_report))
+  end
+
+  it "renders the admin Activity Stream without starting polling from the report view" do
+    expect {
+      get report_path(report)
+    }.not_to have_enqueued_job(BroadcastReportDebugJob)
+
+    expect(response).to have_http_status(:ok)
+    expect(Reports::DebugWatcher.watching?(report.id)).to be(false)
+    expect_activity_stream_structure(report, refresh_debug_lease_report_path(report))
+  end
+
+  it "refreshes the watcher lease from the admin keepalive endpoint for polling reports" do
+    polling_statuses.each do |status|
+      polling_report = create(:report, company: company, status: status)
+
+      expect {
+        post refresh_debug_lease_report_path(polling_report)
+      }.to have_enqueued_job(BroadcastReportDebugJob).with(polling_report.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(Reports::DebugWatcher.watching?(polling_report.id)).to be(true)
+    end
+  end
+
+  it "rejects unauthenticated admin keepalive requests" do
+    sign_out user
+
+    expect {
+      post refresh_debug_lease_report_path(report)
+    }.not_to have_enqueued_job(BroadcastReportDebugJob)
+
+    expect(response).to redirect_to(new_user_session_path)
+    expect(Reports::DebugWatcher.watching?(report.id)).to be(false)
+  end
+
+  it "does not refresh an admin watcher lease for another company report" do
+    other_report = create(:report, :running, company: create(:company))
+
+    expect {
+      post refresh_debug_lease_report_path(other_report)
+    }.not_to have_enqueued_job(BroadcastReportDebugJob)
+
+    expect(response).to have_http_status(:not_found)
+    expect(Reports::DebugWatcher.watching?(other_report.id)).to be(false)
+  end
+
+  it "refreshes the admin watcher lease without polling terminal reports" do
+    completed_report = create(:report, :completed, company: company)
+
+    expect {
+      post refresh_debug_lease_report_path(completed_report)
+    }.not_to have_enqueued_job(BroadcastReportDebugJob)
+
+    expect(response).to have_http_status(:ok)
+    expect(Reports::DebugWatcher.watching?(completed_report.id)).to be(true)
+  end
+
+  it "does not render the admin Activity Stream for terminal reports without debug fallback" do
+    completed_report = create(:report, :completed, company: company)
+
+    expect {
+      get report_path(completed_report)
+    }.not_to have_enqueued_job(BroadcastReportDebugJob)
+
+    expect(response).to have_http_status(:ok)
+    expect(Reports::DebugWatcher.watching?(completed_report.id)).to be(false)
+    expect_no_activity_stream
+  end
+
+  it "renders the admin terminal-report debug fallback without mounting a watcher lease" do
+    completed_report = create(:report, :completed, company: company)
+
+    expect {
+      get report_path(completed_report), params: { debug: "true" }
+    }.not_to have_enqueued_job(BroadcastReportDebugJob)
+
+    expect(response).to have_http_status(:ok)
+    expect(Reports::DebugWatcher.watching?(completed_report.id)).to be(false)
+    expect_static_activity_stream(completed_report)
+  end
+
+  it "renders the admin Activity Stream with live tail logs" do
+    create(
+      :report_debug_log,
+      report: report,
+      tail: "admin live tail line\n",
+      tail_offset: 128,
+      tail_digest: "admin-tail"
+    )
+
+    get report_path(report)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("report-debug-stream-content")
+    expect(response.body).to include("turbo-cable-stream-source")
+    expect(response.body).to include("Live tail")
+    expect(response.body).to include("admin live tail line")
+  end
+
+  it "renders the report details Activity Stream without starting polling from the report view" do
+    expect {
+      get report_detail_path(report)
+    }.not_to have_enqueued_job(BroadcastReportDebugJob)
+
+    expect(response).to have_http_status(:ok)
+    expect(Reports::DebugWatcher.watching?(report.id)).to be(false)
+    expect_activity_stream_structure(report, refresh_debug_lease_report_detail_path(report))
+  end
+
+  it "refreshes the watcher lease from the report details keepalive endpoint for polling reports" do
+    polling_statuses.each do |status|
+      polling_report = create(:report, company: company, status: status)
+
+      expect {
+        post refresh_debug_lease_report_detail_path(polling_report)
+      }.to have_enqueued_job(BroadcastReportDebugJob).with(polling_report.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(Reports::DebugWatcher.watching?(polling_report.id)).to be(true)
+    end
+  end
+
+  it "rejects unauthenticated report-details keepalive requests" do
+    sign_out user
+
+    expect {
+      post refresh_debug_lease_report_detail_path(report)
+    }.not_to have_enqueued_job(BroadcastReportDebugJob)
+
+    expect(response).to redirect_to(new_user_session_path)
+    expect(Reports::DebugWatcher.watching?(report.id)).to be(false)
+  end
+
+  it "does not refresh a report-details watcher lease for another company report" do
+    other_report = create(:report, :running, company: create(:company))
+
+    expect {
+      post refresh_debug_lease_report_detail_path(other_report)
+    }.not_to have_enqueued_job(BroadcastReportDebugJob)
+
+    expect(response).to have_http_status(:not_found)
+    expect(Reports::DebugWatcher.watching?(other_report.id)).to be(false)
+  end
+
+  it "renders the report details Activity Stream with live tail logs" do
+    create(
+      :report_debug_log,
+      report: report,
+      tail: "details live tail line\n",
+      tail_offset: 256,
+      tail_digest: "details-tail"
+    )
+
+    get report_detail_path(report)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("report-debug-stream-content")
+    expect(response.body).to include('data-controller="debug-tabs debug-stream-filter"')
+    expect(response.body).to include('data-action="click->debug-tabs#switch"')
+    expect(response.body).to include("Live tail")
+    expect(response.body).to include("details live tail line")
+  end
+
+  it "does not start report-details polling in PDF mode" do
+    expect {
+      get report_detail_path(report), params: { debug: "true", pdf: "true" }
+    }.not_to have_enqueued_job(BroadcastReportDebugJob)
+
+    expect(response).to have_http_status(:ok)
+    expect(Reports::DebugWatcher.watching?(report.id)).to be(false)
+    expect_no_activity_stream
+  end
+
+  it "renders the report-details terminal-report debug fallback without mounting a watcher lease" do
+    completed_report = create(:report, :completed, company: company)
+
+    expect {
+      get report_detail_path(completed_report), params: { debug: "true" }
+    }.not_to have_enqueued_job(BroadcastReportDebugJob)
+
+    expect(response).to have_http_status(:ok)
+    expect(Reports::DebugWatcher.watching?(completed_report.id)).to be(false)
+    expect_static_activity_stream(completed_report)
+  end
+end

--- a/spec/services/reports/cleanup_spec.rb
+++ b/spec/services/reports/cleanup_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe Reports::Cleanup do
       it 'deletes any stale raw_report_data' do
         expect { service.call }.to change { RawReportData.count }.by(-1)
       end
+
+      it 'preserves shared final logs' do
+        debug_log = create(:report_debug_log, report: report, logs: 'Final execution logs')
+
+        service.call
+
+        expect(debug_log.reload.logs).to eq('Final execution logs')
+      end
     end
 
     context 'when raw_report_data does not exist' do

--- a/spec/services/reports/debug_stream_fingerprint_spec.rb
+++ b/spec/services/reports/debug_stream_fingerprint_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reports::DebugStreamFingerprint do
+  let(:report) { create(:report, :running) }
+
+  def jsonl(probe_name)
+    JSON.generate(entry_type: "attempt", probe_classname: probe_name, uuid: SecureRandom.uuid)
+  end
+
+  def fingerprint(source = report)
+    described_class.new(source).call
+  end
+
+  describe "#call" do
+    it "returns stable metadata and digest when only the debug log row timestamp changes" do
+      create(:raw_report_data, report: report, jsonl_data: jsonl("probe.Alpha"))
+      debug_log = create(
+        :report_debug_log,
+        report: report,
+        tail_digest: "tail-1",
+        tail_offset: 120,
+        tail_synced_at: Time.zone.local(2026, 4, 27, 12, 0, 0),
+        tail_truncated: true
+      )
+
+      first = fingerprint
+      debug_log.touch
+      second = fingerprint
+
+      expect(second).to eq(first)
+      expect(second[:digest]).to match(/\A[a-f0-9]{64}\z/)
+    end
+
+    it "changes digest when raw JSONL metadata changes" do
+      raw_data = create(:raw_report_data, report: report, jsonl_data: jsonl("probe.Before"))
+      first = fingerprint
+
+      raw_data.update_columns(
+        jsonl_data: [ jsonl("probe.After"), jsonl("probe.AfterAgain") ].join("\n"),
+        updated_at: 1.second.from_now
+      )
+      second = fingerprint
+
+      expect(second[:raw_jsonl_bytes]).not_to eq(first[:raw_jsonl_bytes])
+      expect(second[:raw_report_data_updated_at]).not_to eq(first[:raw_report_data_updated_at])
+      expect(second[:digest]).not_to eq(first[:digest])
+    end
+
+    it "changes digest when live-tail digest metadata changes" do
+      create(:raw_report_data, report: report, jsonl_data: jsonl("probe.Alpha"))
+      debug_log = create(
+        :report_debug_log,
+        report: report,
+        tail_digest: "tail-1",
+        tail_offset: 120,
+        tail_synced_at: Time.zone.local(2026, 4, 27, 12, 0, 0)
+      )
+      first = fingerprint
+
+      debug_log.update_columns(
+        tail_digest: "tail-2",
+        tail_offset: 180,
+        tail_synced_at: Time.zone.local(2026, 4, 27, 12, 1, 0)
+      )
+      second = fingerprint
+
+      expect(second[:tail_digest]).to eq("tail-2")
+      expect(second[:tail_offset]).to eq(180)
+      expect(second[:digest]).not_to eq(first[:digest])
+    end
+
+    it "returns status and tail metadata when raw data is missing" do
+      create(:report_debug_log, report: report, tail_digest: "tail-1", tail_offset: 44)
+
+      result = fingerprint
+
+      expect(result).to include(
+        report_id: report.id,
+        status: "running",
+        raw_report_data_id: nil,
+        raw_report_data_updated_at: nil,
+        raw_jsonl_bytes: nil,
+        tail_digest: "tail-1",
+        tail_offset: 44
+      )
+      expect(result[:digest]).to match(/\A[a-f0-9]{64}\z/)
+    end
+
+    it "returns raw data metadata when the debug log is missing" do
+      raw_data = create(:raw_report_data, report: report, jsonl_data: jsonl("probe.Alpha"))
+
+      result = fingerprint
+
+      expect(result).to include(
+        report_id: report.id,
+        status: "running",
+        raw_report_data_id: raw_data.id,
+        report_debug_log_id: nil,
+        tail_offset: nil,
+        tail_digest: nil,
+        tail_synced_at: nil,
+        tail_truncated: nil
+      )
+      expect(result[:raw_jsonl_bytes]).to eq(raw_data.jsonl_data.bytesize)
+      expect(result[:raw_report_data_updated_at]).to be_present
+      expect(result[:digest]).to match(/\A[a-f0-9]{64}\z/)
+    end
+
+    it "returns nil when the report is missing" do
+      expect(described_class.new(Report.maximum(:id).to_i + 1).call).to be_nil
+      expect(described_class.new(nil).call).to be_nil
+    end
+
+    it "selects joined scalar metadata without selecting raw JSONL or log text columns" do
+      create(:raw_report_data, report: report, jsonl_data: jsonl("probe.Alpha"))
+      create(:report_debug_log, report: report, logs: "full logs\n", tail: "live tail\n", tail_digest: "tail-1")
+      sql_statements = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _started, _finished, _id, payload|
+        sql_statements << payload[:sql] if payload[:name] == "Report Load"
+      end
+
+      fingerprint(report.id)
+
+      sql = sql_statements.find { |statement| statement.include?("raw_report_data") && statement.include?("report_debug_logs") }
+      expect(sql).to include("LEFT OUTER JOIN")
+      expect(sql).to include("octet_length(raw_report_data.jsonl_data)")
+      expect(sql).not_to match(/raw_report_data\.jsonl_data\s+AS/i)
+      expect(sql).not_to match(/report_debug_logs\.logs\b/i)
+      expect(sql).not_to match(/report_debug_logs\.tail\b/i)
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+  end
+end

--- a/spec/services/reports/debug_stream_payload_spec.rb
+++ b/spec/services/reports/debug_stream_payload_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reports::DebugStreamPayload do
+  let(:report) { create(:report) }
+
+  def jsonl(*entries)
+    entries.map { |entry| JSON.generate(entry) }.join("\n")
+  end
+
+  describe "#call" do
+    it "builds timeline, raw tail, log, activity, and digest data from a report" do
+      create(
+        :raw_report_data,
+        report: report,
+        jsonl_data: jsonl(
+          { entry_type: "init", start_time: "2026-04-27T12:00:00Z" },
+          { entry_type: "attempt", probe_classname: "probe.Alpha", uuid: "a1", prompt: "hello", outputs: [ "world" ] }
+        )
+      )
+
+      payload = described_class.new(report).call
+
+      expect(payload).to include(:timeline, :raw_tail, :logs, :log_metadata, :activity, :digest)
+      expect(payload[:timeline]).to include(
+        { type: "init", start_time: "2026-04-27T12:00:00Z" },
+        hash_including(type: "attempt", probe: "probe.Alpha", prompt_preview: "hello", output_preview: "world")
+      )
+      expect(payload[:raw_tail]).to include("probe.Alpha")
+      expect(payload[:digest]).to match(/\A[a-f0-9]{32}\z/)
+    end
+
+    it "reads raw JSONL once per payload build" do
+      raw_data = create(
+        :raw_report_data,
+        report: report,
+        jsonl_data: jsonl(
+          { entry_type: "init", start_time: "2026-04-27T12:00:00Z" },
+          { entry_type: "attempt", probe_classname: "probe.Alpha", uuid: "a1" }
+        )
+      )
+
+      expect(raw_data).to receive(:jsonl_data).once.and_call_original
+
+      payload = described_class.new(raw_data).call
+
+      expect(payload[:timeline]).to include(
+        { type: "init", start_time: "2026-04-27T12:00:00Z" },
+        hash_including(type: "attempt", probe: "probe.Alpha")
+      )
+      expect(payload[:digest]).to match(/\A[a-f0-9]{32}\z/)
+    end
+
+    it "returns status-only activity when raw data is missing" do
+      payload = described_class.new(report).call
+
+      expect(payload[:timeline]).to eq([])
+      expect(payload[:raw_tail]).to eq("")
+      expect(payload[:logs]).to eq("")
+      expect(payload[:log_metadata]).to include(source: "none")
+      expect(payload[:activity]).to include(status_label: "Your scan is running.", active: true)
+      expect(payload[:digest]).to be_nil
+    end
+
+    it "uses live tails for statuses that can have current tails and hides stale full logs" do
+      synced_at = Time.zone.local(2026, 4, 27, 12, 30, 0)
+      create(
+        :report_debug_log,
+        report: report,
+        logs: "previous final logs\n",
+        tail: "fresh live tail\n",
+        tail_offset: 42,
+        tail_digest: "tail-digest",
+        tail_synced_at: synced_at,
+        tail_truncated: true
+      )
+
+      Report::DEBUG_STREAM_LIVE_TAIL_STATUSES.each do |status|
+        report.update!(status: status)
+
+        payload = described_class.new(report.reload).call
+
+        expect(payload[:logs]).to eq("fresh live tail\n")
+        expect(payload[:log_metadata]).to include(
+          source: "live_tail",
+          offset: 42,
+          digest: "tail-digest",
+          synced_at: synced_at,
+          truncated: true
+        )
+      end
+    end
+
+    it "does not show stale live tails while a retry is still starting" do
+      report.update!(status: :starting)
+      create(:report_debug_log, report: report, logs: "previous final logs\n", tail: "stale live tail\n")
+
+      payload = described_class.new(report.reload).call
+
+      expect(payload[:logs]).to eq("")
+      expect(payload[:log_metadata]).to include(source: "none")
+    end
+
+    it "does not show stale live tails while a retry is pending" do
+      report.update!(status: :pending)
+      create(:report_debug_log, report: report, logs: "previous final logs\n", tail: "stale live tail\n")
+
+      payload = described_class.new(report.reload).call
+
+      expect(payload[:logs]).to eq("")
+      expect(payload[:log_metadata]).to include(source: "none")
+    end
+
+    it "returns no logs for polling reports before a live tail is synced" do
+      report.update!(status: :processing)
+      create(:report_debug_log, report: report, logs: "previous final logs\n")
+
+      payload = described_class.new(report.reload).call
+
+      expect(payload[:logs]).to eq("")
+      expect(payload[:log_metadata]).to include(source: "none")
+    end
+
+    it "uses final full logs for terminal reports" do
+      terminal_report = create(:report, :completed)
+      full_logs = 200.times.map { |index| "line #{index + 1}\n" }.join
+      create(:report_debug_log, report: terminal_report, logs: full_logs, tail: "stale live tail\n")
+
+      payload = described_class.new(terminal_report.reload).call
+
+      expect(payload[:logs].lines.length).to eq(200)
+      expect(payload[:logs]).to include("line 200")
+      expect(payload[:logs]).to include("line 1\n")
+      expect(payload[:logs]).not_to include("stale live tail")
+      expect(payload[:log_metadata]).to include(source: "full_logs", truncated: false)
+      expect(payload[:digest]).to match(/\A[a-f0-9]{32}\z/)
+    end
+
+    it "uses the last live tail for stopped reports without final logs" do
+      stopped_report = create(:report, status: :stopped)
+      create(
+        :report_debug_log,
+        report: stopped_report,
+        tail: "last live tail before stop\n",
+        tail_offset: 128,
+        tail_digest: "stopped-tail"
+      )
+
+      payload = described_class.new(stopped_report.reload).call
+
+      expect(payload[:logs]).to eq("last live tail before stop\n")
+      expect(payload[:log_metadata]).to include(source: "live_tail", offset: 128, digest: "stopped-tail")
+    end
+
+    it "uses the current stopped live tail before preserved retry logs" do
+      stopped_report = create(:report, status: :stopped, retry_count: 1)
+      create(
+        :report_debug_log,
+        report: stopped_report,
+        logs: "previous attempt logs\n[2026-04-27 12:00:00] Auto-retry 1: Requeued after interruption",
+        tail: "current stopped tail\n",
+        tail_offset: 256,
+        tail_digest: "current-stopped-tail"
+      )
+
+      payload = described_class.new(stopped_report.reload).call
+
+      expect(payload[:logs]).to eq("current stopped tail\n")
+      expect(payload[:logs]).not_to include("previous attempt logs")
+      expect(payload[:log_metadata]).to include(source: "live_tail", offset: 256, digest: "current-stopped-tail")
+    end
+
+    it "logs malformed JSONL without copying raw prompt text into Rails logs" do
+      allow(Rails.logger).to receive(:warn)
+      create(:raw_report_data, report: report, jsonl_data: '{"entry_type":"attempt","prompt":"secret prompt"')
+
+      payload = described_class.new(report).call
+
+      expect(payload[:timeline]).to include(hash_including(type: "_parse_error"))
+      expect(Rails.logger).to have_received(:warn).with(
+        include("malformed JSONL", "line_bytes=", "line_sha256=")
+      )
+      expect(Rails.logger).not_to have_received(:warn).with(include("secret prompt"))
+    end
+
+    it "changes digest when only the live execution-log tail changes" do
+      report.update!(status: :running)
+      create(:raw_report_data, report: report, jsonl_data: jsonl({ entry_type: "init", start_time: "now" }))
+      debug_log = create(:report_debug_log, report: report, tail: "first tail\n", tail_digest: "tail-1")
+
+      first_digest = described_class.new(report.reload).call[:digest]
+      debug_log.update!(tail: "second tail\n", tail_digest: "tail-2")
+      second_digest = described_class.new(report.reload).call[:digest]
+
+      expect(second_digest).not_to eq(first_digest)
+    end
+
+    it "bounds raw JSONL and parsed timeline tails" do
+      total = described_class::TIMELINE_TAIL_LIMIT + 20
+      create(
+        :raw_report_data,
+        report: report,
+        jsonl_data: total.times.map { |index| JSON.generate(entry_type: "attempt", probe_classname: "probe.P#{index}", uuid: "u#{index}") }.join("\n")
+      )
+
+      payload = described_class.new(report).call
+
+      expect(payload[:timeline].length).to eq(described_class::TIMELINE_TAIL_LIMIT)
+      expect(payload[:timeline].first).to include(probe: "probe.P20")
+      expect(payload[:raw_tail].lines.length).to eq(described_class::RAW_TAIL_LINES)
+    end
+  end
+
+  describe "full logs truncation" do
+    let(:report) { create(:report, :completed) }
+
+    it "caps full logs to LOG_TAIL_LINES and sets truncated metadata" do
+      long_log = (1..600).map { |i| "line #{i}" }.join("\n") + "\n"
+      create(:report_debug_log, report: report, logs: long_log)
+
+      result = described_class.new(report.reload).call
+
+      expect(result[:log_metadata][:source]).to eq("full_logs")
+      expect(result[:log_metadata][:truncated]).to be true
+      expect(result[:logs].lines.count).to eq(described_class::LOG_TAIL_LINES)
+      expect(result[:logs]).to include("line 600")
+      expect(result[:logs]).not_to include("line 100")
+    end
+
+    it "leaves shorter full logs untruncated" do
+      short_log = (1..10).map { |i| "line #{i}" }.join("\n") + "\n"
+      create(:report_debug_log, report: report, logs: short_log)
+
+      result = described_class.new(report.reload).call
+
+      expect(result[:log_metadata][:source]).to eq("full_logs")
+      expect(result[:log_metadata][:truncated]).to be false
+      expect(result[:logs].lines.count).to eq(10)
+    end
+  end
+end

--- a/spec/services/reports/process_spec.rb
+++ b/spec/services/reports/process_spec.rb
@@ -54,7 +54,16 @@ RSpec.describe Reports::Process, type: :service do
       let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: jsonl_content, logs_data: logs_content) }
 
       it 'updates report status to processing' do
-        expect(report).to receive(:update).with(status: :processing)
+        expect(report).to receive(:update!).with(status: :processing).and_call_original
+        service.call
+      end
+
+      it 'commits processing status before the final persistence transaction' do
+        expect(Report).to receive(:transaction).and_wrap_original do |method, *args, &block|
+          expect(report.reload.status).to eq('processing')
+          method.call(*args, &block)
+        end
+
         service.call
       end
 
@@ -82,6 +91,7 @@ RSpec.describe Reports::Process, type: :service do
         expect(report.end_time).to be_present
         expect(report.status).to eq('completed')
         expect(report.logs).to eq(logs_content)
+        expect(report.report_debug_log.logs).to eq(logs_content)
         expect(report.input_tokens).to be > 0
         expect(report.output_tokens).to be > 0
       end
@@ -103,6 +113,69 @@ RSpec.describe Reports::Process, type: :service do
 
       it 'destroys raw_data after successful processing' do
         expect { service.call }.to change { RawReportData.count }.by(-1)
+      end
+
+      it 'keeps final logs after raw_data is destroyed' do
+        service.call
+
+        expect(RawReportData.exists?(raw_data.id)).to be(false)
+        expect(report.reload.logs).to eq(logs_content)
+        expect(report.report_debug_log.logs).to eq(logs_content)
+      end
+
+      it 'promotes the shared live log tail when final logs_data is missing' do
+        raw_data.update!(logs_data: nil)
+        create(:report_debug_log, report: report, tail: "shared live tail\n")
+
+        service.call
+
+        expect(report.reload.logs).to eq("shared live tail\n")
+        expect(report.report_debug_log.logs).to eq("shared live tail\n")
+      end
+
+      it 'clears stale final logs when logs_data and live tail are missing' do
+        raw_data.update!(logs_data: nil)
+        debug_log = create(:report_debug_log, report: report, logs: "previous run logs\n")
+
+        service.call
+
+        expect(report.reload.logs).to be_nil
+        expect(debug_log.reload.logs).to be_nil
+      end
+
+      it 'preserves retry audit logs when logs_data and live tail are missing' do
+        raw_data.update!(logs_data: nil)
+        report.update!(retry_count: 1)
+        create(
+          :report_debug_log,
+          report: report,
+          logs: "Previous log\n[2026-04-27 12:00:00] Auto-retry 1: Requeued after interruption"
+        )
+
+        service.call
+
+        expect(report.reload.logs).to include("Previous log")
+        expect(report.logs).to include("Auto-retry 1:")
+        expect(report.report_debug_log.logs).to eq(report.logs)
+      end
+
+      it 'keeps raw_data when the final report save fails' do
+        jsonl_without_time_saves = [
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test prompt', outputs: [ 'Test output' ], notes: { score_percentage: 70 } }.to_json,
+          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din.TestProbe', passed: 3, total_evaluated: 10 }.to_json
+        ].join("\n")
+        raw_data.update!(jsonl_data: jsonl_without_time_saves)
+        save_calls = 0
+        allow(report).to receive(:save!).and_wrap_original do |method, *args, **kwargs, &block|
+          save_calls += 1
+          raise ActiveRecord::RecordInvalid.new(report) if save_calls > 1
+
+          method.call(*args, **kwargs, &block)
+        end
+
+        expect { service.call }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(RawReportData.exists?(raw_data.id)).to be true
+        expect(report.probe_results.reload).to be_empty
       end
 
       it 'logs successful database processing' do

--- a/spec/services/run_garak_scan_spec.rb
+++ b/spec/services/run_garak_scan_spec.rb
@@ -92,6 +92,59 @@ RSpec.describe RunGarakScan, type: :service do
       service.call
     end
 
+    it 'uses the same generated log path for the runner env and command output' do
+      service = described_class.new(report)
+      argv = [ "python3", "script/run_garak.py", report.uuid ]
+      captured_env = nil
+
+      allow(service).to receive(:call).and_call_original
+      allow(service).to receive(:build_argv).and_return(argv)
+      allow(LogPathManager).to receive(:scan_log_file_for_report)
+        .with(report)
+        .and_return(Pathname.new("/tmp/first.log"), Pathname.new("/tmp/second.log"))
+
+      run_command = double("RunCommand")
+      expect(run_command).to receive(:call_async).with(log_file: "/tmp/first.log")
+      expect(RunCommand).to receive(:new) do |received_argv, env:|
+        expect(received_argv).to eq(argv)
+        captured_env = env
+        run_command
+      end
+
+      service.call
+
+      expect(captured_env["LOG_FILE_PATH"]).to eq("/tmp/first.log")
+      expect(LogPathManager).to have_received(:scan_log_file_for_report).once
+    end
+
+    it 'uses the same generated log path for immediate-start failure output' do
+      service = described_class.new(report)
+      argv = [ "python3", "script/run_garak.py", report.uuid ]
+
+      allow(service).to receive(:call).and_call_original
+      allow(service).to receive(:build_argv).and_return(argv)
+      allow(LogPathManager).to receive(:scan_log_file_for_report)
+        .with(report)
+        .and_return(Pathname.new("/tmp/first.log"), Pathname.new("/tmp/second.log"))
+
+      run_command = double("RunCommand")
+      expect(run_command).to receive(:call_async).with(log_file: "/tmp/first.log").and_raise(
+        RunCommand::ImmediateExitError.new(127, "/opt/venv/bin/python3 script/run_garak.py")
+      )
+      expect(RunCommand).to receive(:new).and_return(run_command)
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/tmp/first.log").and_return(true)
+      allow(File).to receive(:read).with("/tmp/first.log").and_return("first path stderr\n")
+      allow(File).to receive(:exist?).with("/tmp/second.log").and_return(true)
+      allow(File).to receive(:read).with("/tmp/second.log").and_return("wrong path stderr\n")
+
+      service.call
+
+      expect(report.reload.logs).to include("first path stderr")
+      expect(report.logs).not_to include("wrong path stderr")
+      expect(LogPathManager).to have_received(:scan_log_file_for_report).once
+    end
+
     it 'fails the report if target has validating status' do
       validating_target = create(:target, :validating)
       validating_report = create(:report, target: validating_target, scan: scan)
@@ -498,6 +551,55 @@ RSpec.describe RunGarakScan, type: :service do
         expect(service).not_to receive(:execute_scan)
 
         service.call
+      end
+
+      it 'persists an existing same-pod log file before processing' do
+        # spec/support/run_garak_scan_stub.rb globally stubs RunGarakScan#call.
+        # Override here to test the real implementation path.
+        allow_any_instance_of(RunGarakScan).to receive(:call).and_call_original
+
+        service = described_class.new(report)
+        log_path = instance_double(Pathname, exist?: true)
+
+        allow(LogPathManager).to receive(:find_existing_log_for_report)
+          .with(report)
+          .and_return(log_path)
+        allow(File).to receive(:read).with(log_path).and_return("resumed logs\n")
+
+        expect(service).to receive(:persist_existing_logs).ordered.and_call_original
+        expect(ProcessReportJob).to receive(:perform_later).ordered.with(report.id)
+
+        service.call
+
+        expect(report.raw_report_data.reload.logs_data).to eq("resumed logs\n")
+      end
+
+      it 'does not overwrite existing full logs_data' do
+        report.raw_report_data.update!(logs_data: "existing full logs\n")
+        service = described_class.new(report)
+
+        expect(LogPathManager).not_to receive(:find_existing_log_for_report)
+
+        service.send(:persist_existing_logs)
+
+        expect(report.raw_report_data.reload.logs_data).to eq("existing full logs\n")
+      end
+
+      it 'logs persistence failures from bang updates' do
+        service = described_class.new(report)
+        raw_data = report.raw_report_data
+        log_path = instance_double(Pathname, exist?: true)
+
+        allow(LogPathManager).to receive(:find_existing_log_for_report)
+          .with(report)
+          .and_return(log_path)
+        allow(File).to receive(:read).with(log_path).and_return("resumed logs\n")
+        allow(raw_data).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(raw_data))
+        allow(report).to receive(:raw_report_data).and_return(raw_data)
+
+        expect(Rails.logger).to receive(:warn).with(/\[ScanResume\] Report #{report.uuid}: Could not persist logs:/)
+
+        service.send(:persist_existing_logs)
       end
     end
 

--- a/spec/views/admin/reports/logs_section_spec.rb
+++ b/spec/views/admin/reports/logs_section_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/reports/_logs_section', type: :view do
+  it 'renders final logs through the Report#logs compatibility accessor' do
+    report = create(:report, :completed)
+    create(:report_debug_log, report: report,
+           logs: "probes.test  test.detector: \e[1m\e[92mPASS\e[0m ok on  3/  3\nINFO final log line\n")
+
+    render partial: 'admin/reports/logs_section', locals: { report: report, lease_url: '/reports/1/refresh_debug_lease' }
+
+    expect(rendered).to include('report-activity-stream')
+    expect(rendered).to include('data-controller="activity-stream"')
+    expect(rendered).to include('report-activity-stream-details')
+    expect(rendered).to include('aria-expanded="false"')
+    expect(rendered).to include('View activity')
+    expect(rendered).to include('Activity Stream')
+    expect(rendered).to include('Execution Logs')
+    expect(rendered).to include('Timeline')
+    expect(rendered).to include('Raw JSONL')
+    expect(rendered).to include('data-controller="debug-tabs debug-stream-filter"')
+    expect(rendered).to include('data-action="click->debug-tabs#switch"')
+    expect(rendered).to include('data-debug-tabs-target="tab"')
+    expect(rendered).to include('data-debug-stream-filter-target="query"')
+    expect(rendered).not_to include('click->report-redesigned#toggleLogs')
+    expect(rendered).to include('report-activity-stream-summary')
+    expect(rendered).to include('Final logs')
+    expect(rendered).to include('final log line')
+    expect(rendered).to include('2 execution log lines captured')
+    expect(rendered).to include('Shown lines:')
+    expect(rendered).not_to include('turbo-cable-stream-source')
+    expect(rendered).not_to include('data-controller="debug-stream-lease"')
+    expect(rendered).not_to include('data-debug-stream-lease-url-value="/reports/1/refresh_debug_lease"')
+    expect(rendered).to include('<span class="font-bold text-green-400">PASS</span>').or include('font-bold text-red-400')
+    expect(rendered).to include('<span class="text-orange-400">')
+  end
+
+  it 'mounts live Activity Stream wiring for active reports' do
+    report = create(:report, :running)
+
+    render partial: 'admin/reports/logs_section', locals: { report: report, lease_url: '/reports/1/refresh_debug_lease' }
+
+    expect(rendered).to include('report-activity-stream')
+    expect(rendered).to include('report-debug-stream-content')
+    expect(rendered).to include('turbo-cable-stream-source')
+    expect(rendered).to include('data-controller="debug-stream-lease"')
+    expect(rendered).to include('data-debug-stream-lease-url-value="/reports/1/refresh_debug_lease"')
+  end
+
+  it 'renders live tail logs with metadata while a report is running' do
+    report = create(:report, :running)
+    create(
+      :report_debug_log,
+      report: report,
+      tail: "first live line\nsecond live line\n",
+      tail_offset: 2048,
+      tail_digest: "tail-digest",
+      tail_synced_at: 2.minutes.ago,
+      tail_truncated: true
+    )
+
+    render partial: 'admin/reports/logs_section', locals: { report: report }
+
+    expect(rendered).to include('LIVE')
+    expect(rendered).to include('Live tail')
+    expect(rendered).to include('Offset 2,048 bytes')
+    expect(rendered).to include('Tail truncated')
+    expect(rendered).to include('second live line')
+  end
+
+  it 'renders the empty state when no logs are available' do
+    report = create(:report)
+
+    render partial: 'admin/reports/logs_section', locals: { report: report }
+
+    expect(rendered).to include('No logs available')
+  end
+end


### PR DESCRIPTION
## Summary

Adds a live debug-stream pipeline for in-progress and completed scans, surfaced as an "Activity Stream" tab on the report detail/admin pages with three sub-tabs (Timeline / Raw JSONL / Execution Logs), a shared search filter, and per-line syntax highlighting for FAIL/PASS/info/emoji/progress/detector/module log lines. Behind it, a new `report_debug_logs` table holds bounded live-tail and final-logs data (logs are moved off the `reports` row), with a Turbo Stream broadcast loop driven by `BroadcastReportDebugJob` + `Reports::DebugWatcher` lease and a Python-side `JournalSyncThread` + `HeartbeatThread` that handle disk-to-DB sync and multi-pod stop coordination via SIGTERM.