### PR TITLE
fix(scan-form): require eligible probes for threat variants

### DIFF
--- a/app/javascript/controllers/threat_variants_controller.js
+++ b/app/javascript/controllers/threat_variants_controller.js
@@ -8,7 +8,9 @@ export default class extends Controller {
     "industryCheckbox",
     "subindustryCheckbox",
     "subindustryItem",
-    "subindustriesContainer"
+    "subindustriesContainer",
+    "content",
+    "disabledNotice"
   ]
 
   connect() {
@@ -20,6 +22,65 @@ export default class extends Controller {
     this.updateSummary()
     // Start with all industries collapsed
     this.collapseAll()
+
+    this._probeSelectionHandler = this.refreshEligibility.bind(this)
+    this._listenerScope = this.element.closest('form') || document
+    this._listenerScope.addEventListener('probe-category:probeSelectionChanged', this._probeSelectionHandler)
+
+    this.refreshEligibility()
+  }
+
+  disconnect() {
+    if (this._probeSelectionHandler && this._listenerScope) {
+      this._listenerScope.removeEventListener('probe-category:probeSelectionChanged', this._probeSelectionHandler)
+      this._probeSelectionHandler = null
+      this._listenerScope = null
+    }
+  }
+
+  refreshEligibility() {
+    this.applyEligibility(this.computeEligibility())
+  }
+
+  computeEligibility() {
+    const form = this.element.closest('form')
+    if (!form) return false
+    return form.querySelectorAll('[data-variant-eligible="true"]:checked').length > 0
+  }
+
+  applyEligibility(eligible) {
+    const disabled = !eligible
+    const variantCheckboxTargets = this.industryCheckboxTargets.concat(this.subindustryCheckboxTargets)
+
+    variantCheckboxTargets.forEach(checkbox => {
+      checkbox.disabled = disabled
+    })
+
+    if (this.hasContentTarget) {
+      if (eligible) {
+        this.contentTarget.classList.remove('opacity-50', 'pointer-events-none')
+        this.contentTarget.removeAttribute('aria-disabled')
+      } else {
+        this.contentTarget.classList.add('opacity-50', 'pointer-events-none')
+        this.contentTarget.setAttribute('aria-disabled', 'true')
+      }
+    }
+
+    if (this.hasDisabledNoticeTarget) {
+      if (eligible) {
+        this.disabledNoticeTarget.classList.add('hidden')
+      } else {
+        this.disabledNoticeTarget.classList.remove('hidden')
+      }
+    }
+  }
+
+  clearSelections() {
+    this.subindustryCheckboxTargets.forEach(cb => { cb.checked = false })
+    this.industryItemTargets.forEach(industryItem => {
+      this.updateIndustryCheckboxState(industryItem)
+    })
+    this.updateSummary()
   }
 
   // Toggle expand/collapse for an industry

--- a/app/models/detector.rb
+++ b/app/models/detector.rb
@@ -1,4 +1,11 @@
 class Detector < ApplicationRecord
+  MITIGATION_BYPASS_DETECTOR_SUFFIX = "MitigationBypass".freeze
+  VARIANT_ELIGIBLE_DETECTOR_SUFFIXES = [
+    MITIGATION_BYPASS_DETECTOR_SUFFIX,
+    "CrystalMethScore",
+    "CopyRightScoreHarryPotterChapterOne"
+  ].freeze
+
   has_many :detector_results, dependent: :destroy
   has_many :reports, through: :detector_results
   has_many :probe_results
@@ -26,7 +33,13 @@ class Detector < ApplicationRecord
   end
 
   def mitigation_bypass?
-    name&.end_with?("MitigationBypass")
+    name&.end_with?(MITIGATION_BYPASS_DETECTOR_SUFFIX)
+  end
+
+  def variant_eligible?
+    return false if name.blank?
+
+    VARIANT_ELIGIBLE_DETECTOR_SUFFIXES.any? { |suffix| name.end_with?(suffix) }
   end
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/probe.rb
+++ b/app/models/probe.rb
@@ -63,4 +63,8 @@ class Probe < ApplicationRecord
 
     "#{category}.#{name}"
   end
+
+  def variant_eligible?
+    detector&.variant_eligible? || false
+  end
 end

--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -36,6 +36,7 @@ class Scan < ApplicationRecord
     validates :probes, presence: true
     validates :avg_successful_attacks, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }, allow_nil: true
     validate :auto_update_flags_have_corresponding_probes
+    validate :variants_require_eligible_probe
 
     serialize :recurrence, coder: IceCubeScheduleCoder
 
@@ -272,6 +273,16 @@ class Scan < ApplicationRecord
       if auto_update_hp? && categorized[:hp].empty?
         errors.add(:auto_update_hp, "cannot be enabled without HP probes")
       end
+    end
+
+    def variants_require_eligible_probe
+      return if threat_variant_subindustries.empty?
+
+      probe_records = probes.to_a
+      ActiveRecord::Associations::Preloader.new(records: probe_records, associations: [ :detector ]).call
+      return if probe_records.any?(&:variant_eligible?)
+
+      errors.add(:base, "Threat variants require at least one copyright or illicit-substance probe")
     end
 
     def generate_uuid

--- a/app/views/admin/scans/_probe_category_item.html.erb
+++ b/app/views/admin/scans/_probe_category_item.html.erb
@@ -115,6 +115,7 @@
                   "detector-id": probe.detector_id,
                   "category-id": category_id,
                   "input-tokens": probe.input_tokens,
+                  "variant-eligible": probe.variant_eligible?,
                   "probe-category-target": "probeCheckbox",
                   action: "change->probe-category#updateCategoryState"
                 } %>

--- a/app/views/admin/scans/_threat_variants.html.erb
+++ b/app/views/admin/scans/_threat_variants.html.erb
@@ -1,150 +1,176 @@
-<div class="bg-backgroundPrimary rounded-lg border border-borderPrimary p-6 mb-6" data-controller="threat-variants">
+<div class="bg-backgroundPrimary rounded-lg border border-borderPrimary p-6 mb-6"
+     data-controller="threat-variants">
   <h3 class="text-lg font-semibold mb-4 text-primary">
     Threat Variants (Optional)
   </h3>
 
-  <div class="bg-primary/10 border border-primary/30 rounded-lg p-4 mb-6">
+  <!-- Disabled-state notice: shown only when no variant-eligible probe is selected -->
+  <div class="hidden bg-amber-500/10 border border-amber-500/30 rounded-lg p-4 mb-6"
+       role="alert"
+       data-threat-variants-target="disabledNotice">
     <div class="flex items-start gap-3">
-      <div class="shrink-0 mt-0.5">
-        <span class="icon icon-md icon-info text-primary"></span>
-      </div>
-      <div>
+      <span class="icon icon-md icon-info text-amber-400 shrink-0 mt-0.5"></span>
+      <div class="flex-1">
         <h4 class="text-sm font-medium text-contentPrimary mb-1">
-          Select industry-specific variants as a follow up for every successful attack from the probes selected above.
+          Threat variants require a copyright or illicit-substance probe.
         </h4>
         <p class="text-sm text-contentSecondary">
-          Select industry categories to include specialized threat variants that will be applied as follow-ups to successful probe attacks.
+          Select at least one copyright or illicit-substance probe above to enable industry-specific variants.
         </p>
       </div>
-    </div>
-  </div>
-
-  <!-- Selection Summary -->
-  <div class="mb-6 flex items-center justify-between">
-    <div data-threat-variants-target="summary" class="text-sm font-medium text-contentSecondary">
-      No categories selected
-    </div>
-    <div class="flex gap-2">
       <button type="button"
-              data-action="click->threat-variants#expandAll"
-              class="btn-base btn-sm btn-default-gray">
-        <span class="icon icon-sm icon-chevron-down"></span>
-        Expand All
-      </button>
-      <button type="button"
-              data-action="click->threat-variants#collapseAll"
-              class="btn-base btn-sm btn-default-gray">
-        <span class="icon icon-sm icon-chevron-up"></span>
-        Collapse All
+              class="btn-base btn-sm btn-default-gray shrink-0"
+              data-action="click->threat-variants#clearSelections">
+        Clear selections
       </button>
     </div>
   </div>
 
-  <!-- Hidden field to ensure empty array is submitted when no variants selected -->
-  <%= hidden_field_tag "scan[threat_variant_subindustry_ids][]", "" %>
-
-  <!-- Industries list -->
-  <div class="threat-variants-container" data-threat-variants-target="container">
-    <div class="industries-list space-y-3">
-      <% industry_configs = {
-           "automotive" => { icon: "icon-truck", color: "blue" },
-           "finance" => { icon: "icon-banknotes", color: "blue" },
-           "healthcare" => { icon: "icon-plus", color: "blue" },
-           "retail" => { icon: "icon-shopping-bag", color: "blue" },
-           "technology" => { icon: "icon-computer", color: "blue" },
-           "energy" => { icon: "icon-lightning", color: "blue" },
-           "education" => { icon: "icon-document", color: "blue" },
-           "government" => { icon: "icon-building", color: "blue" },
-           "manufacturing" => { icon: "icon-wrench-screwdriver", color: "blue" },
-           "marketing" => { icon: "icon-chart", color: "blue" },
-           "social networks" => { icon: "icon-globe", color: "blue" },
-           "telecom" => { icon: "icon-phone", color: "blue" }
-         } %>
-
-      <% threat_variant_industries.each do |industry| %>
-        <% industry_probe_ids = industry.threat_variant_subindustries
-             .flat_map { |sub| sub.threat_variants.pluck(:probe_id) }
-             .uniq %>
-        <% industry_key = industry.name.downcase %>
-        <% config = industry_configs[industry_key] || { icon: "📁", color: "blue" } %>
-
-        <div class="industry-item border border-borderPrimary rounded-lg overflow-hidden hover:border-primary/50 transition-all"
-             data-probe-ids="<%= industry_probe_ids.join(',') %>"
-             data-industry-id="<%= industry.id %>"
-             data-industry-name="<%= industry.name %>"
-             data-threat-variants-target="industryItem">
-          <!-- Industry Header -->
-          <div class="industry-header bg-backgroundSecondary hover:bg-backgroundSecondary/80 transition-colors cursor-pointer"
-               data-action="click->threat-variants#toggleIndustry">
-            <div class="p-4">
-              <div class="flex items-center justify-between">
-                <div class="flex items-center gap-3">
-                  <!-- Checkbox -->
-                  <div data-action="click->threat-variants#stopPropagation">
-                    <%= check_box_tag "industry_#{industry.id}",
-                        "1",
-                        false,
-                        class: "industry-checkbox",
-                        data: {
-                          action: "change->threat-variants#selectAllIndustry",
-                          "threat-variants-target": "industryCheckbox",
-                          "industry-id": industry.id
-                        } %>
-                  </div>
-                  <!-- Icon -->
-                  <span class="icon icon-md <%= config[:icon] %> text-contentSecondary"></span>
-                  <!-- Industry name and count -->
-                  <div class="flex-1">
-                    <h5 class="text-base font-semibold text-contentPrimary"><%= industry.name.humanize %></h5>
-                    <p class="text-xs text-contentTertiary">
-                      <%= industry.threat_variant_subindustries.count %> specialized categories
-                    </p>
-                  </div>
-                </div>
-                <!-- Chevron icon -->
-                <div class="p-1">
-                  <span class="icon icon-md icon-chevron-down chevron-icon text-contentTertiary transition-transform duration-200" data-industry-id="<%= industry.id %>"></span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Subindustries Container -->
-          <div class="subindustries-container bg-backgroundPrimary hidden"
-               data-industry-id="<%= industry.id %>"
-               data-threat-variants-target="subindustriesContainer">
-            <div class="p-4 border-t border-borderPrimary">
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-                <% industry.threat_variant_subindustries.each do |subindustry| %>
-                  <% subindustry_probe_ids = subindustry.threat_variants.pluck(:probe_id).uniq %>
-                  <div class="subindustry-item flex items-center gap-3 p-3 bg-backgroundSecondary rounded-md hover:bg-backgroundSecondary/80 transition-colors"
-                       data-probe-ids="<%= subindustry_probe_ids.join(',') %>"
-                       data-industry-id="<%= industry.id %>"
-                       data-industry-name="<%= industry.name %>"
-                       data-subindustry-id="<%= subindustry.id %>"
-                       data-threat-variants-target="subindustryItem">
-                    <% is_checked = scan.persisted? && scan.threat_variant_subindustries.include?(subindustry) %>
-                    <%= check_box_tag "scan[threat_variant_subindustry_ids][]",
-                        subindustry.id,
-                        is_checked,
-                        id: "scan_threat_variant_subindustry_ids_#{subindustry.id}",
-                        class: "subindustry-checkbox",
-                        data: {
-                          action: "change->threat-variants#selectSubindustry",
-                          "threat-variants-target": "subindustryCheckbox",
-                          "industry-id": industry.id
-                        } %>
-                    <label for="scan_threat_variant_subindustry_ids_<%= subindustry.id %>"
-                           class="text-sm text-contentSecondary cursor-pointer flex-1 hover:text-contentPrimary transition-colors">
-                      <%= subindustry.name.humanize %>
-                    </label>
-                  </div>
-                <% end %>
-              </div>
-            </div>
-          </div>
+  <!-- Content wrapper: dimmed + pointer-events-none when disabled -->
+  <div data-threat-variants-target="content">
+    <div class="bg-primary/10 border border-primary/30 rounded-lg p-4 mb-6">
+      <div class="flex items-start gap-3">
+        <div class="shrink-0 mt-0.5">
+          <span class="icon icon-md icon-info text-primary"></span>
         </div>
-      <% end %>
+        <div>
+          <h4 class="text-sm font-medium text-contentPrimary mb-1">
+            Select industry-specific variants as a follow up for every successful attack from the probes selected above.
+          </h4>
+          <p class="text-sm text-contentSecondary">
+            Select industry categories to include specialized threat variants that will be applied as follow-ups to successful probe attacks.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Selection Summary -->
+    <div class="mb-6 flex items-center justify-between">
+      <div data-threat-variants-target="summary" class="text-sm font-medium text-contentSecondary">
+        No categories selected
+      </div>
+      <div class="flex gap-2">
+        <button type="button"
+                data-action="click->threat-variants#expandAll"
+                class="btn-base btn-sm btn-default-gray">
+          <span class="icon icon-sm icon-chevron-down"></span>
+          Expand All
+        </button>
+        <button type="button"
+                data-action="click->threat-variants#collapseAll"
+                class="btn-base btn-sm btn-default-gray">
+          <span class="icon icon-sm icon-chevron-up"></span>
+          Collapse All
+        </button>
+      </div>
+    </div>
+
+    <!-- Hidden field to ensure empty array is submitted when no variants selected -->
+    <%= hidden_field_tag "scan[threat_variant_subindustry_ids][]", "" %>
+
+    <!-- Industries list -->
+    <div class="threat-variants-container" data-threat-variants-target="container">
+      <div class="industries-list space-y-3">
+        <% industry_configs = {
+             "automotive" => { icon: "icon-truck", color: "blue" },
+             "finance" => { icon: "icon-banknotes", color: "blue" },
+             "healthcare" => { icon: "icon-plus", color: "blue" },
+             "retail" => { icon: "icon-shopping-bag", color: "blue" },
+             "technology" => { icon: "icon-computer", color: "blue" },
+             "energy" => { icon: "icon-lightning", color: "blue" },
+             "education" => { icon: "icon-document", color: "blue" },
+             "government" => { icon: "icon-building", color: "blue" },
+             "manufacturing" => { icon: "icon-wrench-screwdriver", color: "blue" },
+             "marketing" => { icon: "icon-chart", color: "blue" },
+             "social networks" => { icon: "icon-globe", color: "blue" },
+             "telecom" => { icon: "icon-phone", color: "blue" }
+           } %>
+
+        <% threat_variant_industries.each do |industry| %>
+          <% industry_probe_ids = industry.threat_variant_subindustries
+               .flat_map { |sub| sub.threat_variants.pluck(:probe_id) }
+               .uniq %>
+          <% industry_key = industry.name.downcase %>
+          <% config = industry_configs[industry_key] || { icon: "📁", color: "blue" } %>
+
+          <div class="industry-item border border-borderPrimary rounded-lg overflow-hidden hover:border-primary/50 transition-all"
+               data-probe-ids="<%= industry_probe_ids.join(',') %>"
+               data-industry-id="<%= industry.id %>"
+               data-industry-name="<%= industry.name %>"
+               data-threat-variants-target="industryItem">
+            <!-- Industry Header -->
+            <div class="industry-header bg-backgroundSecondary hover:bg-backgroundSecondary/80 transition-colors cursor-pointer"
+                 data-action="click->threat-variants#toggleIndustry">
+              <div class="p-4">
+                <div class="flex items-center justify-between">
+                  <div class="flex items-center gap-3">
+                    <!-- Checkbox -->
+                    <div data-action="click->threat-variants#stopPropagation">
+                      <%= check_box_tag "industry_#{industry.id}",
+                          "1",
+                          false,
+                          class: "industry-checkbox",
+                          data: {
+                            action: "change->threat-variants#selectAllIndustry",
+                            "threat-variants-target": "industryCheckbox",
+                            "industry-id": industry.id
+                          } %>
+                    </div>
+                    <!-- Icon -->
+                    <span class="icon icon-md <%= config[:icon] %> text-contentSecondary"></span>
+                    <!-- Industry name and count -->
+                    <div class="flex-1">
+                      <h5 class="text-base font-semibold text-contentPrimary"><%= industry.name.humanize %></h5>
+                      <p class="text-xs text-contentTertiary">
+                        <%= industry.threat_variant_subindustries.count %> specialized categories
+                      </p>
+                    </div>
+                  </div>
+                  <!-- Chevron icon -->
+                  <div class="p-1">
+                    <span class="icon icon-md icon-chevron-down chevron-icon text-contentTertiary transition-transform duration-200" data-industry-id="<%= industry.id %>"></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Subindustries Container -->
+            <div class="subindustries-container bg-backgroundPrimary hidden"
+                 data-industry-id="<%= industry.id %>"
+                 data-threat-variants-target="subindustriesContainer">
+              <div class="p-4 border-t border-borderPrimary">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  <% industry.threat_variant_subindustries.each do |subindustry| %>
+                    <% subindustry_probe_ids = subindustry.threat_variants.pluck(:probe_id).uniq %>
+                    <div class="subindustry-item flex items-center gap-3 p-3 bg-backgroundSecondary rounded-md hover:bg-backgroundSecondary/80 transition-colors"
+                         data-probe-ids="<%= subindustry_probe_ids.join(',') %>"
+                         data-industry-id="<%= industry.id %>"
+                         data-industry-name="<%= industry.name %>"
+                         data-subindustry-id="<%= subindustry.id %>"
+                         data-threat-variants-target="subindustryItem">
+                      <% is_checked = scan.persisted? && scan.threat_variant_subindustries.include?(subindustry) %>
+                      <%= check_box_tag "scan[threat_variant_subindustry_ids][]",
+                          subindustry.id,
+                          is_checked,
+                          id: "scan_threat_variant_subindustry_ids_#{subindustry.id}",
+                          class: "subindustry-checkbox",
+                          data: {
+                            action: "change->threat-variants#selectSubindustry",
+                            "threat-variants-target": "subindustryCheckbox",
+                            "industry-id": industry.id
+                          } %>
+                      <label for="scan_threat_variant_subindustry_ids_<%= subindustry.id %>"
+                             class="text-sm text-contentSecondary cursor-pointer flex-1 hover:text-contentPrimary transition-colors">
+                        <%= subindustry.name.humanize %>
+                      </label>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/script/tests/javascript_controller_tests.mjs
+++ b/script/tests/javascript_controller_tests.mjs
@@ -124,6 +124,21 @@ function loadLogViewerController() {
   return { ControllerClass }
 }
 
+function loadThreatVariantsController() {
+  const transformed = loadControllerSource(
+    "threat_variants_controller.js",
+    "ThreatVariantsController"
+  )
+
+  const context = { Controller: class {}, document: {} }
+  const ControllerClass = vm.runInNewContext(
+    `${transformed}\nThreatVariantsController`,
+    context
+  )
+
+  return { ControllerClass }
+}
+
 function loadReportRedesignedController() {
   const source = readFileSync(
     new URL("../../app/javascript/controllers/report_redesigned_controller.js", import.meta.url),
@@ -203,6 +218,9 @@ function fakeElement(...initialClasses) {
     focusTarget: null,
     setAttribute(name, value) {
       attributes.set(name, value)
+    },
+    removeAttribute(name) {
+      attributes.delete(name)
     },
     getAttribute(name) {
       return attributes.get(name)
@@ -870,6 +888,69 @@ function testLogViewerController() {
   assert.equal(dynamicFailLine.style.display, "none")
 }
 
+function testThreatVariantsController() {
+  const { ControllerClass } = loadThreatVariantsController()
+
+  const enabledController = new ControllerClass()
+  const enabledContent = fakeElement()
+  const enabledNotice = fakeElement("hidden")
+  const enabledIndustryCheckbox = fakeElement()
+  const enabledSubindustryCheckbox = fakeElement()
+
+  enabledController.contentTarget = enabledContent
+  enabledController.hasContentTarget = true
+  enabledController.disabledNoticeTarget = enabledNotice
+  enabledController.hasDisabledNoticeTarget = true
+  enabledController.industryCheckboxTargets = [enabledIndustryCheckbox]
+  enabledController.subindustryCheckboxTargets = [enabledSubindustryCheckbox]
+
+  enabledController.applyEligibility(true)
+
+  assert.equal(enabledContent.classList.contains("opacity-50"), false)
+  assert.equal(enabledContent.classList.contains("pointer-events-none"), false)
+  assert.equal(enabledContent.getAttribute("aria-disabled"), undefined)
+  assert.equal(enabledNotice.classList.contains("hidden"), true)
+  assert.equal(enabledIndustryCheckbox.disabled, false)
+  assert.equal(enabledSubindustryCheckbox.disabled, false)
+
+  const disabledController = new ControllerClass()
+  const disabledContent = fakeElement()
+  const disabledNotice = fakeElement("hidden")
+  const disabledIndustryCheckbox = fakeElement()
+  const disabledSubindustryCheckbox = fakeElement()
+
+  disabledController.contentTarget = disabledContent
+  disabledController.hasContentTarget = true
+  disabledController.disabledNoticeTarget = disabledNotice
+  disabledController.hasDisabledNoticeTarget = true
+  disabledController.industryCheckboxTargets = [disabledIndustryCheckbox]
+  disabledController.subindustryCheckboxTargets = [disabledSubindustryCheckbox]
+
+  disabledController.applyEligibility(false)
+
+  assert.equal(disabledContent.classList.contains("opacity-50"), true)
+  assert.equal(disabledContent.classList.contains("pointer-events-none"), true)
+  assert.equal(disabledContent.getAttribute("aria-disabled"), "true")
+  assert.equal(disabledNotice.classList.contains("hidden"), false)
+  assert.equal(disabledIndustryCheckbox.disabled, true)
+  assert.equal(disabledSubindustryCheckbox.disabled, true)
+
+  const clearController = new ControllerClass()
+  const cb1 = fakeElement()
+  cb1.checked = true
+  const cb2 = fakeElement()
+  cb2.checked = true
+  clearController.subindustryCheckboxTargets = [cb1, cb2]
+  clearController.industryItemTargets = []
+  clearController.summaryTarget = fakeElement()
+  clearController.hasSummaryTarget = true
+
+  clearController.clearSelections()
+
+  assert.equal(cb1.checked, false)
+  assert.equal(cb2.checked, false)
+}
+
 await testDebugStreamLeaseController()
 testActivityStreamController()
 testDebugTabsController()
@@ -877,4 +958,5 @@ testDebugStreamFilterController()
 testReportRedesignedController()
 testReportRedesignedControllerListenerCleanup()
 testLogViewerController()
+testThreatVariantsController()
 console.log("JavaScript controller tests passed")

--- a/spec/models/detector_spec.rb
+++ b/spec/models/detector_spec.rb
@@ -108,4 +108,24 @@ RSpec.describe Detector, type: :model do
       expect(detector.probes.count).to eq(2)
     end
   end
+
+  describe '#variant_eligible?' do
+    it 'is true for MitigationBypass detector names' do
+      expect(Detector.new(name: '0din.MitigationBypass').variant_eligible?).to be true
+      expect(Detector.new(name: 'mitigation.MitigationBypass').variant_eligible?).to be true
+    end
+
+    it 'is true for CrystalMethScore detector names' do
+      expect(Detector.new(name: '0din.CrystalMethScore').variant_eligible?).to be true
+    end
+
+    it 'is true for CopyRightScoreHarryPotterChapterOne detector names' do
+      expect(Detector.new(name: '0din.CopyRightScoreHarryPotterChapterOne').variant_eligible?).to be true
+    end
+
+    it 'is false for other detector names' do
+      expect(Detector.new(name: '0din.PromptInjection').variant_eligible?).to be false
+      expect(Detector.new(name: nil).variant_eligible?).to be false
+    end
+  end
 end

--- a/spec/models/probe_spec.rb
+++ b/spec/models/probe_spec.rb
@@ -64,4 +64,26 @@ RSpec.describe Probe, type: :model do
       end
     end
   end
+
+  describe '#variant_eligible?' do
+    it 'is true when the detector is variant-eligible' do
+      detector = build(:detector, name: '0din.MitigationBypass')
+      probe = build(:probe, detector: detector)
+
+      expect(probe.variant_eligible?).to be true
+    end
+
+    it 'is false when the detector is not variant-eligible' do
+      detector = build(:detector, name: '0din.PromptInjection')
+      probe = build(:probe, detector: detector)
+
+      expect(probe.variant_eligible?).to be false
+    end
+
+    it 'is false when there is no detector' do
+      probe = build(:probe, detector: nil)
+
+      expect(probe.variant_eligible?).to be false
+    end
+  end
 end

--- a/spec/models/scan_spec.rb
+++ b/spec/models/scan_spec.rb
@@ -92,6 +92,35 @@ RSpec.describe Scan, type: :model do
 
       expect(scan.valid?).to be_truthy
     end
+
+    it 'rejects scans that select threat variants without any variant-eligible probe' do
+      ineligible_detector = create(:detector, name: '0din.PromptInjection')
+      ineligible_probe = create(:probe, detector: ineligible_detector)
+      subindustry = create(:threat_variant_subindustry)
+      scan = Scan.new(name: 'Variant Without Eligible Probe', uuid: SecureRandom.uuid, company: company)
+      scan.targets = [ create(:target, company: company) ]
+      scan.probes = [ ineligible_probe ]
+      scan.threat_variant_subindustries = [ subindustry ]
+
+      allow(scan).to receive(:update_next_scheduled_run)
+
+      expect(scan).not_to be_valid
+      expect(scan.errors[:base]).to include('Threat variants require at least one copyright or illicit-substance probe')
+    end
+
+    it 'is valid when at least one selected probe is variant-eligible' do
+      eligible_detector = create(:detector, name: '0din.MitigationBypass')
+      eligible_probe = create(:probe, detector: eligible_detector)
+      subindustry = create(:threat_variant_subindustry)
+      scan = Scan.new(name: 'Variant With Eligible Probe', uuid: SecureRandom.uuid, company: company)
+      scan.targets = [ create(:target, company: company) ]
+      scan.probes = [ eligible_probe ]
+      scan.threat_variant_subindustries = [ subindustry ]
+
+      allow(scan).to receive(:update_next_scheduled_run)
+
+      expect(scan).to be_valid
+    end
   end
 
   describe 'callbacks' do


### PR DESCRIPTION
## Summary
- require threat variants to be paired with a copyright or illicit-substance probe
- disable threat variant controls until an eligible probe is selected
- add model and JavaScript coverage for the eligibility behavior
