### PR TITLE
feat(nav): clarify Target → Scan → Report in the sidebar

### DIFF
--- a/app/lib/admin_menu.rb
+++ b/app/lib/admin_menu.rb
@@ -2,7 +2,7 @@
 
 # AdminMenu provides a menu system for the admin interface.
 class AdminMenu
-  MenuItem = Struct.new(:id, :label_text, :url_path, :icon_path, :priority, :children, :html_opts, keyword_init: true) do
+  MenuItem = Struct.new(:id, :label_text, :url_path, :icon_path, :priority, :subtitle, :children, :html_opts, keyword_init: true) do
     def label(_context = nil)
       label_text
     end
@@ -83,21 +83,24 @@ class AdminMenu
         label_text: "Reports",
         url_path: "/reports",
         icon_path: "menu/reports.svg",
-        priority: 2
+        subtitle: "findings from each scan",
+        priority: 4
       ),
       MenuItem.new(
         id: "targets",
         label_text: "Targets",
         url_path: "/targets",
         icon_path: "menu/targets.svg",
-        priority: 3
+        subtitle: "the AI models you test",
+        priority: 2
       ),
       MenuItem.new(
         id: "scans",
         label_text: "Scans",
         url_path: "/scans",
         icon_path: "menu/scans.svg",
-        priority: 4
+        subtitle: "pick probes & attack a target",
+        priority: 3
       ),
       MenuItem.new(
         id: "probes",

--- a/app/views/layouts/partials/_main_navigation.html.erb
+++ b/app/views/layouts/partials/_main_navigation.html.erb
@@ -49,7 +49,14 @@
             <% if item.icon.present? %>
               <%= image_tag item.icon, class: "h-5 w-5 nav-item-icon flex-shrink-0 #{is_current ? 'nav-icon-active' : ''}", alt: "" %>
             <% end %>
-            <%= item.label(self) %>
+            <% if item.respond_to?(:subtitle) && item.subtitle.present? %>
+              <span class="flex flex-col min-w-0">
+                <span><%= item.label(self) %></span>
+                <span class="text-xs leading-tight text-zinc-400 font-normal"><%= item.subtitle %></span>
+              </span>
+            <% else %>
+              <%= item.label(self) %>
+            <% end %>
           <% end %>
         <% else %>
           <%= item.label(self) %>

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe Admin::DashboardController, type: :controller do
 
         assert_select "a[href=?]", probe_path(probe.id), text: probe.name
       end
+
+      it "renders explanatory subtitles for the core nav items" do
+        get :index
+
+        expect(response.body).to include("the AI models you test")
+        expect(response.body).to include("pick probes &amp; attack a target") # & is HTML-escaped on render
+        expect(response.body).to include("findings from each scan")
+      end
     end
 
     context "when company has no scans" do

--- a/spec/lib/admin_menu_spec.rb
+++ b/spec/lib/admin_menu_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AdminMenu do
+  # Build with nil context: context-gated items (settings/integrations/companies)
+  # compact out, leaving the always-present items including the core trio.
+  let(:items) { described_class.build.items }
+
+  def find_item(id)
+    items.find { |i| i.id == id }
+  end
+
+  it "gives the core trio explanatory subtitles (V2 copy)" do
+    expect(find_item("targets").subtitle).to eq("the AI models you test")
+    expect(find_item("scans").subtitle).to eq("pick probes & attack a target")
+    expect(find_item("reports").subtitle).to eq("findings from each scan")
+  end
+
+  it "leaves non-core items without a subtitle" do
+    expect(find_item("dashboard").subtitle).to be_nil
+    expect(find_item("probes").subtitle).to be_nil
+  end
+
+  it "orders the nav Targets -> Scans -> Reports" do
+    ids = items.map(&:id)
+    expect(ids.index("targets")).to be < ids.index("scans")
+    expect(ids.index("scans")).to be < ids.index("reports")
+  end
+end


### PR DESCRIPTION
Adds one-line explanatory subtitles to the three core sidebar items (Targets — *the AI models you test*, Scans — *pick probes & attack a target*, Reports — *findings from each scan*) and reorders them so the workflow reads top-to-bottom (**Targets → Scans → Reports**). Nav-only; no route/model changes. Port of scanner #550.

## Test plan
- [ ] `rspec spec/lib/admin_menu_spec.rb spec/controllers/admin/dashboard_controller_spec.rb`
- [ ] CI green (RSpec + CodeQL)