### PR TITLE
fix(scans): guard garak plugin cache access

### DIFF
--- a/script/garak_plugin_cache_guard.py
+++ b/script/garak_plugin_cache_guard.py
@@ -1,0 +1,121 @@
+import json
+import logging
+import os
+import stat
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Linux production path always has fcntl
+    fcntl = None
+
+
+DEFAULT_PLUGIN_CACHE_LOCK_PATH = Path.home() / ".cache" / "garak" / "ai-scanner-plugin-cache.lock"
+PLUGIN_CACHE_LOCK_PATH = Path(os.environ.get("GARAK_PLUGIN_CACHE_LOCK", DEFAULT_PLUGIN_CACHE_LOCK_PATH))
+_PLUGIN_CACHE_THREAD_LOCK = threading.RLock()
+_PLUGIN_CACHE_INSTALL_LOCK = threading.Lock()
+_PLUGIN_CACHE_LOCK_STATE = threading.local()
+
+
+def _open_lock_file(lock_path):
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    fd = os.open(lock_path, flags, 0o600)
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise OSError(f"garak plugin cache lock path is not a regular file: {lock_path}")
+        os.fchmod(fd, 0o600)
+        return os.fdopen(fd, "r+", encoding="utf-8")
+    except Exception:
+        os.close(fd)
+        raise
+
+
+@contextmanager
+def plugin_cache_lock(lock_path=PLUGIN_CACHE_LOCK_PATH):
+    """Serialize garak plugin-cache readers and writers across processes.
+
+    garak's PluginCache mutex only protects threads in a single Python process.
+    ai-scanner can run several garak processes concurrently in the same
+    container, all sharing garak's user plugin_cache.json. Holding this file
+    lock around cache load/build prevents readers from observing a partially
+    written JSON file. The default lock lives alongside garak's user cache; an
+    env override is opened without truncation and without following symlinks.
+    """
+    depth = getattr(_PLUGIN_CACHE_LOCK_STATE, "depth", 0)
+    if depth > 0:
+        _PLUGIN_CACHE_LOCK_STATE.depth = depth + 1
+        try:
+            yield
+        finally:
+            _PLUGIN_CACHE_LOCK_STATE.depth -= 1
+        return
+
+    with _PLUGIN_CACHE_THREAD_LOCK:
+        lock_path = Path(lock_path)
+        lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        with _open_lock_file(lock_path) as lock_file:
+            if fcntl is not None:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            _PLUGIN_CACHE_LOCK_STATE.depth = 1
+            try:
+                yield
+            finally:
+                _PLUGIN_CACHE_LOCK_STATE.depth = 0
+                if fcntl is not None:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def install_plugin_cache_guard():
+    """Patch garak PluginCache I/O to be process-safe and self-healing.
+
+    If a stale or unguarded process left plugin_cache.json truncated, garak
+    normally raises JSONDecodeError before a scan can start. Rebuild once under
+    the same lock, then retry the load so the scan can proceed with a healthy
+    cache.
+    """
+    import garak._plugins as garak_plugins
+
+    with _PLUGIN_CACHE_INSTALL_LOCK:
+        plugin_cache_class = garak_plugins.PluginCache
+        if getattr(plugin_cache_class, "_ai_scanner_cache_guard_installed", False):
+            return
+
+        original_load_plugin_cache = plugin_cache_class._load_plugin_cache
+        original_build_plugin_cache = plugin_cache_class._build_plugin_cache
+
+        def guarded_load_plugin_cache(self):
+            with plugin_cache_lock():
+                try:
+                    return original_load_plugin_cache(self)
+                except json.JSONDecodeError as error:
+                    cache_filename = getattr(self, "_user_plugin_cache_filename", None)
+                    cache_path = Path(cache_filename) if cache_filename else None
+                    logging.warning(
+                        "garak plugin cache is corrupt at %s (%s); rebuilding under lock",
+                        cache_path or "unknown path",
+                        error,
+                    )
+                    try:
+                        if cache_path is not None and cache_path.exists():
+                            cache_path.unlink()
+                    except OSError as unlink_error:
+                        logging.warning("could not remove corrupt garak plugin cache %s: %s", cache_path, unlink_error)
+
+                    original_build_plugin_cache(self)
+                    return original_load_plugin_cache(self)
+
+        def guarded_build_plugin_cache(self):
+            with plugin_cache_lock():
+                return original_build_plugin_cache(self)
+
+        plugin_cache_class._load_plugin_cache = guarded_load_plugin_cache
+        plugin_cache_class._build_plugin_cache = guarded_build_plugin_cache
+        plugin_cache_class._ai_scanner_cache_guard_installed = True

--- a/script/run_garak.py
+++ b/script/run_garak.py
@@ -34,6 +34,7 @@ import logging
 
 from pathlib import Path
 
+from garak_plugin_cache_guard import install_plugin_cache_guard
 from db_notifier import (
     notify_report_running as db_notify_running,
     notify_report_ready as db_notify_ready,
@@ -97,6 +98,7 @@ def run_garak_scan(garak_params):
         else:
             params_list = list(garak_params)
 
+        install_plugin_cache_guard()
         sys.argv = ['garak'] + params_list
 
         print(f"Running Garak with parameters: {params_list}")

--- a/script/tests/test_garak_plugin_cache_guard.py
+++ b/script/tests/test_garak_plugin_cache_guard.py
@@ -1,0 +1,123 @@
+import json
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+_script_dir = str(Path(__file__).resolve().parent.parent)
+if _script_dir not in sys.path:
+    sys.path.insert(0, _script_dir)
+
+import garak_plugin_cache_guard  # noqa: E402
+
+
+class TestGarakPluginCacheGuard(unittest.TestCase):
+    def setUp(self):
+        self.original_garak = sys.modules.get('garak')
+        self.original_garak_plugins = sys.modules.get('garak._plugins')
+        self.tempdir = TemporaryDirectory()
+        self.cache_path = Path(self.tempdir.name) / 'plugin_cache.json'
+        self.cache_path.write_text('{"probes": {', encoding='utf-8')
+        cache_path = self.cache_path
+
+        class FakePluginCache:
+            _plugin_cache_dict = None
+            build_calls = 0
+            load_calls = 0
+            build_during_load = False
+
+            def __init__(self):
+                self._user_plugin_cache_filename = str(cache_path)
+                type(self)._plugin_cache_dict = self._load_plugin_cache()
+
+            def _load_plugin_cache(self):
+                type(self).load_calls += 1
+                if type(self).build_during_load and type(self).load_calls == 1:
+                    self._build_plugin_cache()
+                    return {'probes': {'0din.Example': {}}, 'build_calls': type(self).build_calls}
+                if type(self).load_calls == 1:
+                    raise json.JSONDecodeError('Expecting delimiter', '{', 1)
+                return {'probes': {'0din.Example': {}}, 'build_calls': type(self).build_calls}
+
+            def _build_plugin_cache(self):
+                type(self).build_calls += 1
+                cache_path.write_text('{"probes": {"0din.Example": {}}}', encoding='utf-8')
+
+        self.fake_plugin_cache = FakePluginCache
+        garak = types.ModuleType('garak')
+        garak.__path__ = []
+        plugins = types.ModuleType('garak._plugins')
+        setattr(plugins, 'PluginCache', FakePluginCache)
+        setattr(garak, '_plugins', plugins)
+        sys.modules['garak'] = garak
+        sys.modules['garak._plugins'] = plugins
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+        if self.original_garak is None:
+            sys.modules.pop('garak', None)
+        else:
+            sys.modules['garak'] = self.original_garak
+
+        if self.original_garak_plugins is None:
+            sys.modules.pop('garak._plugins', None)
+        else:
+            sys.modules['garak._plugins'] = self.original_garak_plugins
+
+    def test_guard_rebuilds_corrupt_plugin_cache_and_retries_load(self):
+        garak_plugin_cache_guard.install_plugin_cache_guard()
+
+        cache = self.fake_plugin_cache()
+
+        self.assertEqual({'probes': {'0din.Example': {}}, 'build_calls': 1}, cache._plugin_cache_dict)
+        self.assertEqual(1, self.fake_plugin_cache.build_calls)
+        self.assertEqual(2, self.fake_plugin_cache.load_calls)
+        self.assertEqual('{"probes": {"0din.Example": {}}}', self.cache_path.read_text(encoding='utf-8'))
+
+    def test_guard_installation_is_idempotent(self):
+        garak_plugin_cache_guard.install_plugin_cache_guard()
+        first_load = self.fake_plugin_cache._load_plugin_cache
+        first_build = self.fake_plugin_cache._build_plugin_cache
+
+        garak_plugin_cache_guard.install_plugin_cache_guard()
+
+        self.assertIs(first_load, self.fake_plugin_cache._load_plugin_cache)
+        self.assertIs(first_build, self.fake_plugin_cache._build_plugin_cache)
+
+    def test_guard_allows_load_path_to_build_cache_while_lock_is_held(self):
+        self.fake_plugin_cache.build_during_load = True
+        garak_plugin_cache_guard.install_plugin_cache_guard()
+
+        cache = self.fake_plugin_cache()
+
+        self.assertEqual({'probes': {'0din.Example': {}}, 'build_calls': 1}, cache._plugin_cache_dict)
+        self.assertEqual(1, self.fake_plugin_cache.build_calls)
+        self.assertEqual(1, self.fake_plugin_cache.load_calls)
+
+    def test_lock_file_open_does_not_truncate_existing_file(self):
+        lock_path = Path(self.tempdir.name) / 'existing.lock'
+        lock_path.write_text('do-not-truncate', encoding='utf-8')
+
+        with garak_plugin_cache_guard.plugin_cache_lock(lock_path):
+            pass
+
+        self.assertEqual('do-not-truncate', lock_path.read_text(encoding='utf-8'))
+
+    @unittest.skipUnless(hasattr(os, 'O_NOFOLLOW'), 'platform does not support O_NOFOLLOW')
+    def test_lock_file_rejects_symlink_without_truncating_target(self):
+        target_path = Path(self.tempdir.name) / 'target.txt'
+        target_path.write_text('keep me', encoding='utf-8')
+        lock_path = Path(self.tempdir.name) / 'symlink.lock'
+        lock_path.symlink_to(target_path)
+
+        with self.assertRaises(OSError):
+            with garak_plugin_cache_guard.plugin_cache_lock(lock_path):
+                pass
+
+        self.assertEqual('keep me', target_path.read_text(encoding='utf-8'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/script/tests/test_run_garak_plugin_cache_guard.py
+++ b/script/tests/test_run_garak_plugin_cache_guard.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Regression tests for run_garak plugin-cache guard installation."""
+
+import os
+import signal
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_mock_db = ModuleType("db_notifier")
+_mock_db.notify_report_running = MagicMock(return_value=True)
+_mock_db.notify_report_ready = MagicMock(return_value=True)
+_mock_db.notify_report_ready_from_synced = MagicMock(return_value=True)
+_mock_db.notify_report_stopped = MagicMock(return_value=True)
+_mock_db.load_existing_jsonl_prefix = MagicMock(return_value="")
+_mock_db.get_log_file_path = MagicMock(return_value=Path("/tmp/fake_reports/report.log"))
+_mock_db.HeartbeatThread = MagicMock
+_mock_db.JournalSyncThread = MagicMock
+_mock_db.REPORTS_PATH = Path("/tmp/fake_reports")
+
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__), "..")
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
+_original_db_notifier = sys.modules.get("db_notifier")
+_original_run_garak = sys.modules.pop("run_garak", None)
+_orig_sigterm = signal.getsignal(signal.SIGTERM)
+_orig_sigint = signal.getsignal(signal.SIGINT)
+sys.modules["db_notifier"] = _mock_db
+
+try:
+    import run_garak as _run_garak  # noqa: E402
+finally:
+    if _original_db_notifier is None:
+        sys.modules.pop("db_notifier", None)
+    else:
+        sys.modules["db_notifier"] = _original_db_notifier
+
+    if _original_run_garak is None:
+        sys.modules.pop("run_garak", None)
+    else:
+        sys.modules["run_garak"] = _original_run_garak
+
+    signal.signal(signal.SIGTERM, _orig_sigterm)
+    signal.signal(signal.SIGINT, _orig_sigint)
+
+run_garak = _run_garak
+
+
+class TestRunGarakPluginCacheGuard(unittest.TestCase):
+    def setUp(self):
+        self.original_garak = sys.modules.get("garak")
+        self.original_garak_main = sys.modules.get("garak.__main__")
+
+        garak = ModuleType("garak")
+        garak.__path__ = []
+        garak_main = ModuleType("garak.__main__")
+        garak_main.main = MagicMock(return_value=0)
+        sys.modules["garak"] = garak
+        sys.modules["garak.__main__"] = garak_main
+
+    def tearDown(self):
+        if self.original_garak is None:
+            sys.modules.pop("garak", None)
+        else:
+            sys.modules["garak"] = self.original_garak
+
+        if self.original_garak_main is None:
+            sys.modules.pop("garak.__main__", None)
+        else:
+            sys.modules["garak.__main__"] = self.original_garak_main
+
+    def test_run_garak_scan_installs_plugin_cache_guard_before_main(self):
+        calls = []
+
+        def guard():
+            calls.append("guard")
+
+        def garak_main():
+            calls.append("main")
+            return 0
+
+        sys.modules["garak.__main__"].main = garak_main
+
+        with patch.object(run_garak, "install_plugin_cache_guard", side_effect=guard) as guard_mock:
+            exit_code = run_garak.run_garak_scan(["--list_probes"])
+
+        self.assertEqual(0, exit_code)
+        guard_mock.assert_called_once_with()
+        self.assertEqual(["guard", "main"], calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- Serialize garak PluginCache load/build operations across concurrent scan processes.
- Rebuild and retry once when garak encounters a corrupt plugin cache JSON file.
- Install the guard before garak scan startup and add regression coverage.
