### PR TITLE
fix(ci): align Dockerfile.cypress base image with locked cypress 15.17.0

### DIFF
--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -1,7 +1,7 @@
 # Dockerfile for Cypress E2E tests
 # This creates a lightweight image containing only the cypress tests and configuration
 
-FROM cypress/included:13.17.0
+FROM cypress/included:15.17.0
 
 # Set working directory
 WORKDIR /e2e


### PR DESCRIPTION
Parity with the private scanner. `Dockerfile.cypress` inherited `cypress/included:13.17.0`, which doesn't match the package-locked cypress `15.17.0`; bumping the base tag aligns the image's `cypress run` runner with `package.json`.

No workflow currently builds this image in ai-scanner, so this is a hygiene/parity fix (the GH-runner e2e flow already uses the local 15.17 via `npm ci` + `npx cypress run`). The `cypress/included:15.17.0` tag is published on Docker Hub.

Test plan:
- [ ] CI green