### PR TITLE
fix(probes): render successful target links cleanly

### DIFF
--- a/app/views/admin/probes/show.html.erb
+++ b/app/views/admin/probes/show.html.erb
@@ -148,12 +148,19 @@
           <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Successful Targets (Last 90 Days)</th>
           <td class="py-3 text-sm text-contentPrimary">
             <% if @successful_targets_info.any? %>
-              <% target_links = @successful_targets_info.map do |info| %>
-                <% target = info[:target] %>
-                <% successful_report = info[:successful_report] %>
-                <%= link_to(target.name, target_path(target), class: "text-primary hover:underline") %>
-                (<%= link_to("view report", report_path(successful_report), class: "text-primary hover:underline") %>)
-              <% end %>
+              <%
+                target_links = @successful_targets_info.map do |info|
+                  target = info[:target]
+                  successful_report = info[:successful_report]
+
+                  safe_join([
+                    link_to(target.name, target_path(target), class: "text-primary hover:underline"),
+                    " (",
+                    link_to("view report", report_path(successful_report), class: "text-primary hover:underline"),
+                    ")"
+                  ])
+                end
+              %>
               <%= safe_join(target_links, ", ") %>
             <% else %>
               <span class="text-contentTertiary">—</span>

--- a/spec/controllers/admin/probes_controller_spec.rb
+++ b/spec/controllers/admin/probes_controller_spec.rb
@@ -102,6 +102,34 @@ RSpec.describe Admin::ProbesController, type: :controller do
       expect(response).to have_http_status(:success)
     end
 
+    it "renders successful target links without leaking ERB block return values" do
+      target_alpha = create(:target, :good, company: tier_4_company, name: "Target Alpha")
+      target_beta = create(:target, :good, company: tier_4_company, name: "Target Beta")
+
+      alpha_report = create(:report, :completed, company: tier_4_company, target: target_alpha)
+      beta_report = create(:report, :completed, company: tier_4_company, target: target_beta)
+      allow_any_instance_of(Probe).to receive(:successful_targets_last_90_days).and_return([
+        { target: target_alpha, successful_report: alpha_report },
+        { target: target_beta, successful_report: beta_report }
+      ])
+
+      get :show, params: { id: probe.id }
+
+      expect(response).to have_http_status(:success)
+      doc = Nokogiri::HTML(response.body)
+      row = doc.at_xpath("//th[normalize-space()='Successful Targets (Last 90 Days)']/parent::tr")
+      cell = row.at_css("td")
+
+      expect(cell.css("a").map { |link| link.text.squish }).to eq([
+        "Target Alpha",
+        "view report",
+        "Target Beta",
+        "view report"
+      ])
+      expect(cell.text.squish).to eq("Target Alpha (view report), Target Beta (view report)")
+      expect(cell.text).not_to include(") , )")
+    end
+
     it "renders valid attribution URLs as external links with noopener" do
       probe.update!(attribution: "0DIN by Mozilla - https://0din.ai")
 


### PR DESCRIPTION
## Summary
- Fix probe details successful target links so the page does not render stray punctuation from ERB block return values.
- Add controller coverage for multiple successful target/report links.
