### PR TITLE
feat(dashboard): collapse community detectors into a single radar spoke

### DIFF
--- a/app/services/stats/detector_activity_data.rb
+++ b/app/services/stats/detector_activity_data.rb
@@ -10,29 +10,44 @@ module Stats
       start_date = Time.zone.today - 30.days
       end_date = Time.zone.today
 
-      top_detectors = DetectorResult.joins(:detector, :report)
-                        .where(reports: { created_at: start_date.beginning_of_day..end_date.end_of_day })
-      top_detectors = top_detectors.where(reports: { target_id: @target_id }) if @target_id.present?
-      top_detectors = top_detectors.where(reports: { scan_id: @scan_id }) if @scan_id.present?
-      top_detectors = top_detectors.where(report_id: @report_id) if @report_id.present?
-      top_detectors = top_detectors.select("detectors.name, SUM(detector_results.total) as total_tests, SUM(detector_results.passed) as passed_tests")
-                        .group("detectors.id, detectors.name")
-                        .order("total_tests DESC")
-      detector_names = []
-      test_counts = []
-      passed_counts = []
+      rows = DetectorResult.joins(:detector, :report)
+               .where(reports: { created_at: start_date.beginning_of_day..end_date.end_of_day })
+      rows = rows.where(reports: { target_id: @target_id }) if @target_id.present?
+      rows = rows.where(reports: { scan_id: @scan_id }) if @scan_id.present?
+      rows = rows.where(report_id: @report_id) if @report_id.present?
+      rows = rows.select("detectors.name, SUM(detector_results.total) AS total_tests, SUM(detector_results.passed) AS passed_tests")
+                 .group("detectors.id, detectors.name")
+                 .order("total_tests DESC")
 
-      top_detectors.each do |result|
-        short_name = result.name.split(".").last
-        detector_names << I18n.t("detectors.names.#{short_name}", default: short_name)
-        test_counts << result.total_tests
-        passed_counts << result.passed_tests
+      individual = []
+      community = { total: 0, passed: 0, any: false }
+
+      rows.each do |row|
+        total = row.total_tests.to_i
+        passed = row.passed_tests.to_i
+
+        if row.name.to_s.start_with?("0din.")
+          short_name = row.name.split(".").last
+          individual << {
+            name: I18n.t("detectors.names.#{short_name}", default: short_name),
+            total: total,
+            passed: passed
+          }
+        else
+          community[:total] += total
+          community[:passed] += passed
+          community[:any] = true
+        end
       end
 
+      spokes = individual
+      spokes << { name: "Community", total: community[:total], passed: community[:passed] } if community[:any]
+      spokes.sort_by! { |spoke| -spoke[:total] }
+
       {
-        detector_names: detector_names,
-        test_counts: test_counts,
-        passed_counts: passed_counts,
+        detector_names: spokes.map { |spoke| spoke[:name] },
+        test_counts: spokes.map { |spoke| spoke[:total] },
+        passed_counts: spokes.map { |spoke| spoke[:passed] },
         time_range: "Last 30 Days"
       }
     end

--- a/spec/services/stats/detector_activity_data_spec.rb
+++ b/spec/services/stats/detector_activity_data_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Stats::DetectorActivityData do
     let(:scan) { create(:complete_scan) }
     let(:report) { create(:report, target: target, scan: scan) }
 
-    let(:detector1) { create(:detector, name: 'detector.type1') }
-    let(:detector2) { create(:detector, name: 'detector.type2') }
-    let(:detector3) { create(:detector, name: 'detector.type3') }
+    let(:detector1) { create(:detector, name: '0din.type1') }
+    let(:detector2) { create(:detector, name: '0din.type2') }
+    let(:detector3) { create(:detector, name: '0din.type3') }
 
     describe 'with no filters' do
       subject { described_class.new }
@@ -160,6 +160,51 @@ RSpec.describe Stats::DetectorActivityData do
 
         result = subject.call
         expect(result[:detector_names]).to eq([ "type1" ])
+      end
+    end
+
+    describe 'community collapsing' do
+      subject { described_class.new }
+
+      context 'with multiple community (garak) detectors' do
+        let(:garak1) { create(:detector, name: 'dan.DAN') }
+        let(:garak2) { create(:detector, name: 'ansiescape.Escaped') }
+
+        before do
+          create(:detector_result, report: report, detector: garak1, total: 60, passed: 40)
+          create(:detector_result, report: report, detector: garak2, total: 30, passed: 10)
+        end
+
+        it 'collapses them into a single "Community" spoke with summed counts' do
+          result = subject.call
+
+          expect(result[:detector_names]).to eq([ "Community" ])
+          expect(result[:test_counts]).to eq([ 90 ])
+          expect(result[:passed_counts]).to eq([ 50 ])
+        end
+      end
+
+      context 'with a mix of 0din and community detectors' do
+        let(:odin) { create(:detector, name: '0din.MitigationBypass') }
+        let(:garak1) { create(:detector, name: 'dan.DAN') }
+        let(:garak2) { create(:detector, name: 'continuation.Continuation') }
+
+        before do
+          create(:detector_result, report: report, detector: odin, total: 100, passed: 90)
+          create(:detector_result, report: report, detector: garak1, total: 40, passed: 20)
+          create(:detector_result, report: report, detector: garak2, total: 35, passed: 15)
+          allow(I18n).to receive(:t)
+            .with("detectors.names.MitigationBypass", default: "MitigationBypass")
+            .and_return("Generic Mitigation Bypass Checks")
+        end
+
+        it 'keeps 0din individual and collapses community, ordered by total DESC' do
+          result = subject.call
+
+          expect(result[:detector_names]).to eq([ "Generic Mitigation Bypass Checks", "Community" ])
+          expect(result[:test_counts]).to eq([ 100, 75 ])
+          expect(result[:passed_counts]).to eq([ 90, 35 ])
+        end
       end
     end
   end


### PR DESCRIPTION
Collapses all community (garak) detectors into a single "Community" spoke in the Detector Activity Distribution radar; 0DIN detectors keep individual spokes. Server-side only (`Stats::DetectorActivityData`).

Ported from the private scanner; adapted to ai-scanner — classification is name-only (no `detectors.source` column) and there is **no "Custom" bucket** (ai-scanner has no custom-probe/detector machinery), and no `customer_visible` filter (no `validation_run`).

Test plan:
- [ ] CI green
- [ ] Dashboard radar shows one Community spoke (+ individual 0DIN), not one spoke per community probe