### PR TITLE
fix(reports): surface provider terminal failures

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -72,11 +72,89 @@ class Report < ApplicationRecord
   DEBUG_STREAM_POLLING_STATUSES = (DEBUG_BROADCAST_ACTIVE_STATUSES + %w[pending]).freeze
 
   def self.ransackable_attributes(auth_object = nil)
-    [ "company_id", "name", "created_at", "id", "status", "target_id", "updated_at", "uuid", "asr" ]
+    [ "company_id", "failure_code", "name", "created_at", "id", "status", "target_id", "updated_at", "uuid", "asr" ]
   end
 
   def self.ransackable_associations(auth_object = nil)
     [ "company", "target", "scan" ]
+  end
+
+  def failed_with_reason?
+    failed? && (failure_code.present? || failure_message.present?)
+  end
+
+  def user_failure_message
+    return failure_message if failure_message.present?
+
+    case failure_code
+    when "provider_model_unavailable"
+      "The provider rejected the configured model as unavailable. Update the target model, " \
+        "revalidate the target, then rerun the scan."
+    when "provider_payment_required"
+      "The provider rejected the scan because billing or credits are required. Check the provider account, " \
+        "then rerun the scan."
+    when "provider_auth_failed"
+      "The provider rejected the scan because authentication failed. Check the target credentials, " \
+        "revalidate the target, then rerun the scan."
+    when "provider_rejected_request"
+      "The provider rejected the scan request. Review the target configuration, revalidate the target, " \
+        "then rerun the scan."
+    when "provider_rate_limited"
+      "The provider rate limited the scan. Wait or reduce concurrency, then rerun the scan."
+    when "provider_service_unavailable"
+      "The provider is temporarily unavailable or returned an upstream error. Wait for the provider to recover, " \
+        "revalidate the target, then rerun the scan."
+    when "target_validation_failed"
+      "The target is not ready for scanning. Revalidate the target, then rerun the scan."
+    when "garak_runtime_error"
+      "The scan runtime failed before results could be completed. Review the target configuration, then rerun the scan."
+    else
+      "The scan failed before results could be completed."
+    end
+  end
+
+  def failure_title
+    case failure_code
+    when "provider_model_unavailable"
+      "Provider model unavailable"
+    when "provider_payment_required"
+      "Provider billing required"
+    when "provider_auth_failed"
+      "Provider authentication failed"
+    when "provider_rejected_request"
+      "Provider rejected request"
+    when "provider_rate_limited"
+      "Provider rate limited"
+    when "provider_service_unavailable"
+      "Provider temporarily unavailable"
+    when "target_validation_failed"
+      "Target validation failed"
+    when "garak_runtime_error"
+      "Scan runtime failed"
+    else
+      "Scan failed"
+    end
+  end
+
+  def failure_action
+    case failure_code
+    when "provider_model_unavailable"
+      "Update the target model, revalidate the target, then rerun the scan."
+    when "provider_payment_required"
+      "Check provider billing or credits, then rerun the scan."
+    when "provider_auth_failed"
+      "Check API credentials, revalidate the target, then rerun the scan."
+    when "provider_rejected_request"
+      "Review the target configuration, revalidate the target, then rerun the scan."
+    when "provider_rate_limited"
+      "Wait or reduce scan concurrency, then rerun the scan."
+    when "provider_service_unavailable"
+      "Wait for the provider to recover, revalidate the target, then rerun the scan."
+    when "target_validation_failed"
+      "Fix target validation, then rerun the scan."
+    else
+      "Review the target configuration, then rerun the scan."
+    end
   end
 
   def logs

--- a/app/services/reports/failure_classifier.rb
+++ b/app/services/reports/failure_classifier.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+module Reports
+  class FailureClassifier
+    Result = Struct.new(:code, :message, :details, keyword_init: true) do
+      def failed?
+        code.present?
+      end
+
+      def provider_failure?
+        code.to_s.start_with?("provider_")
+      end
+    end
+
+    OPENROUTER = "OpenRouter"
+    EMPTY_RESULT = Result.new(code: nil, message: nil, details: {}).freeze
+
+    STATUS_CODE_PATTERN = /
+      status_code\s*[=:]\s*(\d{3}) |
+      HTTP\/\d(?:\.\d)?\s+(\d{3}) |
+      status\s*[=:]\s*(\d{3})
+    /ix
+    PROVIDER_FAILURE_STATUS_CODES = ([ 401, 402, 403, 404, 422, 429 ] + (500..599).to_a).freeze
+    MESSAGE_PATTERNS = [
+      /"message"\s*:\s*"([^"]+)"/i,
+      /message\s*[=:]\s*["']?([^"'
+}]+)/i,
+      /error\s*[=:]\s*["']?([^"'
+}]+)/i
+    ].freeze
+    HTTP_PROVIDER_STATUS_PATTERN = /HTTP\/\d(?:\.\d)?\s+(401|402|403|404|422|429|5\d{2})/i
+    HTTP_PROVIDER_HINT_PATTERN = /openrouter|provider|deprecated|no endpoints|credits?|rate limit/i
+    AUTH_HINT_PATTERN = /unauthori[sz]ed|invalid api key|authentication|credentials/i
+    REJECTED_REQUEST_HINT_PATTERN = /rejected request|request rejected|invalid request/i
+    TARGET_VALIDATION_HINT_PATTERN = /target validation failed|no responses received|0\/\d+\s+attempts passed/i
+    MODEL_UNAVAILABLE_HINT_PATTERN = /
+      deprecated|model\ .*unavailable|unavailable\ .*model|no\ endpoints|model\ .*not\ found|not\ found\ .*model
+    /ix
+    SECRET_PATTERNS = [
+      [ /(Bearer\s+)[A-Za-z0-9._~+\-\/=]+/i, '\1[REDACTED]' ],
+      [ /((?:api[_-]?key|token|secret|password|authorization)["']?\s*[:=]\s*)["']?[^"'\s,}]+/i, '\1[REDACTED]' ],
+      [ /sk-(?:or-v1-)?[A-Za-z0-9_\-]{8,}/i, "[REDACTED]" ]
+    ].freeze
+
+    def initialize(report, logs: nil, exit_code: nil, exception_message: nil)
+      @report = report
+      @logs = logs
+      @exit_code = exit_code
+      @exception_message = exception_message
+    end
+
+    def self.sanitize_text(text)
+      return text if text.blank?
+
+      SECRET_PATTERNS.reduce(text.to_s) do |sanitized, (pattern, replacement)|
+        sanitized.gsub(pattern, replacement)
+      end
+    end
+
+    def call
+      return EMPTY_RESULT if evidence_text.blank? && exit_code.blank?
+
+      provider_result = classify_provider_failure
+      return provider_result if provider_result.failed?
+
+      target_result = classify_target_validation_failure
+      return target_result if target_result.failed?
+
+      runtime_result = classify_runtime_failure
+      return runtime_result if runtime_result.failed?
+
+      EMPTY_RESULT
+    end
+
+    private
+
+    attr_reader :report, :logs, :exit_code, :exception_message
+
+    def classify_provider_failure
+      return EMPTY_RESULT unless provider_error_evidence?
+
+      case status_code
+      when 404
+        return build_result("provider_model_unavailable") if model_unavailable_text?
+      when 402
+        return build_result("provider_payment_required")
+      when 401
+        return build_result("provider_auth_failed")
+      when 403
+        return build_result("provider_rejected_request")
+      when 422
+        return build_result("provider_rejected_request")
+      when 429
+        return build_result("provider_rate_limited")
+      when 500..599
+        return build_result("provider_service_unavailable")
+      end
+
+      return build_result("provider_payment_required") if evidence_text.match?(/payment|billing|credits?/i)
+      return build_result("provider_auth_failed") if evidence_text.match?(AUTH_HINT_PATTERN)
+      return build_result("provider_rejected_request") if evidence_text.match?(REJECTED_REQUEST_HINT_PATTERN)
+      return build_result("provider_rate_limited") if evidence_text.match?(/rate limit|too many requests/i)
+      return build_result("provider_model_unavailable") if model_unavailable_text?
+
+      EMPTY_RESULT
+    end
+
+    def classify_target_validation_failure
+      return EMPTY_RESULT unless evidence_text.match?(TARGET_VALIDATION_HINT_PATTERN)
+
+      build_result("target_validation_failed")
+    end
+
+    def classify_runtime_failure
+      return EMPTY_RESULT unless exit_code.to_i.positive? || exception_message.present? ||
+        evidence_text.match?(/traceback|exception|runtimeerror|garak .*failed|non[- ]?zero/i)
+
+      build_result("garak_runtime_error")
+    end
+
+    def build_result(code)
+      Result.new(
+        code: code,
+        message: message_for(code),
+        details: compact_details
+      )
+    end
+
+    def compact_details
+      raw_details = {
+        "provider" => provider,
+        "model" => model,
+        "status_code" => status_code,
+        "provider_message" => provider_message,
+        "exit_code" => exit_code,
+        "exception_message" => exception_message
+      }
+
+      sanitize_value(raw_details.compact)
+    end
+
+    def message_for(code)
+      case code
+      when "provider_model_unavailable"
+        message = "#{provider || 'The provider'} rejected configured model "           "#{model || 'the selected model'} as unavailable or deprecated."
+        message += " Provider message: #{provider_message}." if provider_message.present?
+        message += " Update the target model, revalidate the target, then rerun the scan."
+        sanitize_text(message)
+      when "provider_payment_required"
+        sanitize_text(
+          "#{provider || 'The provider'} rejected the scan because billing or credits are required. "           "Check provider billing or credits, then rerun the scan."
+        )
+      when "provider_auth_failed"
+        sanitize_text(
+          "#{provider || 'The provider'} authentication failed. Check the target API credentials, "           "revalidate the target, then rerun the scan."
+        )
+      when "provider_rejected_request"
+        sanitize_text(
+          "#{provider || 'The provider'} rejected the scan request. Review the target model/configuration, "           "revalidate the target, then rerun the scan."
+        )
+      when "provider_rate_limited"
+        sanitize_text(
+          "#{provider || 'The provider'} rate limit was reached. Wait or reduce scan concurrency, "           "then rerun the scan."
+        )
+      when "provider_service_unavailable"
+        sanitize_text(
+          "#{provider || 'The provider'} is temporarily unavailable or returned an upstream error. "           "Wait for the provider to recover, revalidate the target, then rerun the scan."
+        )
+      when "target_validation_failed"
+        sanitize_text(
+          "Target validation failed. Fix the target configuration, revalidate the target, "           "then rerun the scan."
+        )
+      when "garak_runtime_error"
+        sanitize_text(
+          "The scan runtime failed before results could be completed. Review the target configuration, "           "then rerun the scan."
+        )
+      end
+    end
+
+    def provider_error_evidence?
+      terminal_provider_error? || configured_provider_error? || http_provider_error?
+    end
+
+    def terminal_provider_error?
+      evidence_text.match?(/terminal API status error|provider .*status error/i)
+    end
+
+    def configured_provider_error?
+      provider.present? && terminal_provider_error? && PROVIDER_FAILURE_STATUS_CODES.include?(status_code)
+    end
+
+    def http_provider_error?
+      evidence_text.match?(HTTP_PROVIDER_STATUS_PATTERN) && evidence_text.match?(HTTP_PROVIDER_HINT_PATTERN)
+    end
+
+    def model_unavailable_text?
+      evidence_text.match?(MODEL_UNAVAILABLE_HINT_PATTERN)
+    end
+
+    def evidence_text
+      @evidence_text ||= [ logs, exception_message ].compact.join("
+")
+    end
+
+    def status_code
+      @status_code ||= begin
+        match = evidence_text.match(STATUS_CODE_PATTERN)
+        match&.captures&.compact&.first&.to_i
+      end
+    end
+
+    def provider
+      @provider ||= if evidence_text.match?(/openrouter/i) || report.target&.model_type.to_s.match?(/openrouter/i)
+        OPENROUTER
+      end
+    end
+
+    def model
+      @model ||= begin
+        configured_model = report.target&.model.presence
+        configured_model || evidence_text[/[a-z0-9][a-z0-9._-]+\/[a-z0-9][a-z0-9._-]+/i]
+      end
+    end
+
+    def provider_message
+      @provider_message ||= begin
+        message = MESSAGE_PATTERNS.filter_map { |pattern| evidence_text.match(pattern)&.[](1) }.first
+        sanitize_text(message&.strip)
+      end
+    end
+
+    def sanitize_value(value)
+      case value
+      when Hash
+        value.transform_values { |nested| sanitize_value(nested) }
+      when Array
+        value.map { |nested| sanitize_value(nested) }
+      when String
+        sanitize_text(value)
+      else
+        value
+      end
+    end
+
+    def sanitize_text(text)
+      self.class.sanitize_text(text)
+    end
+  end
+end

--- a/app/services/reports/process.rb
+++ b/app/services/reports/process.rb
@@ -38,6 +38,7 @@ module Reports
         process_jsonl_data(@raw_data.jsonl_data, mark_processing: false)
 
         persist_final_logs
+        apply_failure_metadata
         save_detector_results
         update_target_token_rate
 
@@ -48,15 +49,51 @@ module Reports
     end
 
     def persist_final_logs
-      final_logs = @raw_data.logs_data.presence || report.report_debug_log&.tail.presence
+      final_logs = current_run_final_logs
       return if final_logs.nil? && report.report_debug_log.nil?
       return if final_logs.nil? && preserve_existing_logs_without_final_logs?
 
       report.logs = final_logs
     end
 
+    def current_run_final_logs
+      return @current_run_final_logs if defined?(@current_run_final_logs)
+
+      @current_run_final_logs = @raw_data.logs_data.presence || report.report_debug_log&.tail.presence
+    end
+
     def preserve_existing_logs_without_final_logs?
       report.retry_count.to_i.positive? && report.logs.present?
+    end
+
+    def apply_failure_metadata
+      failure = FailureClassifier.new(report, logs: current_run_failure_logs).call
+      if failure.failed?
+        report.status = :failed
+        report.failure_code = failure.code
+        report.failure_message = failure.message
+        report.failure_details = failure.details
+      else
+        clear_failure_metadata
+      end
+    end
+
+    def current_run_failure_logs
+      return @current_run_failure_logs if defined?(@current_run_failure_logs)
+
+      @current_run_failure_logs = @raw_data.logs_data.presence || current_run_tail_failure_logs
+    end
+
+    def current_run_tail_failure_logs
+      return if report.retry_count.to_i.positive?
+
+      report.report_debug_log&.tail.presence
+    end
+
+    def clear_failure_metadata
+      report.failure_code = nil
+      report.failure_message = nil
+      report.failure_details = {}
     end
 
     def process_jsonl_data(jsonl_string, mark_processing: true)

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -134,9 +134,13 @@ class RunGarakScan
       Rails.logger.error("Cannot run scan for report #{report.id} - target #{target.id} (#{target.name}) has unexpected status: #{target.status}")
     end
 
+    sanitized_error_message = Reports::FailureClassifier.sanitize_text(error_message)
     report.update(
       status: :failed,
-      logs: "Scan failed: #{error_message}"
+      logs: "Scan failed: #{sanitized_error_message}",
+      failure_code: "target_validation_failed",
+      failure_message: sanitized_error_message,
+      failure_details: {}
     )
   end
 

--- a/app/views/admin/reports/_show_v2.html.erb
+++ b/app/views/admin/reports/_show_v2.html.erb
@@ -31,6 +31,10 @@
     <div class="mx-auto space-y-6">
       <%= render partial: 'admin/reports/metadata_section', locals: { report: report } %>
 
+      <% if report.failed_with_reason? %>
+        <%= render partial: 'reports/failure_summary', locals: { report: report, admin: true } %>
+      <% end %>
+
       <%= render partial: 'admin/reports/statistics_section', locals: { report: report } %>
 
       <% if show_activity_stream_for_report?(report, params: params, user: current_user) %>

--- a/app/views/report_details/show.html.erb
+++ b/app/views/report_details/show.html.erb
@@ -72,6 +72,10 @@
     </div>
   </div>
 
+  <% if @report.failed_with_reason? %>
+    <%= render partial: 'reports/failure_summary', locals: { report: @report, pdf_mode: pdf_mode } %>
+  <% end %>
+
   <% if @report.detector_results.exists? %>
     <div class="<%= pdf_mode ? 'px-6 py-5 bg-gray-50 border-b border-gray-200' : 'px-8 py-6 bg-gradient-to-r from-gray-100 via-white to-gray-50 border-b border-gray-200' %>">
       <div class="<%= pdf_mode ? 'mb-3' : 'mb-4' %>">

--- a/app/views/reports/_failure_summary.html.erb
+++ b/app/views/reports/_failure_summary.html.erb
@@ -1,0 +1,53 @@
+<%
+  admin = local_assigns.fetch(:admin, false)
+  pdf_mode = local_assigns.fetch(:pdf_mode, false)
+  details = report.failure_details || {}
+  detail_items = [
+    [ "Provider", details["provider"] ],
+    [ "Model", details["model"] ],
+    [ "Status", details["status_code"] ]
+  ].select { |_label, value| value.present? }
+
+  container_class = if admin
+    "rounded-lg border border-red-400/30 bg-red-950/20 p-4"
+  elsif pdf_mode
+    "px-6 py-5 bg-red-50 border-b border-red-200"
+  else
+    "px-8 py-6 bg-red-50 border-b border-red-200"
+  end
+  title_class = admin ? "text-sm font-semibold text-red-200" : "text-base font-semibold text-red-900"
+  message_class = admin ? "mt-1 text-sm leading-6 text-contentSecondary" : "mt-1 text-sm leading-6 text-red-800"
+  action_class = admin ? "mt-3 text-sm font-medium text-red-200" : "mt-3 text-sm font-medium text-red-900"
+  meta_class = if admin
+    "mt-3 flex flex-wrap gap-2 text-xs text-red-100"
+  else
+    "mt-3 flex flex-wrap gap-2 text-xs text-red-800"
+  end
+  pill_class = if admin
+    "rounded border border-red-400/30 bg-red-950/30 px-2 py-1"
+  else
+    "rounded border border-red-200 bg-white/70 px-2 py-1"
+  end
+%>
+
+<div class="<%= container_class %>" role="alert">
+  <div class="flex gap-3">
+    <span class="icon icon-md icon-warning shrink-0 <%= admin ? 'text-red-300' : 'text-red-600' %>"></span>
+    <div class="min-w-0">
+      <h2 class="<%= title_class %>">Scan failed: <%= report.failure_title %></h2>
+      <p class="<%= message_class %>"><%= report.user_failure_message %></p>
+      <p class="<%= action_class %>">Next step: <%= report.failure_action %></p>
+
+      <% if detail_items.any? %>
+        <dl class="<%= meta_class %>">
+          <% detail_items.each do |label, value| %>
+            <div class="<%= pill_class %>">
+              <dt class="inline font-medium"><%= label %>:</dt>
+              <dd class="inline"><%= value %></dd>
+            </div>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/db/migrate/20260519000000_add_failure_metadata_to_reports.rb
+++ b/db/migrate/20260519000000_add_failure_metadata_to_reports.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddFailureMetadataToReports < ActiveRecord::Migration[8.1]
+  def change
+    add_column :reports, :failure_code, :string
+    add_column :reports, :failure_message, :text
+    add_column :reports, :failure_details, :jsonb, default: {}, null: false
+
+    add_index :reports, :failure_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_27_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_19_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -288,6 +288,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_000000) do
     t.bigint "company_id", null: false
     t.datetime "created_at", null: false
     t.datetime "end_time"
+    t.string "failure_code"
+    t.jsonb "failure_details", default: {}, null: false
+    t.text "failure_message"
     t.datetime "heartbeat_at"
     t.datetime "last_retry_at"
     t.string "name", null: false
@@ -302,6 +305,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_000000) do
     t.string "uuid", null: false
     t.string "variant_probe_name"
     t.index ["company_id"], name: "index_reports_on_company_id"
+    t.index ["failure_code"], name: "index_reports_on_failure_code"
     t.index ["heartbeat_at"], name: "index_reports_on_heartbeat_running_only", where: "(status = 1)"
     t.index ["parent_report_id"], name: "index_reports_on_parent_report_id"
     t.index ["parent_report_id"], name: "index_reports_on_unique_parent_report_id", unique: true, where: "(parent_report_id IS NOT NULL)"

--- a/script/garak_plugins/openrouter.py
+++ b/script/garak_plugins/openrouter.py
@@ -18,11 +18,14 @@ Requires garak 0.14+ (uses Conversation/Message API).
 """
 
 import logging
+import re
+from collections.abc import Mapping, Sequence
 from typing import List, Union, Optional
 
 from garak import _config
-from garak.generators.openai import OpenAICompatible
 from garak.attempt import Conversation, Message
+from garak.exception import BadGeneratorException
+from garak.generators.openai import OpenAICompatible
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
@@ -39,6 +42,77 @@ context_lengths = {
     "mistral/mistral-medium": 32000,
     "mistral/mistral-small": 32000
 }
+
+SENSITIVE_KEY_RE = re.compile(r"(?:api[_-]?key|token|secret|password|authorization)", re.I)
+SECRET_VALUE_PATTERNS = (
+    (re.compile(r"(Bearer\s+)[A-Za-z0-9._~+\-/=]+", re.I), r"\1[REDACTED]"),
+    (re.compile(r"((?:api[_-]?key|token|secret|password|authorization)[\"']?\s*[:=]\s*)[\"']?[^\"'\s,}]+", re.I), r"\1[REDACTED]"),
+    (re.compile(r"\bsk-(?:or-v1-)?[A-Za-z0-9_-]{8,}\b", re.I), "[REDACTED]"),
+)
+
+
+def _safe_getattr(obj, attr, default=None):
+    try:
+        return getattr(obj, attr)
+    except Exception:
+        return default
+
+
+def _redact(value):
+    if isinstance(value, Mapping):
+        return {
+            key: "[REDACTED]" if SENSITIVE_KEY_RE.search(str(key)) else _redact(nested)
+            for key, nested in value.items()
+        }
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_redact(nested) for nested in value]
+
+    if isinstance(value, str):
+        redacted = value
+        for pattern, replacement in SECRET_VALUE_PATTERNS:
+            redacted = pattern.sub(replacement, redacted)
+        return redacted
+
+    return value
+
+
+def _safe_status_detail(value, max_chars=2000):
+    if value is None:
+        return ""
+
+    redacted = _redact(value)
+    try:
+        rendered = repr(redacted)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        rendered = f"<unprintable {type(value).__name__}: {type(exc).__name__}>"
+
+    if len(rendered) > max_chars:
+        return f"{rendered[:max_chars]}...<truncated>"
+    return rendered
+
+
+def _terminal_api_status_message(exc, provider, model):
+    response = _safe_getattr(exc, "response")
+    status_code = _safe_getattr(exc, "status_code")
+    if status_code is None:
+        status_code = _safe_getattr(response, "status_code")
+
+    reason = _safe_getattr(response, "reason_phrase") or _safe_getattr(response, "reason")
+    message = _safe_getattr(exc, "message") or str(exc)
+    body = _safe_getattr(exc, "body")
+    if body is None and response is not None:
+        body = _safe_getattr(response, "text")
+
+    return (
+        f"{provider} terminal API status error: "
+        f"model={_safe_status_detail(model)} "
+        f"status_code={_safe_status_detail(status_code)} "
+        f"reason={_safe_status_detail(reason)} "
+        f"message={_safe_status_detail(message)} "
+        f"body={_safe_status_detail(body)}"
+    )
+
 
 class OpenRouterGenerator(OpenAICompatible):
     """Generator wrapper for OpenRouter.ai models. Expects API key in the OPENROUTER_API_KEY environment variable"""
@@ -129,7 +203,7 @@ class OpenRouterGenerator(OpenAICompatible):
                     logging.debug(f"  Function Call: {choice.message.function_call}")
             elif hasattr(choice, 'text'):
                 logging.debug(f"- Text: {choice.text}")
-            
+
             # Log additional choice attributes if present
             if hasattr(choice, 'finish_reason'):
                 logging.debug(f"  Finish Reason: {choice.finish_reason}")
@@ -141,7 +215,7 @@ class OpenRouterGenerator(OpenAICompatible):
             logging.debug(f"\nModel: {response.model}")
         if hasattr(response, 'system_fingerprint'):
             logging.debug(f"System Fingerprint: {response.system_fingerprint}")
-            
+
         logging.debug("==================")
 
     def _call_model(
@@ -182,6 +256,7 @@ class OpenRouterGenerator(OpenAICompatible):
             self._log_completion_details(prompt, raw_response)
 
             response_messages = self._messages_from_response(raw_response)
+            self._raise_if_all_generations_empty(response_messages)
             if len(response_messages) == generations_this_call:
                 return response_messages
 
@@ -195,7 +270,10 @@ class OpenRouterGenerator(OpenAICompatible):
             )
             return self._call_model_sequential(messages, generations_this_call, prompt)
 
+        except BadGeneratorException:
+            raise
         except Exception as e:
+            self._raise_terminal_api_status_error(e)
             logging.error(f"Error in model call: {str(e)}")
             return [None] * generations_this_call
 
@@ -211,8 +289,12 @@ class OpenRouterGenerator(OpenAICompatible):
                 )
                 self._log_completion_details(original_prompt, raw_response)
                 response_messages = self._messages_from_response(raw_response)
+                self._raise_if_all_generations_empty(response_messages)
                 responses.append(response_messages[0] if response_messages else None)
+            except BadGeneratorException:
+                raise
             except Exception as e:
+                self._raise_terminal_api_status_error(e)
                 logging.error(f"Error in sequential model call: {str(e)}")
                 responses.append(None)
         return responses
@@ -222,5 +304,23 @@ class OpenRouterGenerator(OpenAICompatible):
             Message(text=choice.message.content) if choice.message.content else None
             for choice in raw_response.choices
         ]
+
+    def _raise_if_all_generations_empty(self, response_messages):
+        if response_messages and all(message is None for message in response_messages):
+            raise BadGeneratorException(
+                "OpenRouter returned only empty generations; the provider route may be unavailable."
+            )
+
+    def _raise_terminal_api_status_error(self, exc):
+        import openai
+
+        if isinstance(exc, (openai.RateLimitError, openai.InternalServerError)):
+            raise exc
+
+        if isinstance(exc, openai.APIStatusError):
+            raise BadGeneratorException(
+                _terminal_api_status_message(exc, self.generator_family_name, self.name)
+            ) from exc
+
 
 DEFAULT_CLASS = "OpenRouterGenerator"

--- a/script/tests/test_garak_0141_compat.py
+++ b/script/tests/test_garak_0141_compat.py
@@ -105,6 +105,88 @@ class TestLocalPluginSources(unittest.TestCase):
         self.assertIn("def _load_unsafe", source)
         self.assertIn("OPENROUTER_BASE_URL", source)
         self.assertIn("def _call_model_sequential", source)
+        self.assertIn("terminal API status error", source)
+
+
+@unittest.skipUnless(_garak_available(), "garak is not importable")
+class TestOpenRouterTerminalErrors(unittest.TestCase):
+    def _generator_with_create(self, create):
+        module = _load_local_plugin("local_openrouter_terminal", "openrouter.py")
+        generator = object.__new__(module.OpenRouterGenerator)
+        generator.name = "openai/gpt-4o"
+        generator.client = object()
+        generator.generator = type("FakeCompletions", (), {"create": staticmethod(create)})()
+        generator.suppressed_params = set()
+        generator.max_tokens = 10
+        generator.generator_family_name = "OpenRouter"
+        return module, generator
+
+    def _response(self, status_code):
+        import httpx
+
+        request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+        return httpx.Response(status_code, request=request, json={"error": {"message": "provider rejected"}})
+
+    def test_openrouter_converts_terminal_api_status_to_bad_generator(self):
+        import openai
+        from garak.exception import BadGeneratorException
+
+        body = {
+            "error": "invalid request",
+            "api_key": "sk-or-v1-secretvalue",
+            "debug": '{"api_key":"plainsecret"}',
+            "nested": {"authorization": "Bearer topsecret"}
+        }
+
+        def create(**_kwargs):
+            raise openai.BadRequestError("request rejected", response=self._response(422), body=body)
+
+        _module, generator = self._generator_with_create(create)
+
+        with self.assertRaises(BadGeneratorException) as ctx:
+            generator._call_model("prompt", generations_this_call=1)
+
+        message = str(ctx.exception)
+        self.assertIn("OpenRouter terminal API status error", message)
+        self.assertIn("status_code=422", message)
+        self.assertIn("model='openai/gpt-4o'", message)
+        self.assertNotIn("sk-or-v1-secretvalue", message)
+        self.assertNotIn("plainsecret", message)
+        self.assertNotIn("topsecret", message)
+        self.assertIn("[REDACTED]", message)
+
+    def test_openrouter_retryable_rate_limit_propagates(self):
+        import openai
+
+        def create(**_kwargs):
+            raise openai.RateLimitError("rate limited", response=self._response(429), body={})
+
+        _module, generator = self._generator_with_create(create)
+
+        with self.assertRaises(openai.RateLimitError):
+            generator._call_model("prompt", generations_this_call=1)
+
+    def test_openrouter_all_empty_generations_raise_bad_generator(self):
+        from garak.exception import BadGeneratorException
+
+        class MessageObj:
+            content = None
+
+        class Choice:
+            message = MessageObj()
+
+        class Response:
+            choices = [Choice()]
+
+        def create(**_kwargs):
+            return Response()
+
+        _module, generator = self._generator_with_create(create)
+
+        with self.assertRaises(BadGeneratorException) as ctx:
+            generator._call_model("prompt", generations_this_call=1)
+
+        self.assertIn("empty generations", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -518,7 +518,7 @@ RSpec.describe Report, type: :model do
     end
 
     it 'includes all expected attributes' do
-      expected_attributes = [ "company_id", "name", "created_at", "id", "status", "target_id", "updated_at", "uuid", "asr" ]
+      expected_attributes = [ "company_id", "failure_code", "name", "created_at", "id", "status", "target_id", "updated_at", "uuid", "asr" ]
       expect(Report.ransackable_attributes).to match_array(expected_attributes)
     end
   end
@@ -956,6 +956,37 @@ RSpec.describe Report, type: :model do
 
         expect(labels).to include(trace_id: 'none')
       end
+    end
+  end
+
+  describe "failure metadata helpers" do
+    let(:report) { build(:report, status: :failed, failure_code: failure_code, failure_message: failure_message) }
+    let(:failure_code) { nil }
+    let(:failure_message) { nil }
+
+    it "detects failed reports with structured failure metadata" do
+      report.failure_code = "provider_auth_failed"
+
+      expect(report).to be_failed_with_reason
+    end
+
+    it "uses explicit failure messages when present" do
+      report.failure_message = "Custom safe failure message"
+
+      expect(report.user_failure_message).to eq("Custom safe failure message")
+    end
+
+    it "maps provider outage codes to actionable user copy" do
+      report.failure_code = "provider_service_unavailable"
+
+      expect(report.failure_title).to eq("Provider temporarily unavailable")
+      expect(report.user_failure_message).to include("temporarily unavailable")
+      expect(report.failure_action).to include("Wait for the provider")
+    end
+
+    it "falls back to generic failed copy" do
+      expect(report.failure_title).to eq("Scan failed")
+      expect(report.user_failure_message).to eq("The scan failed before results could be completed.")
     end
   end
 

--- a/spec/services/reports/failure_classifier_spec.rb
+++ b/spec/services/reports/failure_classifier_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe Reports::FailureClassifier do
+  subject(:result) { described_class.new(report, logs: logs, exit_code: exit_code, exception_message: exception_message).call }
+
+  let(:target) { create(:target, model_type: 'OpenRouterGenerator', model: 'openai/gpt-4o') }
+  let(:scan) { create(:complete_scan) }
+  let(:report) { create(:report, target: target, scan: scan) }
+  let(:logs) { nil }
+  let(:exit_code) { nil }
+  let(:exception_message) { nil }
+
+  it 'returns an empty result when there is no evidence' do
+    expect(result).not_to be_failed
+    expect(result.details).to eq({})
+  end
+
+  it 'classifies explicit OpenRouter model unavailable errors' do
+    logs = 'OpenRouter terminal API status error: status_code=404 message="No endpoints found for openai/gpt-4o"'
+    result = described_class.new(report, logs: logs).call
+
+    expect(result.code).to eq('provider_model_unavailable')
+    expect(result.message).to include('OpenRouter')
+    expect(result.details).to include(
+      'provider' => 'OpenRouter',
+      'model' => 'openai/gpt-4o',
+      'status_code' => 404
+    )
+  end
+
+  it 'classifies explicit OpenRouter billing errors' do
+    logs = 'OpenRouter terminal API status error: status_code=402 message="credits exhausted"'
+
+    expect(described_class.new(report, logs: logs).call.code).to eq('provider_payment_required')
+  end
+
+  it 'classifies explicit provider 5xx errors as temporary provider outages' do
+    logs = 'OpenRouter terminal API status error: status_code=503 message="upstream unavailable"'
+
+    expect(described_class.new(report, logs: logs).call.code).to eq('provider_service_unavailable')
+  end
+
+  it 'does not classify bare status-like text from normal model output' do
+    logs = 'Model output: HTTP/1.1 401 Unauthorized. status=401. Request rejected examples.'
+
+    expect(described_class.new(report, logs: logs).call).not_to be_failed
+  end
+
+  it 'redacts credentials from messages and details' do
+    logs = 'OpenRouter terminal API status error: status_code=401 message="invalid api key sk-or-v1-secretvalue" body={"authorization":"Bearer abc123","api_key":"plainsecret"}'
+
+    result = described_class.new(report, logs: logs).call
+
+    expect(result.code).to eq('provider_auth_failed')
+    expect(result.message).not_to include('sk-or-v1-secretvalue')
+    expect(result.details.to_s).not_to include('abc123')
+    expect(result.details.to_s).not_to include('plainsecret')
+  end
+
+  it 'classifies target validation failures' do
+    logs = 'Target validation failed: no responses received from target'
+
+    expect(described_class.new(report, logs: logs).call.code).to eq('target_validation_failed')
+  end
+
+  it 'classifies garak runtime failures' do
+    logs = 'Traceback (most recent call last): RuntimeError: garak failed'
+
+    expect(described_class.new(report, logs: logs).call.code).to eq('garak_runtime_error')
+  end
+end

--- a/spec/services/reports/process_spec.rb
+++ b/spec/services/reports/process_spec.rb
@@ -185,6 +185,99 @@ RSpec.describe Reports::Process, type: :service do
       end
     end
 
+    context 'when current-run logs contain terminal provider failure evidence' do
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let!(:raw_data) do
+        create(
+          :raw_report_data,
+          report: report,
+          jsonl_data: jsonl_content,
+          logs_data: 'OpenRouter terminal API status error: status_code=404 message="No endpoints found for openai/gpt-4o"'
+        )
+      end
+
+      before do
+        target.update!(model_type: 'OpenRouterGenerator', model: 'openai/gpt-4o')
+      end
+
+      it 'marks completed-looking report data as failed with structured provider metadata' do
+        service.call
+
+        report.reload
+        expect(report.status).to eq('failed')
+        expect(report.failure_code).to eq('provider_model_unavailable')
+        expect(report.failure_message).to include('OpenRouter')
+        expect(report.failure_details).to include(
+          'provider' => 'OpenRouter',
+          'model' => 'openai/gpt-4o',
+          'status_code' => 404
+        )
+      end
+    end
+
+    context 'when a retry has no current failure logs' do
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: jsonl_content, logs_data: nil) }
+
+      before do
+        target.update!(model_type: 'OpenRouterGenerator', model: 'openai/gpt-4o')
+        report.update!(
+          retry_count: 1,
+          status: :running,
+          failure_code: 'provider_service_unavailable',
+          failure_message: 'Old provider outage',
+          failure_details: { 'status_code' => 503 }
+        )
+        create(
+          :report_debug_log,
+          report: report,
+          logs: "Previous log\n[2026-04-27 12:00:00] Auto-retry 1: Requeued after interruption",
+          tail: 'OpenRouter terminal API status error: status_code=503 message="stale outage"'
+        )
+      end
+
+      it 'does not reclassify stale debug tail evidence and clears stale metadata' do
+        service.call
+
+        report.reload
+        expect(report.status).to eq('completed')
+        expect(report.failure_code).to be_nil
+        expect(report.failure_message).to be_nil
+        expect(report.failure_details).to eq({})
+      end
+    end
+
+    context 'when current logs explain an early failed report' do
+      let(:jsonl_without_evals) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test prompt', outputs: [ 'Test output' ] }.to_json
+        ].join("\n")
+      end
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let!(:raw_data) do
+        create(
+          :raw_report_data,
+          report: report,
+          jsonl_data: jsonl_without_evals,
+          logs_data: 'OpenRouter terminal API status error: status_code=402 message="credits exhausted"'
+        )
+      end
+
+      before do
+        target.update!(model_type: 'OpenRouterGenerator', model: 'openai/gpt-4o')
+      end
+
+      it 'persists provider failure metadata even when eval rows are absent' do
+        service.call
+
+        report.reload
+        expect(report.status).to eq('failed')
+        expect(report.failure_code).to eq('provider_payment_required')
+        expect(report.failure_details['status_code']).to eq(402)
+      end
+    end
+
     context 'when raw_report_data has only whitespace in jsonl_data' do
       # Note: Model validation prevents blank jsonl_data, so we test with
       # valid-looking but non-processable content

--- a/spec/services/run_garak_scan_spec.rb
+++ b/spec/services/run_garak_scan_spec.rb
@@ -52,7 +52,10 @@ RSpec.describe RunGarakScan, type: :service do
       expect(Rails.logger).to receive(:error).with("Cannot run scan for report #{bad_report.id} - target #{bad_target.id} (#{bad_target.name}) has 'bad' status. Validation text: #{bad_target.validation_text}")
       expect(bad_report).to receive(:update).with(
         status: :failed,
-        logs: "Scan failed: Target '#{bad_target.name}' validation failed. #{bad_target.validation_text}"
+        logs: "Scan failed: Target '#{bad_target.name}' validation failed. #{bad_target.validation_text}",
+        failure_code: "target_validation_failed",
+        failure_message: "Target '#{bad_target.name}' validation failed. #{bad_target.validation_text}",
+        failure_details: {}
       )
 
       service.call
@@ -72,7 +75,10 @@ RSpec.describe RunGarakScan, type: :service do
       expect(Rails.logger).to receive(:error).with("Cannot run scan for report #{bad_report.id} - target #{bad_target.id} (#{bad_target.name}) has 'bad' status. Validation text: ")
       expect(bad_report).to receive(:update).with(
         status: :failed,
-        logs: "Scan failed: Target '#{bad_target.name}' validation failed."
+        logs: "Scan failed: Target '#{bad_target.name}' validation failed.",
+        failure_code: "target_validation_failed",
+        failure_message: "Target '#{bad_target.name}' validation failed.",
+        failure_details: {}
       )
 
       service.call
@@ -158,7 +164,10 @@ RSpec.describe RunGarakScan, type: :service do
       expect(Rails.logger).to receive(:warn).with("Cannot run scan for report #{validating_report.id} - target #{validating_target.id} (#{validating_target.name}) is in 'validating' status")
       expect(validating_report).to receive(:update).with(
         status: :failed,
-        logs: "Scan failed: Target '#{validating_target.name}' is still being validated. Please wait for validation to complete before running scans."
+        logs: "Scan failed: Target '#{validating_target.name}' is still being validated. Please wait for validation to complete before running scans.",
+        failure_code: "target_validation_failed",
+        failure_message: "Target '#{validating_target.name}' is still being validated. Please wait for validation to complete before running scans.",
+        failure_details: {}
       )
 
       service.call
@@ -180,7 +189,10 @@ RSpec.describe RunGarakScan, type: :service do
       expect(Rails.logger).to receive(:error).with("Cannot run scan for report #{unexpected_report.id} - target #{unexpected_target.id} (#{unexpected_target.name}) has unexpected status: unknown_status")
       expect(unexpected_report).to receive(:update).with(
         status: :failed,
-        logs: "Scan failed: Target '#{unexpected_target.name}' is not ready for scanning (status: unknown_status). Target must be validated successfully before running scans."
+        logs: "Scan failed: Target '#{unexpected_target.name}' is not ready for scanning (status: unknown_status). Target must be validated successfully before running scans.",
+        failure_code: "target_validation_failed",
+        failure_message: "Target '#{unexpected_target.name}' is not ready for scanning (status: unknown_status). Target must be validated successfully before running scans.",
+        failure_details: {}
       )
 
       service.call


### PR DESCRIPTION
## Summary
- fail scans with structured, user-facing metadata when provider terminal errors appear in current run logs
- show a friendly failure summary on report pages and clear stale failure metadata on successful retries
- make the OpenRouter plugin surface redacted terminal API status errors instead of silently returning empty generations
