### PR TITLE
fix(detectors): higher-level category labels (drop specific examples)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,10 +36,10 @@ en:
   detectors:
     names:
       MitigationBypass: "Generic Mitigation Bypass Checks"
-      CrystalMethScore: "Illicit Substances: Crystal Meth"
-      NerveAgent: "Harmful Substances: Nerve Agent"
-      CopyRightScoreHarryPotterChapterOne: "Copyright Violation: Harry Potter"
-      TiananmenSquareCensorshipBypass: "Censorship Bypass: Tiananmen Square"
+      CrystalMethScore: "Illicit Substances"
+      NerveAgent: "Harmful Substances"
+      CopyRightScoreHarryPotterChapterOne: "Copyright Violation"
+      TiananmenSquareCensorshipBypass: "Censorship Bypass"
   flash:
     actions:
       destroy:

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Admin::ReportsController, type: :controller do
 
       detector_stat_headers = detector_stats_section.css("th").map { |header| header.text.squish }
 
-      expect(detector_stats_section.text).to include("Illicit Substances: Crystal Meth")
+      expect(detector_stats_section.text).to include("Illicit Substances")
       expect(detector_stats_section.text).to include("Generic Mitigation Bypass Checks")
       expect(detector_stat_headers).to eq([ "Detector", "Attack Success Rate", "Successful Attacks" ])
       expect(detector_stats_section.text).not_to include("Max Score")

--- a/spec/i18n/detector_names_spec.rb
+++ b/spec/i18n/detector_names_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "detectors.names i18n labels" do
+  it "uses higher-level category labels without the specific example" do
+    expect(I18n.t("detectors.names.CrystalMethScore")).to eq("Illicit Substances")
+    expect(I18n.t("detectors.names.CopyRightScoreHarryPotterChapterOne")).to eq("Copyright Violation")
+    expect(I18n.t("detectors.names.NerveAgent")).to eq("Harmful Substances")
+    expect(I18n.t("detectors.names.TiananmenSquareCensorshipBypass")).to eq("Censorship Bypass")
+  end
+end


### PR DESCRIPTION
Detector category labels drop their specific example (Crystal Meth / Harry Potter / Nerve Agent / Tiananmen) so they read as higher-level categories in the UI, report, and PDF. Display-only i18n change. Port of scanner #554.

## Test plan
- [ ] `rspec spec/i18n/detector_names_spec.rb spec/controllers/admin/reports_controller_spec.rb`
- [ ] CI green (RSpec + CodeQL)