### PR TITLE
ci(release): cut releases on-demand only, batch commits since last tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview the next version + notes without releasing (no tag, no Docker build)"
+        type: boolean
+        default: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -25,6 +28,7 @@ jobs:
 
   release:
     needs: ci
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       released: ${{ steps.semantic.outputs.released }}
@@ -47,7 +51,7 @@ jobs:
         id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: npx semantic-release${{ inputs.dry_run && ' --dry-run' || '' }}
 
   build-amd64:
     needs: release
@@ -151,6 +155,7 @@ jobs:
 
   merge:
     needs: [release, build-amd64, build-arm64]
+    if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Download digests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,8 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/): `<type>(<sc
 - `security` / `perf` — triggers patch release
 - `docs` / `refactor` / `test` / `style` / `chore` / `ci` — no release
 
+> Commit types determine the **version bump** when a release is cut — they do **not** auto-release on merge. A maintainer cuts a release on demand via **Actions → Release → Run workflow** (on `main`), which bundles every change since the last release.
+
 Keep subject lines <= 72 characters. Include a body when more context is needed.
 
 **Examples:**


### PR DESCRIPTION
Switches the **Release** workflow from per-push-to-`main` to **manual `workflow_dispatch` only**, so one run batches every releasable commit since the last tag into a single GitHub Release + git tag + multi-arch Docker build. This collapses the release-per-PR noise (25 releases in 30 days; 16 in a single 2-day burst).

CI quality gates are unchanged — `ci.yml` triggers independently on PRs and pushes, so tests/RuboCop/Brakeman still run on every PR. Removing the push trigger also drops the redundant second CI run that fired on each `main` push.

## Changes (single workflow file + one doc line)
- `release.yml` trigger → `workflow_dispatch` only, with an opt-in `dry_run` boolean input (default false) that runs `semantic-release --dry-run` to preview the next version/notes without releasing.
- `release` job guarded to `main` (`if: github.ref == 'refs/heads/main'`) so a dispatch from `develop` can't cut an `rc` prerelease.
- `merge` job guarded with `if: needs.release.outputs.released == 'true'` (explicit skip on no-op/dry runs).
- `CONTRIBUTING.md`: note that releases are now on-demand, not automatic on merge.

## How to cut a release after this
Actions → **Release** → **Run workflow** on `main` (optionally check **dry_run** first to preview).

## Test plan
- [ ] PR CI green (proves `ci.yml` still gates PRs; Release workflow absent from PR checks)
- [ ] Post-merge: merging to `main` does **not** trigger a Release run
- [ ] `dry_run=true` dispatch previews version/notes with no tag/release/build