### PR TITLE
feat(dashboard): add scan-name + ASR Last Five Scans and Top Five Most Successful Attacks list tiles

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -18,6 +18,8 @@ module Admin
       @total_scans = stats["total_scans"]
       @total_targets = stats["total_targets"]
       @total_reports = stats["total_reports"]
+      @last_five_scans = Stats::LastFiveScansData.new.call
+      @top_five_attacks = Stats::TopFiveAttacksData.new(probe_scope: policy_scope(Probe)).call
     end
 
     def get_started

--- a/app/controllers/dashboard_stats_controller.rb
+++ b/app/controllers/dashboard_stats_controller.rb
@@ -26,11 +26,6 @@ class DashboardStatsController < ApplicationController
     render json: result
   end
 
-  def last_five_scans_data
-    result = Stats::LastFiveScansData.new.call
-    render json: result
-  end
-
   def targets_timeline_data
     result = Stats::TargetsTimelineData.new.call
     render json: result

--- a/app/javascript/controllers/dashboard_controller.js
+++ b/app/javascript/controllers/dashboard_controller.js
@@ -19,7 +19,6 @@ export default class extends Controller {
         "percentage4",
         "periodLabel4",
         "sparklineChart4",
-        "lastFiveScansScores",
         "vulnerableTargetsChart",
         "detectorActivityRadarChart",
         "taxonomyDistributionChart",
@@ -67,7 +66,6 @@ export default class extends Controller {
         this.initTotalScans(chartConfig);
         this.initAvgAsrScores(chartConfig);
         this.initAvgScans(chartConfig);
-        this.initLastFiveScanScores(chartConfig);
         this.initVulnerableTargetsChart(chartConfig);
         this.initDetectorActivityRadarChart(chartConfig);
         this.initTaxonomyDistributionChart(chartConfig);
@@ -333,115 +331,6 @@ export default class extends Controller {
         chart.getZr().off('click');
 
         this.charts[chartKeyValue] = chart;
-    }
-
-    initLastFiveScanScores(chartConfig) {
-        const chart = this.initChart(this.lastFiveScansScoresTarget, chartConfig);
-        fetch('/dashboard_stats/last_five_scans_data')
-            .then(response => response.json())
-            .then(data => {
-                // Handle empty data
-                if (!data.models || data.models.length === 0) {
-                    chart.setOption({
-                        ...chartConfig,
-                        title: {
-                            text: 'No scan data available',
-                            left: 'center',
-                            top: 'center',
-                            textStyle: {
-                                color: colors.textColor,
-                                fontSize: 14
-                            }
-                        }
-                    });
-                    return;
-                }
-
-                const chartData = data.models.map((name, index) => ({
-                    name,
-                    value: data.values[index],
-                    reportId: data.report_ids[index]
-                }));
-                chartData.sort((a, b) => a.value - b.value);
-
-                const modelFullNames = chartData.map(d => d.name);
-                const modelNames = chartData.map(d => d.name.length > 22 ? d.name.substring(0, 22) + '...' : d.name);
-                const scoreValues = chartData.map(d => d.value);
-                const reportIds = chartData.map(d => d.reportId);
-
-                chart.setOption({
-                    ...chartConfig,
-                    legend: {
-                        show: false
-                    },
-                    tooltip: {
-                        ...tooltipConfig,
-                        trigger: 'item',
-                        formatter: function(params) {
-                            const dataIndex = params.dataIndex;
-                            return `${modelFullNames[dataIndex]}: ${params.value}%<br/>Click on model name to view report`;
-                        }
-                    },
-                    grid: {
-                        left: '1%',
-                        right: '4%',
-                        bottom: '3%',
-                        top: 0,
-                        containLabel: true
-                    },
-                    xAxis: {
-                        type: 'value',
-                        axisLine: { lineStyle: { color: colors.gridLineColor } },
-                        axisLabel: {
-                            color: colors.subTextColor,
-                            fontFamily: BRAND_FONT
-                        },
-                        splitLine: { lineStyle: { color: colors.gridLineColor, type: 'dashed' } }
-                    },
-                    yAxis: {
-                        type: 'category',
-                        data: modelNames,
-                        axisLine: { lineStyle: { color: colors.gridLineColor } },
-                        axisLabel: {
-                            color: colors.subTextColor,
-                            cursor: 'pointer',
-                            fontFamily: BRAND_FONT
-                        },
-                        triggerEvent: true
-                    },
-                    series: [
-                        {
-                            name: 'Attack Success Rate (ASR)',
-                            type: 'bar',
-                            data: scoreValues,
-                            barWidth: 16,
-                            itemStyle: {
-                                color: new echarts.graphic.LinearGradient(0, 0, 1, 0, [
-                                    { offset: 0, color: '#B94E10' },
-                                    { offset: 1, color: '#FF9456' }
-                                ]),
-                                cursor: 'pointer'
-                            },
-                            emphasis: {
-                                itemStyle: {
-                                    color: new echarts.graphic.LinearGradient(0, 0, 1, 0, [
-                                        { offset: 0, color: '#C85D1A' },
-                                        { offset: 1, color: '#FDB97F' }
-                                    ])
-                                }
-                            },
-                            barCategoryGap: '20%'
-                        }
-                    ]
-                });
-
-                chart.on('click', function(params) {
-                    const reportId = reportIds[params.dataIndex];
-                    if (reportId) {
-                        window.location.href = `/reports/${reportId}`;
-                    }
-                });
-            });
     }
 
     initVulnerableTargetsChart(chartConfig) {

--- a/app/services/stats/last_five_scans_data.rb
+++ b/app/services/stats/last_five_scans_data.rb
@@ -1,42 +1,15 @@
 module Stats
   class LastFiveScansData
     def call
-      # Get the last 5 completed reports with pre-aggregated probe_results stats
-      # Using a single SQL query with GROUP BY to avoid N+1 queries
-      last_five_reports = Report
-        .joins(:target)
-        .left_joins(:probe_results)
-        .where(status: Report.statuses[:completed])
-        .group("reports.id", "targets.name")
-        .select(
-          "reports.id",
-          "reports.created_at",
-          "targets.name as target_name",
-          "COALESCE(SUM(probe_results.passed), 0) as total_passed",
-          "COALESCE(SUM(probe_results.total), 0) as total_tests"
-        )
-        .order(created_at: :desc)
-        .limit(5)
-
-      models = []
-      scores = []
-      report_ids = []
-
-      last_five_reports.each do |report|
-        total_passed = report.total_passed.to_i
-        total_tests = report.total_tests.to_i
-        score = total_tests.zero? ? 0 : ((total_passed.to_f / total_tests) * 100).round(0)
-
-        models << report.target_name
-        scores << score
-        report_ids << report.id
-      end
-
-      {
-        models: models,
-        values: scores,
-        report_ids: report_ids
-      }
+      Scan.order(created_at: :desc)
+          .limit(5)
+          .map do |scan|
+            {
+              scan_name: scan.name,
+              scan_id: scan.id,
+              asr: (scan.avg_successful_attacks || 0).round
+            }
+          end
     end
   end
 end

--- a/app/services/stats/top_five_attacks_data.rb
+++ b/app/services/stats/top_five_attacks_data.rb
@@ -1,0 +1,33 @@
+module Stats
+  class TopFiveAttacksData
+    def initialize(probe_scope: Probe.all)
+      @probe_scope = probe_scope
+    end
+
+    def call
+      ProbeResult
+        .joins(:probe)
+        .where(report_id: Report.completed.select(:id))
+        .where(probe_id: @probe_scope.select(:id))
+        .group("probes.id", "probes.name")
+        .having("SUM(probe_results.total) > 0")
+        .select(
+          "probes.id AS probe_id",
+          "probes.name AS probe_name",
+          "SUM(probe_results.passed) AS total_passed",
+          "SUM(probe_results.total) AS total_tests"
+        )
+        .order(Arel.sql("SUM(probe_results.passed)::float / SUM(probe_results.total) DESC, SUM(probe_results.total) DESC"))
+        .limit(5)
+        .map do |row|
+          passed = row.total_passed.to_i
+          total = row.total_tests.to_i
+          {
+            probe_name: row.probe_name,
+            probe_id: row.probe_id,
+            asr: ((passed.to_f / total) * 100).round
+          }
+        end
+    end
+  end
+end

--- a/app/views/admin/dashboard/_last_five_scans_card.html.erb
+++ b/app/views/admin/dashboard/_last_five_scans_card.html.erb
@@ -1,9 +1,21 @@
-<div class="bg-white dark:bg-zinc-900 rounded-lg shadow-sm border border-gray-100 dark:border-zinc-700 p-3 lg:p-4">
+<div class="bg-white dark:bg-zinc-900 rounded-lg shadow-sm border border-gray-100 dark:border-zinc-700 p-3 lg:p-4 flex flex-col">
   <div class="flex items-center gap-2 mb-4">
-    <h3 class="text-white font-sans text-base font-normal">Last Five Scans Attack Success Rate</h3>
-    <%= render 'shared/info_tooltip', aria_label: 'Information about Last Five Scans Attack Success Rate', content: t('dashboard.tooltips.last_five_scans') %>
+    <h3 class="text-white font-sans text-base font-normal">Last Five Scans</h3>
+    <%= render 'shared/info_tooltip', aria_label: 'Information about Last Five Scans', content: t('dashboard.tooltips.last_five_scans') %>
   </div>
-  <div data-dashboard-target="lastFiveScansScores" class="w-full h-56 sm:h-64" aria-label="Last Five Scans Score chart">
-    <%= render partial: "charts/shared/loading_notice" %>
+  <div class="flex flex-col flex-grow">
+    <% if @last_five_scans.blank? %>
+      <p class="text-sm text-contentSecondary">No scans yet</p>
+    <% else %>
+      <ul class="flex flex-col divide-y divide-zinc-800">
+        <% @last_five_scans.each do |scan| %>
+          <li class="flex items-center justify-between gap-3 py-2">
+            <%= link_to scan[:scan_name], scan_path(scan[:scan_id]),
+                  class: "text-sm text-primary hover:underline truncate", title: scan[:scan_name] %>
+            <span class="text-sm font-semibold shrink-0 <%= asr_color_class(scan[:asr]) %>"><%= scan[:asr] %>%</span>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/dashboard/_top_five_attacks_card.html.erb
+++ b/app/views/admin/dashboard/_top_five_attacks_card.html.erb
@@ -1,0 +1,20 @@
+<div class="bg-white dark:bg-zinc-900 rounded-lg shadow-sm border border-gray-100 dark:border-zinc-700 p-3 lg:p-4 flex flex-col">
+  <div class="flex items-center gap-2 mb-4">
+    <h3 class="text-white font-sans text-base font-normal">Top Five Most Successful Attacks</h3>
+    <%= render 'shared/info_tooltip', aria_label: 'Information about Top Five Most Successful Attacks', content: t('dashboard.tooltips.top_five_attacks') %>
+  </div>
+  <div class="flex flex-col flex-grow">
+    <% if @top_five_attacks.blank? %>
+      <p class="text-sm text-contentSecondary">No attack data yet</p>
+    <% else %>
+      <ul class="flex flex-col divide-y divide-zinc-800">
+        <% @top_five_attacks.each do |attack| %>
+          <li class="flex items-center justify-between gap-3 py-2">
+            <span class="text-sm text-white truncate" title="<%= attack[:probe_name] %>"><%= attack[:probe_name] %></span>
+            <span class="text-sm font-semibold shrink-0 <%= asr_color_class(attack[:asr]) %>"><%= attack[:asr] %>%</span>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -29,8 +29,9 @@
       <%= render "admin/dashboard/average_scan_time_card" %>
     </div>
 
-    <div class="grid gap-4 grid-cols-1 lg:grid-cols-3">
+    <div class="grid gap-4 grid-cols-1 lg:grid-cols-4">
       <%= render "admin/dashboard/last_five_scans_card" %>
+      <%= render "admin/dashboard/top_five_attacks_card" %>
       <%= render "admin/dashboard/vulnerable_targets_card" %>
       <%= render "admin/dashboard/detector_activity_card" %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,7 @@ en:
       average_asr: "Average Attack Success Rate across all completed scans. ASR measures the percentage of probe attempts that successfully identified vulnerabilities."
       average_scan_time: "Average time taken to complete a security scan."
       last_five_scans: "Attack Success Rate for the five most recent scans, showing recent vulnerability detection trends."
+      top_five_attacks: "The five probes (attacks) with the highest Attack Success Rate across your recent scans."
       vulnerable_targets: "Targets with the highest vulnerability scores over time, helping identify systems that need attention."
       detector_activity: "Distribution of probe activity across different detector categories, showing which detection methods are most active."
       taxonomy_distribution: "Distribution of probes by security taxonomy categories, showing coverage across different vulnerability types."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,7 +119,6 @@ Rails.application.routes.draw do
   resource :dashboard_stats, only: [] do
     get :total_scans_data
     get :probes_data
-    get :last_five_scans_data
     get :targets_timeline_data
     get :reports_timeline_data
     get :probes_passed_failed_timeline_data

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe Admin::DashboardController, type: :controller do
         expect(response.body).to include("icon-wand")
         expect(response.body).to include(get_started_path)
       end
+
+      it "renders the Last Five Scans and Top Five Most Successful Attacks list tiles" do
+        get :index
+
+        expect(response.body).to include("Last Five Scans")
+        expect(response.body).to include("Top Five Most Successful Attacks")
+        expect(response.body).to include(scan.name)
+      end
     end
 
     context "when company has no scans" do

--- a/spec/controllers/dashboard_stats_controller_spec.rb
+++ b/spec/controllers/dashboard_stats_controller_spec.rb
@@ -160,23 +160,6 @@ RSpec.describe DashboardStatsController, type: :controller do
     end
   end
 
-  describe '#last_five_scans_data' do
-    let(:mock_result) { { scans: [ { id: 1, name: 'Scan 1' } ] } }
-    let(:mock_service) { instance_double(Stats::LastFiveScansData, call: mock_result) }
-
-    before do
-      allow(Stats::LastFiveScansData).to receive(:new).and_return(mock_service)
-    end
-
-    it 'calls the service and returns the result as JSON' do
-      get :last_five_scans_data
-
-      expect(Stats::LastFiveScansData).to have_received(:new)
-      expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq(mock_result.as_json)
-    end
-  end
-
   describe '#targets_timeline_data' do
     let(:mock_result) { { targets: [ { id: 1, name: 'Target 1' } ] } }
     let(:mock_service) { instance_double(Stats::TargetsTimelineData, call: mock_result) }

--- a/spec/services/stats/last_five_scans_data_spec.rb
+++ b/spec/services/stats/last_five_scans_data_spec.rb
@@ -2,103 +2,71 @@ require 'rails_helper'
 
 RSpec.describe Stats::LastFiveScansData, type: :service do
   describe '#call' do
-    let(:target1) { create(:target, name: 'Model 1') }
-    let(:target2) { create(:target, name: 'Model 2') }
-    let(:target3) { create(:target, name: 'Model 3') }
-    let(:scan) { create(:complete_scan) }
+    let(:company) { create(:company) }
 
     before do
+      ActsAsTenant.current_tenant = company
       # Stub service calls that might be triggered
       allow_any_instance_of(RunGarakScan).to receive(:call)
       allow_any_instance_of(ToastNotifier).to receive(:call)
     end
 
-    context 'when there are completed reports' do
-      before do
-        # Create 7 completed reports (2 more than we need to test limiting)
-        report1 = create(:report, :completed, target: target1, scan: scan, created_at: 7.days.ago)
-        report2 = create(:report, :completed, target: target2, scan: scan, created_at: 6.days.ago)
-        report3 = create(:report, :completed, target: target3, scan: scan, created_at: 5.days.ago)
-        report4 = create(:report, :completed, target: target1, scan: scan, created_at: 4.days.ago)
-        report5 = create(:report, :completed, target: target2, scan: scan, created_at: 3.days.ago)
-        report6 = create(:report, :completed, target: target3, scan: scan, created_at: 2.days.ago)
-        report7 = create(:report, :completed, target: target1, scan: scan, created_at: 1.day.ago)
+    def scan_with_asr(name:, asr:, created_at:)
+      scan = create(:complete_scan, company: company, name: name, created_at: created_at)
+      scan.update_column(:avg_successful_attacks, asr) unless asr.nil?
+      scan
+    end
 
-        # Create probe results for each report with different scores
-        create(:probe_result, report: report1, passed: 8, total: 10) # 80%
-        create(:probe_result, report: report2, passed: 6, total: 10) # 60%
-        create(:probe_result, report: report3, passed: 9, total: 10) # 90%
-        create(:probe_result, report: report4, passed: 5, total: 10) # 50%
-        create(:probe_result, report: report5, passed: 7, total: 10) # 70%
-        create(:probe_result, report: report6, passed: 4, total: 10) # 40%
-        create(:probe_result, report: report7, passed: 10, total: 10) # 100%
+    context 'with more than five scans' do
+      before do
+        scan_with_asr(name: 'Scan A', asr: 10, created_at: 6.days.ago)
+        scan_with_asr(name: 'Scan B', asr: 20, created_at: 5.days.ago)
+        scan_with_asr(name: 'Scan C', asr: 30, created_at: 4.days.ago)
+        scan_with_asr(name: 'Scan D', asr: 40, created_at: 3.days.ago)
+        scan_with_asr(name: 'Scan E', asr: 50, created_at: 2.days.ago)
+        scan_with_asr(name: 'Scan F', asr: 60, created_at: 1.day.ago)
       end
 
-      it 'returns data for the last 5 completed reports' do
+      it 'returns the five most recent scans, newest first' do
         result = described_class.new.call
 
-        # Should have 5 entries
-        expect(result[:models].length).to eq(5)
-        expect(result[:values].length).to eq(5)
-
-        # Check that the models and values match up in reverse chronological order
-        # The most recent 5 reports should be included (reports 3-7)
-        expect(result[:models]).to eq([ 'Model 1', 'Model 3', 'Model 2', 'Model 1', 'Model 3' ])
-        expect(result[:values]).to eq([ 100, 40, 70, 50, 90 ])
+        expect(result.length).to eq(5)
+        expect(result.map { |r| r[:scan_name] }).to eq([ 'Scan F', 'Scan E', 'Scan D', 'Scan C', 'Scan B' ])
+        expect(result.map { |r| r[:asr] }).to eq([ 60, 50, 40, 30, 20 ])
+        expect(result.first[:scan_id]).to be_present
       end
     end
 
-    context 'when there are fewer than 5 completed reports' do
-      before do
-        report1 = create(:report, :completed, target: target1, scan: scan, created_at: 3.days.ago)
-        report2 = create(:report, :completed, target: target2, scan: scan, created_at: 2.days.ago)
-        report3 = create(:report, :completed, target: target3, scan: scan, created_at: 1.day.ago)
+    context 'when a scan has no computed ASR' do
+      before { scan_with_asr(name: 'No ASR', asr: nil, created_at: 1.day.ago) }
 
-        create(:probe_result, report: report1, passed: 8, total: 10) # 80%
-        create(:probe_result, report: report2, passed: 6, total: 10) # 60%
-        create(:probe_result, report: report3, passed: 9, total: 10) # 90%
-
-        # Create a non-completed report that should be excluded
-        incomplete_report = create(:report, :running, target: target1, scan: scan, created_at: 4.days.ago)
-        create(:probe_result, report: incomplete_report, passed: 3, total: 10) # 30%
-      end
-
-      it 'returns data for all available completed reports' do
+      it 'reports 0' do
         result = described_class.new.call
-
-        expect(result[:models].length).to eq(3)
-        expect(result[:values].length).to eq(3)
-
-        expect(result[:models]).to eq([ 'Model 3', 'Model 2', 'Model 1' ])
-        expect(result[:values]).to eq([ 90, 60, 80 ])
+        expect(result).to eq([ { scan_name: 'No ASR', scan_id: Scan.last.id, asr: 0 } ])
       end
     end
 
-    context 'when there are no completed reports' do
-      before do
-        create(:report, :running, target: target1, scan: scan)
-        create(:report, :processing, target: target2, scan: scan)
-      end
+    context 'rounding' do
+      before { scan_with_asr(name: 'Fractional', asr: 62.4, created_at: 1.day.ago) }
 
-      it 'returns empty arrays' do
-        result = described_class.new.call
-
-        expect(result[:models]).to eq([])
-        expect(result[:values]).to eq([])
+      it 'rounds ASR to an integer' do
+        expect(described_class.new.call.first[:asr]).to eq(62)
       end
     end
 
-    context 'when reports have zero tests' do
+    context 'tenant isolation' do
       before do
-        report = create(:report, :completed, target: target1, scan: scan)
-        create(:probe_result, report: report, passed: 0, total: 0)
+        scan_with_asr(name: 'Mine', asr: 25, created_at: 1.day.ago)
+        other = create(:company)
+        ActsAsTenant.with_tenant(other) do
+          s = create(:complete_scan, company: other, name: 'Theirs', created_at: 1.day.ago)
+          s.update_column(:avg_successful_attacks, 80)
+        end
       end
 
-      it 'handles zero division correctly' do
+      it 'only returns the current tenant scans' do
         result = described_class.new.call
-
-        expect(result[:models]).to eq([ 'Model 1' ])
-        expect(result[:values]).to eq([ 0 ]) # Score should be 0 when total is 0
+        expect(result.map { |r| r[:scan_name] }).to eq([ 'Mine' ])
       end
     end
   end

--- a/spec/services/stats/top_five_attacks_data_spec.rb
+++ b/spec/services/stats/top_five_attacks_data_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe Stats::TopFiveAttacksData, type: :service do
+  describe '#call' do
+    let(:company) { create(:company) }
+    let(:scan) { create(:complete_scan, company: company) }
+    let(:report) { create(:report, :completed, company: company, scan: scan, target: create(:target, company: company)) }
+
+    before { ActsAsTenant.current_tenant = company }
+
+    def probe_result_for(name:, passed:, total:, rpt: report)
+      probe = create(:probe, name: name)
+      create(:probe_result, report: rpt, probe: probe, passed: passed, total: total)
+      probe
+    end
+
+    context 'ranking' do
+      before do
+        probe_result_for(name: 'attack.low',  passed: 1, total: 10) # 10%
+        probe_result_for(name: 'attack.high', passed: 9, total: 10) # 90%
+        probe_result_for(name: 'attack.mid',  passed: 5, total: 10) # 50%
+      end
+
+      it 'orders probes by ASR descending and rounds to integers' do
+        result = described_class.new(probe_scope: Probe.all).call
+
+        expect(result.map { |r| r[:probe_name] }).to eq([ 'attack.high', 'attack.mid', 'attack.low' ])
+        expect(result.map { |r| r[:asr] }).to eq([ 90, 50, 10 ])
+        expect(result.first[:probe_id]).to be_present
+      end
+    end
+
+    context 'with more than five probes' do
+      before { (1..6).each { |i| probe_result_for(name: "attack.#{i}", passed: i, total: 10) } }
+
+      it 'limits to five' do
+        expect(described_class.new(probe_scope: Probe.all).call.length).to eq(5)
+      end
+    end
+
+    context 'tie-break on volume' do
+      before do
+        probe_result_for(name: 'attack.small', passed: 1, total: 1)   # 100%, total 1
+        probe_result_for(name: 'attack.big',   passed: 10, total: 10) # 100%, total 10
+      end
+
+      it 'orders equal-ASR probes by total descending' do
+        result = described_class.new(probe_scope: Probe.all).call
+        expect(result.map { |r| r[:probe_name] }).to eq([ 'attack.big', 'attack.small' ])
+      end
+    end
+
+    context 'probes with zero total' do
+      before do
+        probe_result_for(name: 'attack.zero', passed: 0, total: 0)
+        probe_result_for(name: 'attack.real', passed: 4, total: 10)
+      end
+
+      it 'excludes probes with no tests' do
+        result = described_class.new(probe_scope: Probe.all).call
+        expect(result.map { |r| r[:probe_name] }).to eq([ 'attack.real' ])
+      end
+    end
+
+    context 'non-completed reports' do
+      before do
+        probe_result_for(name: 'attack.visible', passed: 5, total: 10)
+        failed = create(:report, :failed, company: company, scan: scan, target: create(:target, company: company))
+        probe_result_for(name: 'attack.failed', passed: 9, total: 10, rpt: failed)
+      end
+
+      it 'excludes results from failed/incomplete reports' do
+        result = described_class.new(probe_scope: Probe.all).call
+        expect(result.map { |r| r[:probe_name] }).to eq([ 'attack.visible' ])
+      end
+    end
+
+    context 'probe_scope filtering' do
+      before do
+        @included = probe_result_for(name: 'attack.included', passed: 8, total: 10)
+        probe_result_for(name: 'attack.excluded', passed: 9, total: 10)
+      end
+
+      it 'only counts probes within the provided scope' do
+        result = described_class.new(probe_scope: Probe.where(id: @included.id)).call
+        expect(result.map { |r| r[:probe_name] }).to eq([ 'attack.included' ])
+      end
+    end
+
+    context 'tenant isolation' do
+      before do
+        probe_result_for(name: 'attack.mine', passed: 5, total: 10)
+        other = create(:company)
+        ActsAsTenant.with_tenant(other) do
+          oscan = create(:complete_scan, company: other)
+          orpt = create(:report, :completed, company: other, scan: oscan, target: create(:target, company: other))
+          op = create(:probe, name: 'attack.theirs')
+          create(:probe_result, report: orpt, probe: op, passed: 9, total: 10)
+        end
+      end
+
+      it 'only aggregates the current tenant reports' do
+        result = described_class.new(probe_scope: Probe.all).call
+        expect(result.map { |r| r[:probe_name] }).to eq([ 'attack.mine' ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Port of the private scanner dashboard tiles. Two server-rendered list tiles (no ECharts/JSON/JS):

- **Last Five Scans** — repurposes the old target-labeled bar chart into a list of the 5 most recent scans: scan name (links to the scan) + color-coded ASR badge (`Scan#avg_successful_attacks`). Removes the dead `last_five_scans_data` endpoint + `initLastFiveScanScores` JS.
- **Top Five Most Successful Attacks** — new `Stats::TopFiveAttacksData`: top 5 probes by ASR for the tenant, scoped to `completed` reports.

Row 2 widened to `lg:grid-cols-4`.

Adapted for ai-scanner: no `customer_visible`/`validation_run` (Last-5 uses `Scan.order(...)`, Top-5 uses `Report.completed`); tenant isolation via `acts_as_tenant`. Verified with a headed agent-browser E2E.

Test plan:
- [x] Service specs + controller specs + dashboard_stats spec — 50 examples, 0 failures
- [x] `npm run test:js`, Brakeman, RuboCop clean
- [x] Headed E2E (both tiles render; Top-5 shows correct ranked ASR)
- [ ] CI green