### PR TITLE
fix(reports): use authoritative garak exit code for completion and failure classification

### DIFF
--- a/app/services/reports/failure_classifier.rb
+++ b/app/services/reports/failure_classifier.rb
@@ -126,7 +126,12 @@ module Reports
       # is post-scan noise (e.g. garak's report-digest builder), not a runtime failure.
       return EMPTY_RESULT if self.class.cleanly_completed?(evidence_text) && !exit_code.to_i.positive?
 
-      return EMPTY_RESULT unless exit_code.to_i.positive? || exception_message.present? ||
+      # A nonzero last completion marker is an authoritative current-run failure even
+      # without a traceback: db_notifier appends the real garak exit code to the logs,
+      # so an exit != 0 means garak itself signalled failure (the digest crash exits 0,
+      # so this never re-fails a cleanly-completed scan).
+      return EMPTY_RESULT unless exit_code.to_i.positive? || nonzero_garak_exit? ||
+        exception_message.present? ||
         evidence_text.match?(/traceback|exception|runtimeerror|garak .*failed|non[- ]?zero/i)
 
       build_result("garak_runtime_error")
@@ -146,7 +151,7 @@ module Reports
         "model" => model,
         "status_code" => status_code,
         "provider_message" => provider_message,
-        "exit_code" => exit_code,
+        "exit_code" => effective_exit_code,
         "exception_message" => exception_message
       }
 
@@ -211,6 +216,26 @@ module Reports
 
     def successful_garak_completion?
       self.class.cleanly_completed?(evidence_text)
+    end
+
+    # Exit code from the LAST "Garak scan completed ... Exit code: N" marker in the
+    # accumulated log, or nil when no marker is present. Same parse as cleanly_completed?
+    # (last match wins across same-day retry logs).
+    def last_marker_exit_code
+      return @last_marker_exit_code if defined?(@last_marker_exit_code)
+
+      match = evidence_text.scan(GARAK_COMPLETION_PATTERN).last
+      @last_marker_exit_code = match&.first&.to_i
+    end
+
+    def nonzero_garak_exit?
+      last_marker_exit_code.to_i.positive?
+    end
+
+    # The explicit constructor exit code is authoritative; otherwise fall back to a
+    # nonzero marker exit so the persisted failure detail matches the classification.
+    def effective_exit_code
+      exit_code || (nonzero_garak_exit? ? last_marker_exit_code : nil)
     end
 
     def model_unavailable_text?

--- a/script/db_notifier.py
+++ b/script/db_notifier.py
@@ -1298,7 +1298,30 @@ def _enqueue_process_report_job(report_id: int, queue_conn) -> int:
     return job_id
 
 
-def notify_report_ready(report_uuid: str, prefix: str = "") -> bool:
+def _append_authoritative_completion_marker(
+    logs_data: Optional[str], report_uuid: str, exit_code: Optional[int]
+) -> Optional[str]:
+    """Append a canonical garak-completion marker reflecting the current run's exit code.
+
+    The scan log is captured by Ruby's RunCommand reader threads, so the
+    "Garak scan completed ... Exit code: N" line run_garak.py emits may not be flushed
+    to the log file before this process reads it back. Appending the marker from the
+    exit_code we already hold guarantees Reports::FailureClassifier.cleanly_completed?
+    sees the true current-run exit (it reads the LAST match) — free of that flush race
+    and of stale clean-exit lines left by earlier retry attempts.
+
+    When exit_code is unknown (None), logs_data is returned unchanged.
+    """
+    if exit_code is None:
+        return logs_data
+    marker = f"Garak scan completed - Report: {report_uuid}, Exit code: {exit_code}"
+    if not logs_data:
+        return marker + "\n"
+    separator = "" if logs_data.endswith("\n") else "\n"
+    return f"{logs_data}{separator}{marker}\n"
+
+
+def notify_report_ready(report_uuid: str, prefix: str = "", exit_code: Optional[int] = None) -> bool:
     """
     Store report data in database and enqueue processing job using pooled connections.
 
@@ -1371,6 +1394,8 @@ def notify_report_ready(report_uuid: str, prefix: str = "") -> bool:
     except Exception as e:
         logger.error(f"Error reading report files: {e}")
         return False
+
+    logs_data = _append_authoritative_completion_marker(logs_data, report_uuid, exit_code)
 
     # Prepend prefix from previous interrupted run (resumed scans)
     if prefix and jsonl_data:
@@ -1471,7 +1496,7 @@ def notify_report_ready(report_uuid: str, prefix: str = "") -> bool:
         return False
 
 
-def notify_report_ready_from_synced(report_uuid: str) -> bool:
+def notify_report_ready_from_synced(report_uuid: str, exit_code: Optional[int] = None) -> bool:
     """
     Enqueue ProcessReportJob using already-synced raw_report_data.
 
@@ -1506,6 +1531,8 @@ def notify_report_ready_from_synced(report_uuid: str) -> bool:
             )
         except Exception as e:
             logger.warning(f"Failed to read log file: {e}")
+
+    logs_data = _append_authoritative_completion_marker(logs_data, report_uuid, exit_code)
 
     try:
         with pooled_connection("primary") as primary_conn, \

--- a/script/run_garak.py
+++ b/script/run_garak.py
@@ -132,10 +132,10 @@ def notify_report_running(report_uuid, pid):
         return False
 
 
-def notify_report_ready(report_uuid, prefix=""):
+def notify_report_ready(report_uuid, prefix="", exit_code=None):
     """Store report data in database and enqueue processing job."""
     try:
-        result = db_notify_ready(report_uuid, prefix=prefix)
+        result = db_notify_ready(report_uuid, prefix=prefix, exit_code=exit_code)
         if result:
             print(f"Report {report_uuid} data stored and job enqueued")
         else:
@@ -146,10 +146,10 @@ def notify_report_ready(report_uuid, prefix=""):
         return False
 
 
-def notify_report_ready_from_synced(report_uuid):
+def notify_report_ready_from_synced(report_uuid, exit_code=None):
     """Enqueue processing job using already-synced raw_report_data."""
     try:
-        result = db_notify_ready_from_synced(report_uuid)
+        result = db_notify_ready_from_synced(report_uuid, exit_code=exit_code)
         if result:
             print(f"Report {report_uuid} job enqueued (from synced data)")
         else:
@@ -244,7 +244,7 @@ def main():
 
             if sync_clean:
                 # Use synced variant — JSONL already in raw_report_data, just add logs + enqueue job
-                if not notify_report_ready_from_synced(report_uuid):
+                if not notify_report_ready_from_synced(report_uuid, exit_code=exit_code):
                     logger.error(f"Failed to enqueue ProcessReportJob for {report_uuid}")
                     exit_code = 1
             else:
@@ -254,7 +254,7 @@ def main():
                     f"JournalSync did not stop cleanly for {report_uuid}, "
                     f"falling back to full JSONL read from disk"
                 )
-                if not notify_report_ready(report_uuid, prefix=prefix):
+                if not notify_report_ready(report_uuid, prefix=prefix, exit_code=exit_code):
                     logger.error(f"Failed to enqueue ProcessReportJob for {report_uuid}")
                     exit_code = 1
 

--- a/script/tests/test_db_notifier_debug_log_tail.py
+++ b/script/tests/test_db_notifier_debug_log_tail.py
@@ -5,6 +5,7 @@ Tests for JournalSyncThread live execution log tail syncing.
 
 import importlib
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -387,6 +388,66 @@ class TestJournalSyncDebugLogTail(unittest.TestCase):
         self.assertEqual(params[0], "first line\nnul stripped\n")
         self.assertIsNotNone(params[1])
         self.assertEqual(params[2], 123)
+
+    def test_notify_report_ready_from_synced_appends_authoritative_exit_marker(self):
+        # The async scan log is written by Ruby's RunCommand reader threads, so the
+        # "Garak scan completed ... Exit code: 0" line may not be flushed to the file
+        # before this process reads it. When the current-run exit_code is known it must
+        # be appended so downstream classification sees the true clean exit.
+        self.log_path.write_text("probe output without completion marker\n", encoding="utf-8")
+        cursor = RecordingCursor(report_id=123)
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn), \
+             patch.object(db_notifier, "get_log_file_path", return_value=self.log_path), \
+             patch.object(db_notifier, "_enqueue_process_report_job", return_value="job-id"), \
+             patch.object(db_notifier, "cleanup_scan_files"):
+            self.assertTrue(
+                db_notifier.notify_report_ready_from_synced("report-uuid", exit_code=0)
+            )
+
+        logs_data = self._sql_calls_containing(cursor, "UPDATE raw_report_data")[0][1][0]
+        self.assertIn("probe output without completion marker", logs_data)
+        self.assertRegex(logs_data, r"Garak scan completed.*Exit code:\s*0")
+
+    def test_notify_report_ready_from_synced_marker_reflects_failing_exit(self):
+        # A stale clean exit from a prior attempt must not win: the appended marker carries
+        # the real current-run exit code, and last-match-wins keeps the report failed.
+        self.log_path.write_text(
+            "Garak scan completed - Report: old, Exit code: 0\n"
+            "Traceback (most recent call last): boom\n",
+            encoding="utf-8",
+        )
+        cursor = RecordingCursor(report_id=123)
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn), \
+             patch.object(db_notifier, "get_log_file_path", return_value=self.log_path), \
+             patch.object(db_notifier, "_enqueue_process_report_job", return_value="job-id"), \
+             patch.object(db_notifier, "cleanup_scan_files"):
+            self.assertTrue(
+                db_notifier.notify_report_ready_from_synced("report-uuid", exit_code=1)
+            )
+
+        logs_data = self._sql_calls_containing(cursor, "UPDATE raw_report_data")[0][1][0]
+        exits = re.findall(r"Garak scan completed.*?Exit code:\s*(\d+)", logs_data)
+        self.assertEqual(exits[-1], "1")
+
+    def test_notify_report_ready_from_synced_omits_marker_without_exit_code(self):
+        # Backward compatible: callers that do not pass an exit_code get no synthetic marker.
+        self.log_path.write_text("plain logs\n", encoding="utf-8")
+        cursor = RecordingCursor(report_id=123)
+        conn = RecordingConnection(cursor)
+
+        with self._patch_pooled_connection(conn), \
+             patch.object(db_notifier, "get_log_file_path", return_value=self.log_path), \
+             patch.object(db_notifier, "_enqueue_process_report_job", return_value="job-id"), \
+             patch.object(db_notifier, "cleanup_scan_files"):
+            self.assertTrue(db_notifier.notify_report_ready_from_synced("report-uuid"))
+
+        logs_data = self._sql_calls_containing(cursor, "UPDATE raw_report_data")[0][1][0]
+        self.assertEqual(logs_data, "plain logs\n")
+        self.assertNotIn("Garak scan completed", logs_data)
 
 
 if __name__ == "__main__":

--- a/spec/services/reports/failure_classifier_spec.rb
+++ b/spec/services/reports/failure_classifier_spec.rb
@@ -122,4 +122,15 @@ RSpec.describe Reports::FailureClassifier do
 
     expect(described_class.new(report, logs: logs).call.code).to eq('garak_runtime_error')
   end
+
+  it 'classifies a nonzero exit marker as a runtime failure even without a traceback' do
+    logs = <<~LOG
+      2026-05-27 23:10:00,000 - root - INFO - run complete, ending
+      2026-05-27 23:13:53,174 - __main__ - INFO - Garak scan completed - Report: current-run, Exit code: 1
+    LOG
+
+    result = described_class.new(report, logs: logs).call
+    expect(result.code).to eq('garak_runtime_error')
+    expect(result.details['exit_code']).to eq(1)
+  end
 end

--- a/spec/services/reports/process_spec.rb
+++ b/spec/services/reports/process_spec.rb
@@ -239,6 +239,26 @@ RSpec.describe Reports::Process, type: :service do
       end
     end
 
+    context 'when completed results carry a current non-zero exit without a traceback' do
+      let!(:probe) { create(:probe, name: 'TestProbe') }
+      let!(:raw_data) do
+        create(
+          :raw_report_data,
+          report: report,
+          jsonl_data: jsonl_content,
+          logs_data: "2023-06-01 10:30:00,123 - __main__ - INFO - Garak scan completed - Report: test, Exit code: 1\n"
+        )
+      end
+
+      it 'marks the report failed as a garak runtime error' do
+        service.call
+
+        report.reload
+        expect(report.status).to eq('failed')
+        expect(report.failure_code).to eq('garak_runtime_error')
+      end
+    end
+
     context 'when completed results carry a current non-zero exit despite an earlier clean exit' do
       let!(:probe) { create(:probe, name: 'TestProbe') }
       let!(:raw_data) do


### PR DESCRIPTION
## Summary
- **Persist the authoritative garak exit code into `logs_data`.** The clean-exit marker the failure classifier relies on is written to the scan log by Ruby's `RunCommand` reader threads, so `notify_report_ready[_from_synced]` could read the log file before that line was flushed — leaving a completed scan looking un-completed and getting re-marked failed. `run_garak.py` now threads the current-run `exit_code` into both notify functions, which append a canonical `Garak scan completed … Exit code: N` marker to `logs_data`. `cleanly_completed?` reads the **last** match, so it's authoritative regardless of flush timing and overrides any stale clean-exit line from an earlier retry.
- **Treat a nonzero last completion marker as `garak_runtime_error`.** A scan with complete JSONL but a nonzero garak exit and no traceback/provider line previously stayed `completed`, because the classifier neither parsed the marker nor matched `Exit code: N` with its runtime regex. `nonzero_garak_exit?` now feeds the runtime guard. The clean-completion guard is unchanged, so an exit‑0 post‑scan digest error is still treated as noise. The exit code is persisted in `failure_details`.

## Tests
- `script/tests/test_db_notifier_debug_log_tail.py`: marker appended from the authoritative exit code when the log lacks it; last‑match‑wins on a failing exit; omitted when no exit code is supplied.
- `failure_classifier_spec` / `process_spec`: a nonzero‑exit marker without a traceback now classifies/fails as `garak_runtime_error` (with the exit code in `failure_details`); the exit‑0 digest‑error case stays `completed`.
