### PR TITLE
fix(reports): ignore transient provider statuses after successful scans

### DIFF
--- a/app/services/reports/failure_classifier.rb
+++ b/app/services/reports/failure_classifier.rb
@@ -17,7 +17,6 @@ module Reports
 
     STATUS_CODE_PATTERN = /
       status_code\s*[=:]\s*(\d{3}) |
-      HTTP\/\d(?:\.\d)?\s+(\d{3}) |
       status\s*[=:]\s*(\d{3})
     /ix
     PROVIDER_FAILURE_STATUS_CODES = ([ 401, 402, 403, 404, 422, 429 ] + (500..599).to_a).freeze
@@ -190,7 +189,13 @@ module Reports
     end
 
     def http_provider_error?
+      return false if successful_garak_completion?
+
       evidence_text.match?(HTTP_PROVIDER_STATUS_PATTERN) && evidence_text.match?(HTTP_PROVIDER_HINT_PATTERN)
+    end
+
+    def successful_garak_completion?
+      evidence_text.match?(/Garak scan completed .*Exit code:\s*0/i)
     end
 
     def model_unavailable_text?
@@ -203,10 +208,17 @@ module Reports
     end
 
     def status_code
-      @status_code ||= begin
-        match = evidence_text.match(STATUS_CODE_PATTERN)
-        match&.captures&.compact&.first&.to_i
-      end
+      @status_code ||= explicit_status_code || http_provider_status_code
+    end
+
+    def explicit_status_code
+      match = evidence_text.match(STATUS_CODE_PATTERN)
+      match&.captures&.compact&.first&.to_i
+    end
+
+    def http_provider_status_code
+      match = evidence_text.match(HTTP_PROVIDER_STATUS_PATTERN)
+      match&.[](1)&.to_i
     end
 
     def provider

--- a/spec/services/reports/failure_classifier_spec.rb
+++ b/spec/services/reports/failure_classifier_spec.rb
@@ -46,6 +46,33 @@ RSpec.describe Reports::FailureClassifier do
     expect(described_class.new(report, logs: logs).call).not_to be_failed
   end
 
+  it 'does not classify transient provider HTTP errors after a successful garak run' do
+    logs = <<~LOG
+      2026-05-27 19:52:28,598 - root - INFO - probe init: <garak.probes.0din.AcademicCredentials object>
+      2026-05-27 19:52:28,766 - httpx - INFO - HTTP Request: POST https://openrouter.ai/api/v1/chat/completions "HTTP/1.1 200 OK"
+      2026-05-27 19:59:00,930 - httpx - INFO - HTTP Request: POST https://openrouter.ai/api/v1/chat/completions "HTTP/1.1 429 Too Many Requests"
+      2026-05-27 23:13:53,174 - __main__ - INFO - Garak scan completed - Report: example-report, Exit code: 0
+    LOG
+
+    result = described_class.new(report, logs: logs).call
+
+    expect(result.code).to be_nil
+    expect(result.message).to be_nil
+    expect(result.details).to eq({})
+  end
+
+  it 'uses provider error HTTP status evidence after earlier successful requests' do
+    logs = <<~LOG
+      HTTP Request: POST https://openrouter.ai/api/v1/chat/completions "HTTP/1.1 200 OK"
+      HTTP Request: POST https://openrouter.ai/api/v1/chat/completions "HTTP/1.1 429 Too Many Requests"
+    LOG
+
+    result = described_class.new(report, logs: logs).call
+
+    expect(result.code).to eq('provider_rate_limited')
+    expect(result.details['status_code']).to eq(429)
+  end
+
   it 'redacts credentials from messages and details' do
     logs = 'OpenRouter terminal API status error: status_code=401 message="invalid api key sk-or-v1-secretvalue" body={"authorization":"Bearer abc123","api_key":"plainsecret"}'
 


### PR DESCRIPTION
## Summary
- Avoid classifying transient provider HTTP status lines as terminal failures when garak finishes successfully.
- Prefer explicit provider status evidence over generic earlier HTTP response lines when recording failure metadata.
- Add regression coverage for successful scans with transient OpenRouter 429s and logs with earlier HTTP 200 responses.

## Validation
- `bundle exec rspec spec/services/reports/failure_classifier_spec.rb`
- `bundle exec rubocop app/services/reports/failure_classifier.rb spec/services/reports/failure_classifier_spec.rb`
