### PR TITLE
fix(reports): stop marking completed scans as failed + improve crash diagnostics

### DIFF
--- a/app/services/reports/failure_classifier.rb
+++ b/app/services/reports/failure_classifier.rb
@@ -210,7 +210,7 @@ module Reports
     end
 
     def successful_garak_completion?
-      evidence_text.match?(/Garak scan completed .*Exit code:\s*0/i)
+      self.class.cleanly_completed?(evidence_text)
     end
 
     def model_unavailable_text?

--- a/app/services/reports/failure_classifier.rb
+++ b/app/services/reports/failure_classifier.rb
@@ -27,6 +27,17 @@ module Reports
       /error\s*[=:]\s*["']?([^"'
 }]+)/i
     ].freeze
+    # garak logs one "Garak scan completed ... Exit code: N" line per attempt, and the
+    # run log is appended across same-day retries (deterministic per-report path opened
+    # in append mode), so only the LAST line reflects the current run. Judge a clean
+    # completion from that last exit code, not any matching line in the accumulated log.
+    GARAK_COMPLETION_PATTERN = /Garak scan completed.*?Exit code:\s*(\d+)/i
+
+    def self.cleanly_completed?(logs)
+      last_exit = logs.to_s.scan(GARAK_COMPLETION_PATTERN).last
+      last_exit.present? && last_exit.first == "0"
+    end
+
     HTTP_PROVIDER_STATUS_PATTERN = /HTTP\/\d(?:\.\d)?\s+(401|402|403|404|422|429|5\d{2})/i
     HTTP_PROVIDER_HINT_PATTERN = /openrouter|provider|deprecated|no endpoints|credits?|rate limit/i
     AUTH_HINT_PATTERN = /unauthori[sz]ed|invalid api key|authentication|credentials/i
@@ -111,6 +122,10 @@ module Reports
     end
 
     def classify_runtime_failure
+      # A traceback/exception that surfaces after a clean garak completion (exit 0)
+      # is post-scan noise (e.g. garak's report-digest builder), not a runtime failure.
+      return EMPTY_RESULT if self.class.cleanly_completed?(evidence_text) && !exit_code.to_i.positive?
+
       return EMPTY_RESULT unless exit_code.to_i.positive? || exception_message.present? ||
         evidence_text.match?(/traceback|exception|runtimeerror|garak .*failed|non[- ]?zero/i)
 

--- a/app/services/reports/process.rb
+++ b/app/services/reports/process.rb
@@ -68,7 +68,7 @@ module Reports
 
     def apply_failure_metadata
       failure = FailureClassifier.new(report, logs: current_run_failure_logs).call
-      if failure.failed?
+      if failure.failed? && !completed_scan_with_clean_exit?
         report.status = :failed
         report.failure_code = failure.code
         report.failure_message = failure.message
@@ -80,6 +80,14 @@ module Reports
       else
         clear_failure_metadata
       end
+    end
+
+    # A report whose results are complete (process_jsonl_data set :completed) AND whose
+    # run log shows a clean garak completion must not be turned into a failure by trailing
+    # log noise (a post-scan report-digest error, or a transient provider status garak
+    # retried past). Genuine failures (incomplete results, or a non-clean exit) are unaffected.
+    def completed_scan_with_clean_exit?
+      report.completed? && Reports::FailureClassifier.cleanly_completed?(current_run_failure_logs)
     end
 
     def current_run_failure_logs

--- a/script/garak_plugins/probes/0din_variants.py
+++ b/script/garak_plugins/probes/0din_variants.py
@@ -64,6 +64,10 @@ class SingleShotVariant(Probe):
     lang = "en"
     primary_detector = "0din.MitigationBypass"
     goal = "To explore the affect of a validated jailbreak tactic against an industry specific subject matter."
+    description = (
+        "Industry-specific variant of a validated 0DIN probe for assessing "
+        "whether a jailbreak tactic generalizes to a selected business context."
+    )
     sis = 2
 
     def _generate_prompt(self) -> str:
@@ -91,6 +95,7 @@ class MultiShotVariant(Probe):
     lang = "en"
     primary_detector = "0din.MitigationBypass"
     goal = "To explore the affect of a validated jailbreak tactic against an industry specific subject matter."
+    description = SingleShotVariant.description
     sis = 2
 
     def _generate_prompts(self) -> list[str]:

--- a/script/run_garak.py
+++ b/script/run_garak.py
@@ -31,6 +31,7 @@ import sys
 import shlex
 import signal
 import logging
+import traceback
 
 from pathlib import Path
 
@@ -114,6 +115,7 @@ def run_garak_scan(garak_params):
         return 1
     except Exception as e:
         print(f"Error running Garak scan: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
         return 1
 
 def notify_report_running(report_uuid, pid):

--- a/script/tests/test_run_garak_traceback.py
+++ b/script/tests/test_run_garak_traceback.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Regression tests for run_garak crash diagnostics.
+
+When garak raises an unexpected exception, run_garak_scan must surface the full
+traceback to stderr (not just a one-line summary) so opaque crashes like
+"'NoneType' object is not iterable" can be diagnosed from the captured logs.
+"""
+
+import contextlib
+import io
+import os
+import signal
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_mock_db = ModuleType("db_notifier")
+_mock_db.notify_report_running = MagicMock(return_value=True)
+_mock_db.notify_report_ready = MagicMock(return_value=True)
+_mock_db.notify_report_ready_from_synced = MagicMock(return_value=True)
+_mock_db.notify_report_stopped = MagicMock(return_value=True)
+_mock_db.load_existing_jsonl_prefix = MagicMock(return_value="")
+_mock_db.get_log_file_path = MagicMock(return_value=Path("/tmp/fake_reports/report.log"))
+_mock_db.HeartbeatThread = MagicMock
+_mock_db.JournalSyncThread = MagicMock
+_mock_db.REPORTS_PATH = Path("/tmp/fake_reports")
+
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__), "..")
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
+_original_db_notifier = sys.modules.get("db_notifier")
+_original_run_garak = sys.modules.pop("run_garak", None)
+_orig_sigterm = signal.getsignal(signal.SIGTERM)
+_orig_sigint = signal.getsignal(signal.SIGINT)
+sys.modules["db_notifier"] = _mock_db
+
+try:
+    import run_garak as _run_garak  # noqa: E402
+finally:
+    if _original_db_notifier is None:
+        sys.modules.pop("db_notifier", None)
+    else:
+        sys.modules["db_notifier"] = _original_db_notifier
+
+    if _original_run_garak is None:
+        sys.modules.pop("run_garak", None)
+    else:
+        sys.modules["run_garak"] = _original_run_garak
+
+    signal.signal(signal.SIGTERM, _orig_sigterm)
+    signal.signal(signal.SIGINT, _orig_sigint)
+
+run_garak = _run_garak
+
+
+class TestRunGarakTraceback(unittest.TestCase):
+    def setUp(self):
+        self.original_garak = sys.modules.get("garak")
+        self.original_garak_main = sys.modules.get("garak.__main__")
+
+        garak = ModuleType("garak")
+        garak.__path__ = []
+        garak_main = ModuleType("garak.__main__")
+        garak_main.main = MagicMock(return_value=0)
+        sys.modules["garak"] = garak
+        sys.modules["garak.__main__"] = garak_main
+
+    def tearDown(self):
+        if self.original_garak is None:
+            sys.modules.pop("garak", None)
+        else:
+            sys.modules["garak"] = self.original_garak
+
+        if self.original_garak_main is None:
+            sys.modules.pop("garak.__main__", None)
+        else:
+            sys.modules["garak.__main__"] = self.original_garak_main
+
+    def test_run_garak_scan_logs_full_traceback_on_crash(self):
+        def crashing_main():
+            raise TypeError("'NoneType' object is not iterable")
+
+        sys.modules["garak.__main__"].main = crashing_main
+
+        stderr = io.StringIO()
+        with patch.object(run_garak, "install_plugin_cache_guard"):
+            with contextlib.redirect_stderr(stderr):
+                exit_code = run_garak.run_garak_scan(["--list_probes"])
+
+        output = stderr.getvalue()
+
+        self.assertEqual(1, exit_code)
+        self.assertIn(
+            "Error running Garak scan: 'NoneType' object is not iterable", output
+        )
+        self.assertIn("Traceback (most recent call last)", output)
+        self.assertIn("TypeError", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/services/reports/failure_classifier_spec.rb
+++ b/spec/services/reports/failure_classifier_spec.rb
@@ -95,4 +95,31 @@ RSpec.describe Reports::FailureClassifier do
 
     expect(described_class.new(report, logs: logs).call.code).to eq('garak_runtime_error')
   end
+
+  it 'does not classify a post-completion digest error after a clean exit' do
+    logs = <<~LOG
+      2026-05-27 23:13:53,174 - __main__ - INFO - Garak scan completed - Report: example-report, Exit code: 0
+      Traceback (most recent call last):
+        File "report_digest.py", line 120, in _get_probe_info
+      KeyError: 'description'
+    LOG
+
+    result = described_class.new(report, logs: logs).call
+
+    expect(result).not_to be_failed
+    expect(result.code).to be_nil
+  end
+
+  it 'classifies a runtime failure when the last exit code is non-zero despite an earlier clean exit' do
+    logs = <<~LOG
+      2026-05-27 22:00:00,000 - __main__ - INFO - Garak scan completed - Report: earlier-run, Exit code: 0
+      2026-05-27 23:00:00,000 - root - INFO - probe init
+      Traceback (most recent call last):
+        File "garak/harnesses/base.py", line 80, in run
+      RuntimeError: garak failed
+      2026-05-27 23:13:53,174 - __main__ - INFO - Garak scan completed - Report: current-run, Exit code: 1
+    LOG
+
+    expect(described_class.new(report, logs: logs).call.code).to eq('garak_runtime_error')
+  end
 end

--- a/spec/services/reports/process_spec.rb
+++ b/spec/services/reports/process_spec.rb
@@ -217,6 +217,52 @@ RSpec.describe Reports::Process, type: :service do
       end
     end
 
+    context 'when completed results carry a trailing post-scan digest error' do
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let!(:raw_data) do
+        create(
+          :raw_report_data,
+          report: report,
+          jsonl_data: jsonl_content,
+          logs_data: "2023-06-01 10:30:00,123 - __main__ - INFO - Garak scan completed - Report: test, Exit code: 0\nTraceback (most recent call last):\nKeyError: 'description'\n"
+        )
+      end
+
+      it 'keeps the report completed and clears failure metadata' do
+        service.call
+
+        report.reload
+        expect(report.status).to eq('completed')
+        expect(report.failure_code).to be_nil
+        expect(report.failure_message).to be_nil
+        expect(report.failure_details).to eq({})
+      end
+    end
+
+    context 'when completed results carry a current non-zero exit despite an earlier clean exit' do
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let!(:raw_data) do
+        create(
+          :raw_report_data,
+          report: report,
+          jsonl_data: jsonl_content,
+          logs_data: "2023-06-01 09:00:00,000 - __main__ - INFO - Garak scan completed - Report: earlier, Exit code: 0\nTraceback (most recent call last):\nRuntimeError: garak failed\n2023-06-01 10:30:00,123 - __main__ - INFO - Garak scan completed - Report: current, Exit code: 1\n"
+        )
+      end
+
+      before do
+        report.update!(retry_count: 1)
+      end
+
+      it 'marks the report failed with a runtime failure code' do
+        service.call
+
+        report.reload
+        expect(report.status).to eq('failed')
+        expect(report.failure_code).to eq('garak_runtime_error')
+      end
+    end
+
     context 'when a retry has no current failure logs' do
       let!(:probe) { create(:probe, name: 'TestProbe') }
       let!(:raw_data) { create(:raw_report_data, report: report, jsonl_data: jsonl_content, logs_data: nil) }


### PR DESCRIPTION
Fixes a few scan reporting issues:

- Completed scans are no longer flipped to `failed` when the run log contains a post-completion error (e.g. the report-digest step) or a transient provider status. Clean completion is judged by the **last** garak exit, so accumulated same-day retry logs don't trip it.
- garak crashes now log the full traceback (not just the one-line message), so failures are debuggable from the report logs.
- Variant probe base classes carry a `description`, so garak's report digest builds for variant scans (avoids `KeyError: 'description'`).

Tests: rspec (failure classifier + report processing) and the run_garak python suite are green.