### PR TITLE
fix(reports): require completion timing before success

### DIFF
--- a/app/services/reports/process.rb
+++ b/app/services/reports/process.rb
@@ -73,6 +73,10 @@ module Reports
         report.failure_code = failure.code
         report.failure_message = failure.message
         report.failure_details = failure.details
+      elsif report.failed?
+        report.failure_code = "scan_incomplete_results"
+        report.failure_message = "The scan exited before producing a complete set of results."
+        report.failure_details = {}
       else
         clear_failure_metadata
       end
@@ -104,6 +108,7 @@ module Reports
       valid_lines = 0
       attempts_processed = false
       evals_processed = false
+      completion_processed = false
 
       jsonl_string.each_line do |line|
         line_number += 1
@@ -127,7 +132,7 @@ module Reports
           when "eval"
             evals_processed = true if process_eval(data)
           when "completion"
-            process_completion(data)
+            completion_processed = true if process_completion(data) == :processed
           else
             next
           end
@@ -146,22 +151,63 @@ module Reports
         end
       end
 
-      # Mark as completed only if we processed attempts AND evals AND created probe results.
-      # Having attempts but no evals indicates a malformed report (garak exited early).
-      # Having evals but no probe_results means all probes were unknown/skipped — treat as failed
-      # so operators see the drift between the runtime probe catalog and the database.
+      # Mark as completed only if the report has all result and timing rows.
+      # Having attempts/evals without completion means garak exited early after
+      # producing partial data; keep those probe results for diagnosis, but do
+      # not present the report as completed with an unknown duration.
       if !attempts_processed
         Rails.logger.warn "Report #{report.id}: No attempts found in report, marking as failed"
         report.status = :failed
       elsif !evals_processed
         Rails.logger.warn "Report #{report.id}: Attempts found but no eval results - scan may have been interrupted, marking as failed"
         report.status = :failed
-      elsif processed && valid_lines > 0 && @probe_results_saved_this_run
+      elsif !completion_processed
+        Rails.logger.warn "Report #{report.id}: Attempts and eval results found but no completion row - scan exited before completion, marking as failed"
+        report.status = :failed
+      elsif report.start_time.blank? || report.end_time.blank?
+        Rails.logger.warn "Report #{report.id}: Completion found but scan timing is incomplete, marking as failed"
+        report.status = :failed
+      elsif processed && valid_lines > 0
         report.status = :completed
       else
         Rails.logger.warn "Report #{report.id}: No probe results created despite processing lines, marking as failed"
         report.status = :failed
       end
+
+      finalize_failed_report_timing
+    end
+
+    def finalize_failed_report_timing
+      return unless report.failed?
+      return if report.end_time.present?
+      return if report.start_time.blank?
+
+      candidate = terminal_log_end_time
+      candidate = raw_data_updated_at if candidate.blank? || candidate < report.start_time
+      candidate = Time.current if candidate.blank? || candidate < report.start_time
+      return if candidate < report.start_time
+
+      report.end_time = candidate
+    end
+
+    def terminal_log_end_time
+      current_run_failure_logs.to_s.each_line.reverse_each do |line|
+        next unless line.include?("Garak scan completed")
+
+        timestamp = line.match(/\A(?<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})(?:,\d+)?/)&.[](:timestamp)
+        next if timestamp.blank?
+
+        parsed = Time.zone.parse(timestamp)
+        return parsed if parsed
+      rescue ArgumentError
+        next
+      end
+
+      nil
+    end
+
+    def raw_data_updated_at
+      @raw_data&.updated_at
     end
 
     def save_detector_results
@@ -375,11 +421,17 @@ module Reports
       rescue ArgumentError, TypeError => e
         Rails.logger.warn("Report #{report.id}: invalid end_time '#{data['end_time']}': #{e.message}")
         report.end_time = nil
+        report.save! if report.end_time_changed?
+        return :rejected_invalid
       end
+
       report.save! if report.end_time_changed?
+      :processed
     end
 
     def send_to_output_server
+      return unless report.completed?
+
       OutputServers::Dispatcher.new(report).call
     end
   end

--- a/spec/services/reports/process_spec.rb
+++ b/spec/services/reports/process_spec.rb
@@ -201,6 +201,8 @@ RSpec.describe Reports::Process, type: :service do
       end
 
       it 'marks completed-looking report data as failed with structured provider metadata' do
+        expect_any_instance_of(OutputServers::Dispatcher).not_to receive(:call)
+
         service.call
 
         report.reload
@@ -275,6 +277,93 @@ RSpec.describe Reports::Process, type: :service do
         expect(report.status).to eq('failed')
         expect(report.failure_code).to eq('provider_payment_required')
         expect(report.failure_details['status_code']).to eq(402)
+      end
+    end
+
+    context 'when result rows are present but completion is missing' do
+      let(:jsonl_without_completion) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test prompt', outputs: [ 'Test output' ], notes: { score_percentage: 70 } }.to_json,
+          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din.TestProbe', passed: 3, total_evaluated: 10 }.to_json
+        ].join("\n")
+      end
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let!(:raw_data) do
+        create(
+          :raw_report_data,
+          report: report,
+          jsonl_data: jsonl_without_completion,
+          logs_data: "2023-06-01 10:30:00,123 Garak scan completed\n"
+        )
+      end
+
+      it 'marks the report failed without losing partial probe results' do
+        expect_any_instance_of(OutputServers::Dispatcher).not_to receive(:call)
+
+        expect { service.call }.to change { ProbeResult.count }.by(1)
+
+        report.reload
+        expect(report.status).to eq('failed')
+        expect(report.failure_code).to eq('scan_incomplete_results')
+        expect(report.failure_message).to eq('The scan exited before producing a complete set of results.')
+        expect(report.start_time).to eq(Time.zone.parse('2023-06-01T10:00:00Z'))
+        expect(report.end_time).to eq(Time.zone.parse('2023-06-01 10:30:00'))
+      end
+    end
+
+    context 'when provider failure logs are present but completion is missing' do
+      let(:jsonl_without_completion) do
+        [
+          { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json,
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test prompt', outputs: [ 'Test output' ], notes: { score_percentage: 70 } }.to_json,
+          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din.TestProbe', passed: 3, total_evaluated: 10 }.to_json
+        ].join("\n")
+      end
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let!(:raw_data) do
+        create(
+          :raw_report_data,
+          report: report,
+          jsonl_data: jsonl_without_completion,
+          logs_data: "OpenRouter terminal API status error: status_code=402 message=\"credits exhausted\"\n2023-06-01 10:30:00,123 Garak scan completed\n"
+        )
+      end
+
+      before do
+        target.update!(model_type: 'OpenRouterGenerator', model: 'openai/gpt-4o')
+      end
+
+      it 'preserves provider failure metadata and failed timing' do
+        service.call
+
+        report.reload
+        expect(report.status).to eq('failed')
+        expect(report.failure_code).to eq('provider_payment_required')
+        expect(report.failure_details['status_code']).to eq(402)
+        expect(report.end_time).to eq(Time.zone.parse('2023-06-01 10:30:00'))
+      end
+    end
+
+    context 'when completion is valid but start timing is missing' do
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let(:jsonl_without_start_time) do
+        [
+          { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'attempt-1', prompt: 'Test prompt', outputs: [ 'Test output' ], notes: { score_percentage: 70 } }.to_json,
+          { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din.TestProbe', passed: 3, total_evaluated: 10 }.to_json,
+          { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json
+        ].join("\n")
+      end
+      let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: jsonl_without_start_time, logs_data: nil) }
+
+      it 'marks the report failed instead of completed with incomplete timing' do
+        service.call
+
+        report.reload
+        expect(report.status).to eq('failed')
+        expect(report.failure_code).to eq('scan_incomplete_results')
+        expect(report.start_time).to be_nil
+        expect(report.end_time).to be_present
       end
     end
 
@@ -402,11 +491,13 @@ RSpec.describe Reports::Process, type: :service do
       end
       let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: bad_end_time_jsonl, logs_data: nil) }
 
-      it 'logs a warning and leaves end_time nil' do
+      it 'logs a warning and marks the report failed with fallback timing' do
         allow(Rails.logger).to receive(:warn).and_call_original
         service.call
         report.reload
-        expect(report.end_time).to be_nil
+        expect(report.status).to eq('failed')
+        expect(report.failure_code).to eq('scan_incomplete_results')
+        expect(report.end_time).to be_present
         expect(Rails.logger).to have_received(:warn).with(/invalid end_time/i)
       end
     end


### PR DESCRIPTION
## Summary
- Require garak completion and timing rows before a report can be marked completed.
- Mark partial result sets as failed while preserving probe results and provider failure metadata.
- Skip output-server dispatch for failed reports.
