### PR TITLE
fix(dashboard): open Top Five attack probe links in the same tab

### DIFF
--- a/app/views/admin/dashboard/_top_five_attacks_card.html.erb
+++ b/app/views/admin/dashboard/_top_five_attacks_card.html.erb
@@ -12,8 +12,7 @@
           <li class="flex items-center justify-between gap-3 py-2">
             <%= link_to attack[:probe_name], probe_path(attack[:probe_id]),
                 class: "text-sm text-white truncate min-w-0 hover:text-white/80 no-underline transition-colors",
-                title: attack[:probe_name],
-                target: "_blank" %>
+                title: attack[:probe_name] %>
             <span class="text-sm font-semibold shrink-0 <%= asr_color_class(attack[:asr]) %>"><%= attack[:asr] %>%</span>
           </li>
         <% end %>

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe Admin::DashboardController, type: :controller do
         get :index
 
         assert_select "a[href=?]", probe_path(probe.id), text: probe.name
+        # Opens in the same tab (no target="_blank")
+        assert_select "a[href=?][target=?]", probe_path(probe.id), "_blank", count: 0
       end
 
       it "renders explanatory subtitles for the core nav items" do


### PR DESCRIPTION
Drops `target="_blank"` from the Top Five Most Successful Attacks probe links so they navigate in the same tab. Port of scanner #551.