### PR TITLE
fix(dev): keep dev container alive when tailwind --watch can't start

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,6 @@
 web: env RUBY_DEBUG_OPEN=true RUBY_YJIT_ENABLE=1 bin/rails server -p $PORT -b '0.0.0.0'
-css: yarn build:css --watch
+# css: tailwind --watch, but fall back to a one-time build + idle when the watcher
+# can't start (tailwind v4 oxide throws "Bad file descriptor" over the macOS Docker
+# bind mount). Without the fallback the css process exits and foreman tears down the
+# whole dev container. On Linux/CI the watcher runs normally and the fallback is never hit.
+css: yarn build:css --watch || { yarn build:css; exec tail -f /dev/null; }


### PR DESCRIPTION
Parity with the private scanner. `docker compose -f docker-compose.dev.yml up` crash-loops on macOS: tailwind v4's oxide file-watcher throws `[Error: Bad file descriptor]` over the Docker bind mount, the `css` process exits, and foreman tears down the whole container.

Fix: the `css` Procfile entry falls back to a one-time build + idle when `--watch` exits non-zero, so the container stays up. On Linux/CI the watcher runs normally and the fallback is never reached. Verified on the private scanner (identical Procfile/tailwind): `up` now yields `status=running restarts=0`, web listening, http 200, CSS built once.

Test plan:
- [ ] CI green