### PR TITLE
fix(targets): guard non-object json_config in provider-host inference

### DIFF
--- a/app/helpers/targets_helper.rb
+++ b/app/helpers/targets_helper.rb
@@ -294,7 +294,10 @@ module TargetsHelper
 
   def rest_config_host(json_config)
     parsed = JSON.parse(json_config.to_s)
-    URI.parse(parsed.dig("rest", "RestGenerator", "uri").to_s).host.to_s
+    rest = parsed.is_a?(Hash) ? parsed["rest"] : nil
+    generator = rest.is_a?(Hash) ? rest["RestGenerator"] : nil
+    uri = generator.is_a?(Hash) ? generator["uri"] : nil
+    URI.parse(uri.to_s).host.to_s
   rescue JSON::ParserError, URI::Error
     ""
   end

--- a/spec/helpers/targets_helper_spec.rb
+++ b/spec/helpers/targets_helper_spec.rb
@@ -386,6 +386,13 @@ RSpec.describe TargetsHelper, type: :helper do
                               json_config: { rest: { RestGenerator: { uri: 'https://api.anthropic.com.evil.test/v1/messages' } } }.to_json)
       expect(helper.infer_provider_from_target(target)).to eq('custom')
     end
+
+    it 'falls back to custom for non-object or malformed json_config without raising' do
+      [ '[1, 2, 3]', '"just a string"', '42', '{"rest": "not-an-object"}', '{}' ].each do |cfg|
+        target = build(:target, model_type: 'RestGenerator', model: 'claude-x', json_config: cfg)
+        expect(helper.infer_provider_from_target(target)).to eq('custom')
+      end
+    end
   end
 
   describe 'PROVIDER_TEMPLATES' do


### PR DESCRIPTION
Parity with the private scanner. `rest_config_host` called `parsed.dig(...)` without checking `parsed` is a Hash — a valid-JSON-but-non-object `json_config` (`[1,2,3]`, a bare string/number, or `{"rest":"x"}`) would raise `TypeError`/`NoMethodError` (not caught by the `JSON::ParserError`/`URI::Error` rescue) → 500 on the target edit form. Now guards each nesting level is a Hash and falls back to `custom`. Added a spec covering array/string/number/malformed-nesting/empty configs.

Test plan:
- [x] Helper spec (incl. non-object/malformed cases) — 47 examples, 0 failures on the identical scanner change
- [ ] CI green (rspec + CodeQL)