### PR TITLE
fix(reports): render PDFs for archived targets

### DIFF
--- a/app/decorators/report_decorator.rb
+++ b/app/decorators/report_decorator.rb
@@ -1,6 +1,6 @@
 class ReportDecorator < SimpleDelegator
   def target_name
-    target.name
+    __getobj__.historical_target_name
   end
 
   def probe_results

--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -118,7 +118,7 @@ class GeneratePdfJob < ApplicationJob
     labels = {
       report_id: report.id,
       report_uuid: report.uuid,
-      target_name: report.target.name,
+      target_name: report.historical_target_name,
       scan_name: report.scan.name,
       pdf_generation_duration_ms: duration_ms,
       pdf_generation_success: success ? 1 : 0,

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -70,6 +70,7 @@ class Report < ApplicationRecord
   DEBUG_BROADCAST_ACTIVE_STATUSES = (BROADCAST_ACTIVE_STATUSES + %w[processing]).freeze
   DEBUG_STREAM_LIVE_TAIL_STATUSES = %w[running processing].freeze
   DEBUG_STREAM_POLLING_STATUSES = (DEBUG_BROADCAST_ACTIVE_STATUSES + %w[pending]).freeze
+  UNKNOWN_TARGET_NAME = "Unknown target".freeze
 
   def self.ransackable_attributes(auth_object = nil)
     [ "company_id", "failure_code", "name", "created_at", "id", "status", "target_id", "updated_at", "uuid", "asr" ]
@@ -77,6 +78,14 @@ class Report < ApplicationRecord
 
   def self.ransackable_associations(auth_object = nil)
     [ "company", "target", "scan" ]
+  end
+
+  def historical_target
+    historical_target_with_deleted
+  end
+
+  def historical_target_name
+    historical_target&.name || UNKNOWN_TARGET_NAME
   end
 
   def failed_with_reason?
@@ -249,6 +258,14 @@ class Report < ApplicationRecord
       end
     else
       build_report_debug_log
+    end
+  end
+
+  def historical_target_with_deleted
+    return if target_id.blank? || company_id.blank? || company.blank?
+
+    ActsAsTenant.with_tenant(company) do
+      Target.with_deleted.where(company_id: company_id).find_by(id: target_id)
     end
   end
 

--- a/spec/decorators/report_decorator_spec.rb
+++ b/spec/decorators/report_decorator_spec.rb
@@ -1,14 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe ReportDecorator, type: :decorator do
-  let(:target) { create(:target, name: 'Test Target') }
-  let(:scan) { create(:complete_scan) }
-  let(:report) { create(:report, target: target, scan: scan) }
+  let(:company) { create(:company) }
+  let(:target) { create(:target, name: 'Test Target', company: company) }
+  let(:scan) { create(:complete_scan, company: company) }
+  let(:report) { create(:report, company: company, target: target, scan: scan) }
   let(:decorated_report) { described_class.new(report) }
 
   describe '#target_name' do
     it 'returns the name of the target' do
       expect(decorated_report.target_name).to eq('Test Target')
+    end
+
+    it 'returns the historical target name when the target has been soft-deleted' do
+      target.mark_deleted!
+      report.reload
+
+      expect(report.target).to be_nil
+      expect(described_class.new(report).target_name).to eq('Test Target')
     end
   end
 
@@ -24,7 +33,7 @@ RSpec.describe ReportDecorator, type: :decorator do
 
     it 'includes probe and detector associations' do
       # Create a new instance for this test to avoid memoization issues
-      new_report = create(:report, target: target, scan: scan)
+      new_report = create(:report, company: company, target: target, scan: scan)
       new_probe = create(:probe, name: 'TestProbe')
       new_detector = create(:detector, name: 'TestDetector')
       create(:probe_result, report: new_report, probe: new_probe, detector: new_detector)

--- a/spec/jobs/generate_pdf_job_spec.rb
+++ b/spec/jobs/generate_pdf_job_spec.rb
@@ -76,6 +76,23 @@ RSpec.describe GeneratePdfJob, type: :job do
         )
       end
 
+      it "collects metrics with the historical target name when the target is soft-deleted" do
+        target_name = report.target.name
+        ActsAsTenant.with_tenant(company) { report.target.mark_deleted! }
+        allow(MonitoringService).to receive(:active?).and_return(true)
+        allow(MonitoringService).to receive(:set_labels)
+
+        described_class.new.perform(report.id, user.id)
+
+        expect(MonitoringService).to have_received(:set_labels).with(
+          hash_including(
+            report_id: report.id,
+            target_name: target_name,
+            pdf_generation_success: 1
+          )
+        )
+      end
+
       it "includes a signed download_url that PdfDownloadToken can verify" do
         captured = nil
         allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to) do |_stream, **opts|

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -65,6 +65,43 @@ RSpec.describe Report, type: :model do
     end
   end
 
+  describe '#historical_target' do
+    let(:company) { create(:company) }
+    let(:target) { create(:target, name: 'Archived Target', company: company) }
+    let(:scan) do
+      build(:scan, company: company).tap do |record|
+        record.targets << target
+        record.save!(validate: false)
+      end
+    end
+    let(:report) { create(:report, company: company, target: target, scan: scan) }
+
+    it 'resolves a soft-deleted target without exposing other deleted targets globally' do
+      ActsAsTenant.with_tenant(company) do
+        target.mark_deleted!
+        report.reload
+
+        expect(report.target).to be_nil
+        expect(report.historical_target).to eq(target)
+        expect(report.historical_target_name).to eq('Archived Target')
+      end
+    end
+
+    it 'does not resolve a target from another tenant' do
+      other_company = create(:company)
+      other_target = create(:target, name: 'Other Tenant Target', company: other_company)
+      ActsAsTenant.with_tenant(other_company) { other_target.mark_deleted! }
+      report.update_column(:target_id, other_target.id)
+
+      ActsAsTenant.with_tenant(company) do
+        report.reload
+
+        expect(report.historical_target).to be_nil
+        expect(report.historical_target_name).to eq(Report::UNKNOWN_TARGET_NAME)
+      end
+    end
+  end
+
   describe 'callbacks' do
     let(:target) { create(:target) }
     let(:scan) { create(:complete_scan) }

--- a/spec/requests/report_details_spec.rb
+++ b/spec/requests/report_details_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe "ReportDetails", type: :request do
 
         expect(response).to have_http_status(:ok)
       end
+
+      it "renders historical reports whose targets have been soft-deleted" do
+        target_name = report.target.name
+        ActsAsTenant.with_tenant(company) { report.target.mark_deleted! }
+
+        get report_detail_path(report, pdf: "true", pdf_token: pdf_token)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Report for #{target_name}")
+      end
     end
 
     context "with pdf=true but an invalid pdf_token" do


### PR DESCRIPTION
## Summary
- resolve soft-deleted targets when rendering historical report PDFs
- use a stable fallback target name if the original target is unavailable
- cover report details rendering, PDF metrics, and tenant isolation
