### PR TITLE
fix(reports): report-row click opens the report + clearer table actions

### DIFF
--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -62,12 +62,15 @@
   columns += [
     {
       key: :scan_name,
-      label: "Scan",
+      label: "Report",
       type: :custom,
       sortable: false,
       sort_key: :scan_name,
       render: ->(report) {
-        link_to report.scan.name, scan_path(report.scan), class: "text-sm text-primary hover:underline"
+        safe_join([
+          link_to(report.scan.name, report_path(report), class: "text-sm text-primary hover:underline"),
+          content_tag(:div, link_to("Scan ↗", scan_path(report.scan), class: "text-xs text-textMuted hover:underline"), class: "mt-0.5")
+        ])
       }
     },
     {
@@ -142,38 +145,29 @@
       type: :custom,
       align: :right,
       render: ->(report) {
-        content_tag(:div, class: "flex items-center justify-end gap-3") do
-          links = []
+        links = []
 
-          # Stop/Cancel button (for running states)
-          if report.running? || report.pending? || report.starting? || report.interrupted?
-            if report.interrupted?
-              links << button_to(stop_report_path(report), method: :post, data: { turbo_confirm: "Are you sure you want to cancel this retry?" }, class: "text-actionButton hover:text-textMuted transition-colors cursor-pointer", title: "Cancel Retry", form: { class: "inline-flex items-center" }) do
-                content_tag(:span, "", class: "icon icon-sm icon-cancel")
-              end
-            else
-              links << button_to(stop_report_path(report), method: :post, data: { turbo_confirm: "Are you sure you want to stop this scan?" }, class: "text-actionButton hover:text-textMuted transition-colors cursor-pointer", title: "Stop Scan", form: { class: "inline-flex items-center" }) do
-                content_tag(:span, "", class: "icon icon-sm icon-stop")
-              end
+        if report.running? || report.pending? || report.starting? || report.interrupted?
+          if report.interrupted?
+            links << button_to(stop_report_path(report), method: :post, data: { turbo_confirm: "Are you sure you want to cancel this retry?" }, class: "inline-flex items-center gap-1 text-xs text-actionButton hover:text-textMuted transition-colors cursor-pointer", form: { class: "inline-flex items-center" }) do
+              safe_join([content_tag(:span, "", class: "icon icon-sm icon-cancel"), "Cancel retry"])
             end
           else
-            links << content_tag(:span, "", class: "w-4")
-          end
-
-          # View Overview (always visible)
-          links << link_to(report_path(report), class: "text-actionButton hover:text-textMuted transition-colors cursor-pointer", title: "View Overview") do
-            content_tag(:span, "", class: "icon icon-sm icon-view")
-          end
-
-          # View Detailed Report (completed only, opens in new tab)
-          if report.completed?
-            links << link_to(report_detail_path(report), target: "_blank", class: "text-actionButton hover:text-textMuted transition-colors cursor-pointer", title: "View Detailed Report") do
-              content_tag(:span, "", class: "icon icon-sm icon-external-link")
+            links << button_to(stop_report_path(report), method: :post, data: { turbo_confirm: "Are you sure you want to stop this scan?" }, class: "inline-flex items-center gap-1 text-xs text-actionButton hover:text-textMuted transition-colors cursor-pointer", form: { class: "inline-flex items-center" }) do
+              safe_join([content_tag(:span, "", class: "icon icon-sm icon-stop"), "Stop"])
             end
-          else
-            links << content_tag(:span, "", class: "w-4")
           end
+        end
 
+        if report.completed?
+          links << link_to(report_detail_path(report), target: "_blank", class: "inline-flex items-center gap-1 text-xs text-actionButton hover:text-textMuted transition-colors cursor-pointer") do
+            safe_join([content_tag(:span, "", class: "icon icon-sm icon-external-link"), "Details"])
+          end
+        end
+
+        next "" if links.empty?
+
+        content_tag(:div, class: "flex items-center justify-end gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity") do
           safe_join(links)
         end
       }

--- a/app/views/admin/scans/index.html.erb
+++ b/app/views/admin/scans/index.html.erb
@@ -163,13 +163,13 @@
         type: :custom,
         align: :right,
         render: ->(scan) {
-          content_tag(:div, class: "flex items-center justify-end gap-3") do
+          content_tag(:div, class: "flex items-center justify-end gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity") do
             safe_join([
-              link_to(reports_path(q: { scan_id_eq: scan.id }), class: "text-actionButton hover:text-textMuted transition-colors", title: "View Reports") do
-                content_tag(:span, "", class: "icon icon-sm icon-view")
+              link_to(reports_path(q: { scan_id_eq: scan.id }), class: "inline-flex items-center gap-1 text-xs text-actionButton hover:text-textMuted transition-colors") do
+                safe_join([content_tag(:span, "", class: "icon icon-sm icon-view"), "Reports"])
               end,
-              button_to(rerun_scan_path(scan), method: :post, form: { data: { turbo: true }, class: "inline-flex items-center" }, class: "text-actionButton hover:text-textMuted transition-colors cursor-pointer", title: "Rerun Scan") do
-                content_tag(:span, "", class: "icon icon-sm icon-restore")
+              button_to(rerun_scan_path(scan), method: :post, form: { data: { turbo: true }, class: "inline-flex items-center" }, class: "inline-flex items-center gap-1 text-xs text-actionButton hover:text-textMuted transition-colors cursor-pointer") do
+                safe_join([content_tag(:span, "", class: "icon icon-sm icon-restore"), "Rerun"])
               end
             ])
           end

--- a/app/views/shared/table/_table_content.html.erb
+++ b/app/views/shared/table/_table_content.html.erb
@@ -29,7 +29,7 @@
       </thead>
       <tbody class="bg-backgroundPrimary divide-y divide-borderPrimary">
         <% collection.each do |item| %>
-          <tr class="hover:bg-zinc-800/50 transition-colors">
+          <tr class="group hover:bg-zinc-800/50 transition-colors">
             <% if has_batch_actions %>
               <td class="px-4 py-3">
                 <%= check_box_tag "ids[]", item.id, false,

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -19,6 +19,30 @@ RSpec.describe Admin::ReportsController, type: :controller do
     ActsAsTenant.current_tenant = company
   end
 
+  describe "GET #index" do
+    it "links the report name to the report overview, not the scan" do
+      get :index
+
+      assert_select "a[href=?]", report_path(report), text: report.scan.name
+      assert_select "a[href=?]", scan_path(report.scan)
+      assert_select "th", text: /Report/
+    end
+
+    it "labels the report action buttons" do
+      get :index
+
+      assert_select "a[href=?]", report_detail_path(report), text: /Details/
+    end
+
+    it "labels the Stop action on a running report" do
+      ActsAsTenant.with_tenant(company) { report.update!(status: :running) }
+
+      get :index
+
+      assert_select "form[action=?] button", stop_report_path(report), text: /Stop/
+    end
+  end
+
   describe "GET #show" do
     it "returns success" do
       get :show, params: { id: report.id }

--- a/spec/controllers/admin/scans_controller_spec.rb
+++ b/spec/controllers/admin/scans_controller_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe Admin::ScansController, type: :controller do
       get :index, params: { scope: "all" }
       expect(response).to have_http_status(:success)
     end
+
+    it "renders labeled, hover-reveal action buttons" do
+      get :index, params: { scope: "all" }
+
+      assert_select "a[href=?]", reports_path(q: { scan_id_eq: scan.id }), text: /Reports/
+      assert_select "tbody tr.group"
+      expect(response.body).to include("group-hover:opacity-100")
+      expect(response.body).to include("group-focus-within:opacity-100")
+    end
   end
 
   describe "GET #new" do


### PR DESCRIPTION
Reports list name column now opens the report (admin Overview, same tab) with a muted "Scan ↗" link; Reports/Scans action columns become labeled, keyboard-accessible hover-reveal buttons (`group` on the shared table row + `opacity-0 group-hover/group-focus-within:opacity-100`). View-only; no route/model changes. Port of scanner #553.

## Test plan
- [ ] `rspec spec/controllers/admin/reports_controller_spec.rb spec/controllers/admin/scans_controller_spec.rb`
- [ ] CI green (RSpec + CodeQL)