### PR TITLE
fix(scans): category title toggles expand/collapse, select-all confined to checkbox

### DIFF
--- a/app/javascript/controllers/probe_category_controller.js
+++ b/app/javascript/controllers/probe_category_controller.js
@@ -57,7 +57,7 @@ export default class extends Controller {
   }
 
   toggleCategory(event) {
-    if (event.target.type === 'checkbox' || event.target.tagName === 'LABEL') {
+    if (event.target.type === 'checkbox') {
       return
     }
 

--- a/app/views/admin/scans/_probe_category_item.html.erb
+++ b/app/views/admin/scans/_probe_category_item.html.erb
@@ -29,6 +29,7 @@
               "category-id": category_id,
               action: "change->probe-category#selectCategory"
             },
+            title: "Select all #{category_name} probes",
             "aria-label": "Select all #{category_name} probes" %>
       </div>
 
@@ -36,9 +37,9 @@
       <% unless is_nested %>
         <span class="icon icon-md <%= icon %> text-<%= color %>-500"></span>
       <% end %>
-      <label for="category_<%= category_id %>" class="text-<%= is_nested ? 'xs' : 'sm' %> font-medium text-contentPrimary cursor-pointer">
+      <span class="text-<%= is_nested ? 'xs' : 'sm' %> font-medium text-contentPrimary cursor-pointer">
         <%= category_name %>
-      </label>
+      </span>
 
       <!-- Selection count badge -->
       <span class="inline-flex items-center px-2.5 py-0.5 rounded text-xs font-medium bg-zinc-700/50 text-contentTertiary border border-borderPrimary"

--- a/app/views/admin/scans/_probe_selection.html.erb
+++ b/app/views/admin/scans/_probe_selection.html.erb
@@ -108,14 +108,15 @@
                       "is-parent": "true",
                       action: "change->probe-category#selectCommunityParent"
                     },
+                    title: "Select all Community probes",
                     "aria-label": "Select all Community probes" %>
               </div>
 
               <!-- Category icon and label -->
               <span class="icon icon-md icon-globe text-contentSecondary"></span>
-              <label for="category_community_probes" class="text-sm font-medium text-contentPrimary cursor-pointer">
+              <span class="text-sm font-medium text-contentPrimary cursor-pointer">
                 Community Probes
-              </label>
+              </span>
 
               <!-- Selection count badge -->
               <span class="inline-flex items-center px-2.5 py-0.5 rounded text-xs font-medium bg-zinc-700/50 text-contentTertiary border border-borderPrimary"

--- a/script/tests/javascript_controller_tests.mjs
+++ b/script/tests/javascript_controller_tests.mjs
@@ -1377,6 +1377,64 @@ function testWebchatAutoDetectCurrentAuth() {
   assert.equal(malformed.currentAuth(), null)
 }
 
+function loadProbeCategoryController() {
+  const transformed = loadControllerSource(
+    "probe_category_controller.js",
+    "ProbeCategoryController"
+  )
+
+  const context = {
+    Controller: class {}
+  }
+
+  const ControllerClass = vm.runInNewContext(
+    `${transformed}\nProbeCategoryController`,
+    context
+  )
+
+  return { ControllerClass, context }
+}
+
+function testProbeCategoryToggleCategory() {
+  const { ControllerClass } = loadProbeCategoryController()
+  const controller = new ControllerClass()
+
+  const content = { dataset: { categoryId: "c1" }, style: {}, scrollHeight: 240 }
+  const chevron = { dataset: { categoryId: "c1" }, classList: classListWith() }
+  controller.contentTargets = [content]
+  controller.chevronTargets = [chevron]
+
+  let ariaExpanded = "false"
+  const header = {
+    dataset: { probeCategoryId: "c1" },
+    getAttribute() {
+      return ariaExpanded
+    },
+    setAttribute(_name, value) {
+      ariaExpanded = value
+    }
+  }
+
+  // Clicking the title (a SPAN) expands the category
+  controller.toggleCategory({ target: { tagName: "SPAN" }, currentTarget: header })
+  assert.equal(ariaExpanded, "true")
+  assert.equal(content.style.maxHeight, "240px")
+  assert.equal(chevron.classList.contains("rotate-180"), true)
+
+  // Clicking again collapses it
+  controller.toggleCategory({ target: { tagName: "SPAN" }, currentTarget: header })
+  assert.equal(ariaExpanded, "false")
+  assert.equal(content.style.maxHeight, "0px")
+
+  // Guard removed: a LABEL target must also toggle
+  controller.toggleCategory({ target: { tagName: "LABEL" }, currentTarget: header })
+  assert.equal(ariaExpanded, "true")
+
+  // The checkbox itself never toggles expand state
+  controller.toggleCategory({ target: { type: "checkbox", tagName: "INPUT" }, currentTarget: header })
+  assert.equal(ariaExpanded, "true")
+}
+
 await testDebugStreamLeaseController()
 testActivityStreamController()
 testDebugTabsController()
@@ -1389,4 +1447,5 @@ testWebchatAuthController()
 testTargetWizardRedactAuth()
 testTargetWizardSyncModel()
 testWebchatAutoDetectCurrentAuth()
+testProbeCategoryToggleCategory()
 console.log("JavaScript controller tests passed")


### PR DESCRIPTION
Port of 0din-ai/scanner#556.

## Bug
On the new-scan probe-selection screen, clicking a category **title** selected every probe in that category instead of expanding it — the title was a `<label for="category_<id>">` pointing at the select-all checkbox, so a title click toggled select-all via native label behavior, and `toggleCategory` bailed on `LABEL` targets so the title never expanded. Same pattern affected the Community-parent header.

## Fix
- Category titles → plain `<span>` (no `for`) in `_probe_category_item.html.erb` and the Community-parent header in `_probe_selection.html.erb`; title clicks now expand/collapse via the header's `toggleCategory`.
- Select-all confined to the category checkbox, which gains a hover `title=` tooltip.
- Removed the dead `LABEL` clause from `toggleCategory`'s guard.
- Selection logic, counts, badges, auto-update, tokens untouched.

## Test plan
- [x] JS controller test for `toggleCategory` (RED with old guard → GREEN after removal); `npm run test:js` passes
- [ ] CI green

Non-goal: header keyboard-a11y (`<div>` not `<button>`) is pre-existing.