### PR TITLE
fix(variants): ghost Threat Variants by actual variant data, not detector name

### DIFF
--- a/app/helpers/scan_helper.rb
+++ b/app/helpers/scan_helper.rb
@@ -18,6 +18,12 @@ module ScanHelper
     end
   end
 
+  # Probe ids that actually have threat variants — loaded once per request so the
+  # probe-selection form (≈935 probes) can flag variant-eligibility without N+1.
+  def variant_eligible_probe_ids
+    @variant_eligible_probe_ids ||= ThreatVariant.distinct.pluck(:probe_id).to_set
+  end
+
   private
 
   def extract_rule_type(recurrence)

--- a/app/models/detector.rb
+++ b/app/models/detector.rb
@@ -1,10 +1,5 @@
 class Detector < ApplicationRecord
   MITIGATION_BYPASS_DETECTOR_SUFFIX = "MitigationBypass".freeze
-  VARIANT_ELIGIBLE_DETECTOR_SUFFIXES = [
-    MITIGATION_BYPASS_DETECTOR_SUFFIX,
-    "CrystalMethScore",
-    "CopyRightScoreHarryPotterChapterOne"
-  ].freeze
 
   has_many :detector_results, dependent: :destroy
   has_many :reports, through: :detector_results
@@ -34,12 +29,6 @@ class Detector < ApplicationRecord
 
   def mitigation_bypass?
     name&.end_with?(MITIGATION_BYPASS_DETECTOR_SUFFIX)
-  end
-
-  def variant_eligible?
-    return false if name.blank?
-
-    VARIANT_ELIGIBLE_DETECTOR_SUFFIXES.any? { |suffix| name.end_with?(suffix) }
   end
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/probe.rb
+++ b/app/models/probe.rb
@@ -65,6 +65,6 @@ class Probe < ApplicationRecord
   end
 
   def variant_eligible?
-    detector&.variant_eligible? || false
+    threat_variants.exists?
   end
 end

--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -277,12 +277,9 @@ class Scan < ApplicationRecord
 
     def variants_require_eligible_probe
       return if threat_variant_subindustries.empty?
+      return if ThreatVariant.where(probe_id: probe_ids).exists?
 
-      probe_records = probes.to_a
-      ActiveRecord::Associations::Preloader.new(records: probe_records, associations: [ :detector ]).call
-      return if probe_records.any?(&:variant_eligible?)
-
-      errors.add(:base, "Threat variants require at least one copyright or illicit-substance probe")
+      errors.add(:base, "Threat variants require at least one probe that supports variants")
     end
 
     def generate_uuid

--- a/app/views/admin/scans/_probe_category_item.html.erb
+++ b/app/views/admin/scans/_probe_category_item.html.erb
@@ -115,7 +115,7 @@
                   "detector-id": probe.detector_id,
                   "category-id": category_id,
                   "input-tokens": probe.input_tokens,
-                  "variant-eligible": probe.variant_eligible?,
+                  "variant-eligible": variant_eligible_probe_ids.include?(probe.id),
                   "probe-category-target": "probeCheckbox",
                   action: "change->probe-category#updateCategoryState"
                 } %>

--- a/app/views/admin/scans/_threat_variants.html.erb
+++ b/app/views/admin/scans/_threat_variants.html.erb
@@ -12,10 +12,10 @@
       <span class="icon icon-md icon-info text-amber-400 shrink-0 mt-0.5"></span>
       <div class="flex-1">
         <h4 class="text-sm font-medium text-contentPrimary mb-1">
-          Threat variants require a copyright or illicit-substance probe.
+          Threat variants require a probe that supports variants.
         </h4>
         <p class="text-sm text-contentSecondary">
-          Select at least one copyright or illicit-substance probe above to enable industry-specific variants.
+          Select at least one probe that supports threat variants above to enable industry-specific variants.
         </p>
       </div>
       <button type="button"

--- a/spec/helpers/scan_helper_spec.rb
+++ b/spec/helpers/scan_helper_spec.rb
@@ -161,6 +161,20 @@ RSpec.describe ScanHelper, type: :helper do
     end
   end
 
+  describe '#variant_eligible_probe_ids' do
+    it 'returns the ids of probes that have threat variants, memoized' do
+      with_variant = create(:probe)
+      without_variant = create(:probe)
+      create(:threat_variant, probe: with_variant)
+
+      expect(ThreatVariant).to receive(:distinct).once.and_call_original
+
+      expect(helper.variant_eligible_probe_ids).to include(with_variant.id)
+      expect(helper.variant_eligible_probe_ids).not_to include(without_variant.id)
+      expect(helper.variant_eligible_probe_ids).to be_a(Set)
+    end
+  end
+
   describe '#detector_color' do
     it 'returns red for Crystal Meth detector' do
       expect(helper.send(:detector_color, "CrystalMethScore")).to eq("red")

--- a/spec/models/detector_spec.rb
+++ b/spec/models/detector_spec.rb
@@ -108,24 +108,4 @@ RSpec.describe Detector, type: :model do
       expect(detector.probes.count).to eq(2)
     end
   end
-
-  describe '#variant_eligible?' do
-    it 'is true for MitigationBypass detector names' do
-      expect(Detector.new(name: '0din.MitigationBypass').variant_eligible?).to be true
-      expect(Detector.new(name: 'mitigation.MitigationBypass').variant_eligible?).to be true
-    end
-
-    it 'is true for CrystalMethScore detector names' do
-      expect(Detector.new(name: '0din.CrystalMethScore').variant_eligible?).to be true
-    end
-
-    it 'is true for CopyRightScoreHarryPotterChapterOne detector names' do
-      expect(Detector.new(name: '0din.CopyRightScoreHarryPotterChapterOne').variant_eligible?).to be true
-    end
-
-    it 'is false for other detector names' do
-      expect(Detector.new(name: '0din.PromptInjection').variant_eligible?).to be false
-      expect(Detector.new(name: nil).variant_eligible?).to be false
-    end
-  end
 end

--- a/spec/models/probe_spec.rb
+++ b/spec/models/probe_spec.rb
@@ -66,23 +66,14 @@ RSpec.describe Probe, type: :model do
   end
 
   describe '#variant_eligible?' do
-    it 'is true when the detector is variant-eligible' do
-      detector = build(:detector, name: '0din.MitigationBypass')
-      probe = build(:probe, detector: detector)
-
+    it 'is true when the probe has a threat variant' do
+      probe = create(:probe)
+      create(:threat_variant, probe: probe)
       expect(probe.variant_eligible?).to be true
     end
 
-    it 'is false when the detector is not variant-eligible' do
-      detector = build(:detector, name: '0din.PromptInjection')
-      probe = build(:probe, detector: detector)
-
-      expect(probe.variant_eligible?).to be false
-    end
-
-    it 'is false when there is no detector' do
-      probe = build(:probe, detector: nil)
-
+    it 'is false when the probe has no threat variant' do
+      probe = create(:probe)
       expect(probe.variant_eligible?).to be false
     end
   end

--- a/spec/models/scan_spec.rb
+++ b/spec/models/scan_spec.rb
@@ -105,13 +105,13 @@ RSpec.describe Scan, type: :model do
       allow(scan).to receive(:update_next_scheduled_run)
 
       expect(scan).not_to be_valid
-      expect(scan.errors[:base]).to include('Threat variants require at least one copyright or illicit-substance probe')
+      expect(scan.errors[:base]).to include('Threat variants require at least one probe that supports variants')
     end
 
     it 'is valid when at least one selected probe is variant-eligible' do
-      eligible_detector = create(:detector, name: '0din.MitigationBypass')
-      eligible_probe = create(:probe, detector: eligible_detector)
+      eligible_probe = create(:probe)
       subindustry = create(:threat_variant_subindustry)
+      create(:threat_variant, probe: eligible_probe, threat_variant_subindustry: subindustry)
       scan = Scan.new(name: 'Variant With Eligible Probe', uuid: SecureRandom.uuid, company: company)
       scan.targets = [ create(:target, company: company) ]
       scan.probes = [ eligible_probe ]


### PR DESCRIPTION
Ghosts the Threat Variants section based on whether the selected probes actually have `ThreatVariant` rows, instead of inferring eligibility from detector class names. The old heuristic over-included probes whose detectors merely *looked* variant-eligible (e.g. MitigationBypass) but had no variants, and excluded variant-bearing probes that didn't match a name suffix.

## Changes
- `Probe#variant_eligible?` → `threat_variants.exists?`
- `Scan` validation checks for real `ThreatVariant` rows on the selected probes
- New `ScanHelper#variant_eligible_probe_ids` (single query, memoized) drives the `data-variant-eligible` flag on probe checkboxes
- Removed the detector-name heuristic (`Detector#variant_eligible?` + suffix constant)
- Updated ghost-notice copy

## Test plan
- [ ] CI green (RSpec, RuboCop, Brakeman, CodeQL)
- [x] Probe/Scan/ScanHelper specs updated to assert variant-data-based eligibility