### PR TITLE
fix(reports): remove sparse detector max score column

### DIFF
--- a/app/views/admin/reports/_statistics_section.html.erb
+++ b/app/views/admin/reports/_statistics_section.html.erb
@@ -104,7 +104,6 @@
               <th class="text-left text-contentSecondary font-sans text-xs font-medium uppercase tracking-wide py-2 pr-4">Detector</th>
               <th class="text-left text-contentSecondary font-sans text-xs font-medium uppercase tracking-wide py-2 px-4">Attack Success Rate</th>
               <th class="text-left text-contentSecondary font-sans text-xs font-medium uppercase tracking-wide py-2 px-4">Successful Attacks</th>
-              <th class="text-left text-contentSecondary font-sans text-xs font-medium uppercase tracking-wide py-2 pl-4">Max Score</th>
             </tr>
           </thead>
           <tbody>
@@ -126,10 +125,6 @@
 
                 <td class="text-white font-sans text-sm py-2 px-4">
                   <%= detector_result.passed %> / <%= detector_result.total %>
-                </td>
-
-                <td class="text-white font-sans text-sm py-2 pl-4">
-                  <%= detector_result.max_score.present? ? detector_result.max_score : "--" %>
                 </td>
               </tr>
             <% end %>

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -24,6 +24,33 @@ RSpec.describe Admin::ReportsController, type: :controller do
       get :show, params: { id: report.id }
       expect(response).to have_http_status(:success)
     end
+
+    it "omits the sparse max score column from detector statistics" do
+      ActsAsTenant.with_tenant(company) do
+        scored_detector = create(:detector, name: "0din.CrystalMethScore")
+        binary_detector = create(:detector, name: "mitigation.MitigationBypass")
+
+        create(:detector_result, report: report, detector: scored_detector, passed: 1, total: 10, max_score: 90)
+        create(:detector_result, report: report, detector: binary_detector, passed: 4, total: 10, max_score: nil)
+      end
+
+      get :show, params: { id: report.id }
+
+      detector_stats_section = Nokogiri::HTML(response.body).at_xpath(
+        "//h2[normalize-space()='Detector Statistics']/ancestor::div[contains(@class,'bg-zinc-900')][1]"
+      )
+
+      expect(response).to have_http_status(:success)
+      expect(detector_stats_section).to be_present
+
+      detector_stat_headers = detector_stats_section.css("th").map { |header| header.text.squish }
+
+      expect(detector_stats_section.text).to include("Illicit Substances: Crystal Meth")
+      expect(detector_stats_section.text).to include("Generic Mitigation Bypass Checks")
+      expect(detector_stat_headers).to eq([ "Detector", "Attack Success Rate", "Successful Attacks" ])
+      expect(detector_stats_section.text).not_to include("Max Score")
+      expect(detector_stats_section.text).not_to include("--")
+    end
   end
 
   describe "GET #probes_tab" do


### PR DESCRIPTION
## Summary
- Remove the sparse Max Score column from detector statistics
- Keep the table focused on ASR and successful attack counts
- Add coverage for mixed scored and binary detector rows
