### PR TITLE
feat(scans): pre-select the most-successful probes by default on a new scan

### DIFF
--- a/app/controllers/admin/scans_controller.rb
+++ b/app/controllers/admin/scans_controller.rb
@@ -55,6 +55,7 @@ module Admin
       authorize @scan
       @page_title = "New Scan"
       load_form_data
+      @default_probe_ids = Scans::DefaultProbeSelector.new(probe_scope: policy_scope(Probe).enabled).call
     end
 
     def create

--- a/app/services/scans/default_probe_selector.rb
+++ b/app/services/scans/default_probe_selector.rb
@@ -1,0 +1,29 @@
+module Scans
+  # Returns the ids of the probes most successful against the current tenant's
+  # own past targets, for pre-selecting on a new scan. Mirrors the dashboard
+  # Stats::TopFiveAttacksData aggregation, but returns a Set of probe ids,
+  # applies a minimum-attempts floor, and excludes custom probes.
+  class DefaultProbeSelector
+    DEFAULT_PROBE_COUNT = 10
+    MIN_ATTEMPTS = 5
+
+    def initialize(probe_scope: Probe.all, limit: DEFAULT_PROBE_COUNT, min_attempts: MIN_ATTEMPTS)
+      @probe_scope = probe_scope
+      @limit = limit
+      @min_attempts = min_attempts
+    end
+
+    def call
+      ProbeResult
+        .joins(:probe)
+        .where(report_id: Report.completed.select(:id))
+        .where(probe_id: @probe_scope.where.not(source: "custom").select(:id))
+        .group("probes.id")
+        .having("SUM(probe_results.total) > 0 AND SUM(probe_results.total) >= ?", @min_attempts)
+        .order(Arel.sql("SUM(probe_results.passed)::float / SUM(probe_results.total) DESC, SUM(probe_results.total) DESC, probes.id ASC"))
+        .limit(@limit)
+        .pluck("probes.id")
+        .to_set
+    end
+  end
+end

--- a/app/views/admin/scans/_form.html.erb
+++ b/app/views/admin/scans/_form.html.erb
@@ -139,7 +139,7 @@
   </div>
 
   <!-- Probe Selection Section -->
-  <%= render "probe_selection", f: f, scan: @scan, probe_categories: @probe_categories, community_categories: @community_categories %>
+  <%= render "probe_selection", f: f, scan: @scan, probe_categories: @probe_categories, community_categories: @community_categories, default_probe_ids: @default_probe_ids %>
 
   <!-- Threat Variants Section (only when variant infrastructure is available) -->
   <% if @threat_variant_industries.present? %>

--- a/app/views/admin/scans/_probe_category_item.html.erb
+++ b/app/views/admin/scans/_probe_category_item.html.erb
@@ -7,6 +7,7 @@
 <% icon = category_data[:icon] %>
 <% color = category_data[:color] %>
 <% is_nested = local_assigns[:nested] || false %>
+<% default_probe_ids = local_assigns[:default_probe_ids] || Set.new %>
 
 <div class="border border-borderPrimary rounded-lg overflow-hidden hover:border-primary/50 transition-all <%= 'bg-backgroundSecondary/30' if is_nested %>"
      data-probe-category-target="category"
@@ -106,7 +107,7 @@
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-<%= is_nested ? '2' : '3' %>">
         <% probes.sort_by(&:name).each do |probe| %>
           <div class="flex items-center">
-            <% is_checked = scan.probes.include?(probe) if scan.persisted? %>
+            <% is_checked = scan.probes.any? ? scan.probes.include?(probe) : default_probe_ids.include?(probe.id) %>
             <%= check_box_tag "scan[probe_ids][]",
                 probe.id,
                 is_checked,

--- a/app/views/admin/scans/_probe_selection.html.erb
+++ b/app/views/admin/scans/_probe_selection.html.erb
@@ -1,9 +1,20 @@
+<% default_probe_ids = local_assigns[:default_probe_ids] || Set.new %>
 <div class="bg-backgroundPrimary rounded-lg border border-borderPrimary p-6 mb-6">
   <h3 class="text-lg font-semibold mb-4 text-primary">
     Probe Selection
   </h3>
 
   <div class="probe-selection-section" data-controller="probe-category">
+    <% if default_probe_ids.any? %>
+      <div class="bg-primary/10 border border-primary/30 rounded-lg p-4 mb-6">
+        <div class="flex items-start gap-3">
+          <span class="icon icon-md icon-info text-primary shrink-0 mt-0.5"></span>
+          <p class="text-sm text-contentSecondary">
+            Pre-selected the <%= default_probe_ids.size %> <%= "probe".pluralize(default_probe_ids.size) %> most successful against your past targets — adjust as needed.
+          </p>
+        </div>
+      </div>
+    <% end %>
     <!-- Search bar -->
     <div class="mb-6">
       <div class="relative">
@@ -80,7 +91,7 @@
     <div class="space-y-3">
       <%# Curated probe categories %>
       <% probe_categories.each do |category_name, category_data| %>
-        <%= render "probe_category_item", f: f, scan: scan, category_name: category_name, category_data: category_data, show_auto_update: true %>
+        <%= render "probe_category_item", f: f, scan: scan, category_name: category_name, category_data: category_data, show_auto_update: true, default_probe_ids: default_probe_ids %>
       <% end %>
 
       <%# Community probes section (nested) %>
@@ -142,7 +153,7 @@
             <div class="p-4 bg-backgroundPrimary border-t border-borderPrimary">
               <div class="space-y-2 ml-2 pl-4 border-l-2 border-borderPrimary">
                 <% community_categories.each do |category_name, category_data| %>
-                  <%= render "probe_category_item", f: f, scan: scan, category_name: category_name, category_data: category_data, show_auto_update: false, nested: true %>
+                  <%= render "probe_category_item", f: f, scan: scan, category_name: category_name, category_data: category_data, show_auto_update: false, nested: true, default_probe_ids: default_probe_ids %>
                 <% end %>
               </div>
             </div>

--- a/spec/controllers/admin/scans_controller_spec.rb
+++ b/spec/controllers/admin/scans_controller_spec.rb
@@ -58,6 +58,43 @@ RSpec.describe Admin::ScansController, type: :controller do
       # The controller uses policy_scope(Probe) for tier-based filtering
       expect(response).to have_http_status(:success)
     end
+
+    context "default probe pre-selection" do
+      let!(:results_scan) { ActsAsTenant.with_tenant(company) { create(:complete_scan, company: company) } }
+      let!(:results_report) do
+        ActsAsTenant.with_tenant(company) do
+          create(:report, :completed, company: company, scan: results_scan, target: target)
+        end
+      end
+
+      def seed_result(name, passed, total)
+        p = create(:probe, name: name, detector: create(:detector))
+        ActsAsTenant.with_tenant(company) { create(:probe_result, report: results_report, probe: p, passed: passed, total: total) }
+        p
+      end
+
+      it "pre-checks successful probes above the attempts floor and shows the note" do
+        winner = seed_result("attack.win", 9, 10)   # 90%, 10 attempts -> checked
+        low_vol = seed_result("attack.lowvol", 3, 3) # 3 attempts -> below floor, not checked
+
+        get :new
+
+        doc = Nokogiri::HTML(response.body)
+        expect(doc.at_css("input#scan_probe_ids_#{winner.id}")["checked"]).to eq("checked")
+        expect(doc.at_css("input#scan_probe_ids_#{low_vol.id}")["checked"]).to be_nil
+        expect(response.body).to include("most successful against your past targets")
+      end
+
+      it "pre-checks nothing and renders no note when the tenant has no data" do
+        fresh = create(:probe, name: "attack.fresh", detector: create(:detector))
+
+        get :new
+
+        doc = Nokogiri::HTML(response.body)
+        expect(doc.at_css("input#scan_probe_ids_#{fresh.id}")["checked"]).to be_nil
+        expect(response.body).not_to include("most successful against your past targets")
+      end
+    end
   end
 
   describe "POST #create" do
@@ -80,6 +117,25 @@ RSpec.describe Admin::ScansController, type: :controller do
     it "redirects to scan show page on success" do
       post :create, params: valid_params
       expect(response).to redirect_to(scan_path(Scan.last))
+    end
+
+    it "keeps the submitted probe selection (not defaults) when create fails validation" do
+      submitted = create(:probe, name: "attack.submitted", detector: create(:detector))
+      default_only = create(:probe, name: "attack.defaultonly", detector: create(:detector)) # high ASR -> would be a default, but not submitted
+      results_scan = ActsAsTenant.with_tenant(company) { create(:complete_scan, company: company) }
+      results_report = ActsAsTenant.with_tenant(company) { create(:report, :completed, company: company, scan: results_scan, target: target) }
+      ActsAsTenant.with_tenant(company) do
+        create(:probe_result, report: results_report, probe: submitted, passed: 1, total: 10)
+        create(:probe_result, report: results_report, probe: default_only, passed: 9, total: 10)
+      end
+
+      # Omitting target_ids fails Scan's targets-presence validation -> re-renders :new.
+      post :create, params: { scan: { name: "Invalid Scan", probe_ids: [ submitted.id.to_s ] } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      doc = Nokogiri::HTML(response.body)
+      expect(doc.at_css("input#scan_probe_ids_#{submitted.id}")["checked"]).to eq("checked")
+      expect(doc.at_css("input#scan_probe_ids_#{default_only.id}")["checked"]).to be_nil
     end
   end
 

--- a/spec/services/scans/default_probe_selector_spec.rb
+++ b/spec/services/scans/default_probe_selector_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe Scans::DefaultProbeSelector, type: :service do
+  describe '#call' do
+    let(:company) { create(:company) }
+    let(:scan) { create(:complete_scan, company: company) }
+    let(:report) { create(:report, :completed, company: company, scan: scan, target: create(:target, company: company)) }
+
+    before { ActsAsTenant.current_tenant = company }
+
+    def seed(name:, passed:, total:, rpt: report)
+      probe = create(:probe, name: name)
+      create(:probe_result, report: rpt, probe: probe, passed: passed, total: total)
+      probe
+    end
+
+    it 'returns a Set of probe ids ordered by ASR (most successful first)' do
+      low  = seed(name: 'attack.low',  passed: 1, total: 10) # 10%
+      high = seed(name: 'attack.high', passed: 9, total: 10) # 90%
+      mid  = seed(name: 'attack.mid',  passed: 5, total: 10) # 50%
+
+      result = described_class.new(probe_scope: Probe.all).call
+
+      expect(result).to be_a(Set)
+      expect(result.to_a).to eq([ high.id, mid.id, low.id ])
+    end
+
+    it 'respects the limit' do
+      (1..6).each { |i| seed(name: "attack.#{i}", passed: i, total: 10) }
+      expect(described_class.new(probe_scope: Probe.all, limit: 3).call.size).to eq(3)
+    end
+
+    it 'excludes probes below the minimum-attempts floor' do
+      strong = seed(name: 'attack.strong', passed: 5, total: 10) # 5 attempts >= floor
+      tiny   = seed(name: 'attack.tiny',   passed: 3, total: 3)  # 3 attempts < floor
+
+      result = described_class.new(probe_scope: Probe.all, min_attempts: 5).call
+
+      expect(result).to include(strong.id)
+      expect(result).not_to include(tiny.id)
+    end
+
+    it 'never divides by zero even when the attempts floor is lowered to zero' do
+      has_attempts = seed(name: 'attack.has', passed: 1, total: 2)
+      zero_attempts = seed(name: 'attack.zero', passed: 0, total: 0)
+
+      result = nil
+      expect { result = described_class.new(probe_scope: Probe.all, min_attempts: 0).call }.not_to raise_error
+      expect(result).to include(has_attempts.id)
+      expect(result).not_to include(zero_attempts.id)
+    end
+
+    it 'excludes custom probes' do
+      builtin = seed(name: 'attack.builtin', passed: 8, total: 10)
+      custom  = create(:probe, name: 'attack.custom')
+      custom.update_column(:source, 'custom')
+      create(:probe_result, report: report, probe: custom, passed: 9, total: 10)
+
+      result = described_class.new(probe_scope: Probe.all).call
+
+      expect(result).to include(builtin.id)
+      expect(result).not_to include(custom.id)
+    end
+
+    it 'only counts probes within the provided scope' do
+      included = seed(name: 'attack.included', passed: 8, total: 10)
+      seed(name: 'attack.excluded', passed: 9, total: 10)
+
+      result = described_class.new(probe_scope: Probe.where(id: included.id)).call
+
+      expect(result.to_a).to eq([ included.id ])
+    end
+
+    it 'ignores non-completed reports' do
+      visible = seed(name: 'attack.visible', passed: 6, total: 10)
+
+      failed = create(:report, :failed, company: company, scan: scan, target: create(:target, company: company))
+      seed(name: 'attack.failed', passed: 9, total: 10, rpt: failed)
+
+      result = described_class.new(probe_scope: Probe.all).call
+
+      expect(result.to_a).to eq([ visible.id ])
+    end
+
+    it 'returns an empty Set when there is no qualifying data' do
+      expect(described_class.new(probe_scope: Probe.all).call).to eq(Set.new)
+    end
+
+    it 'only aggregates the current tenant reports' do
+      mine = seed(name: 'attack.mine', passed: 5, total: 10)
+      other = create(:company)
+      ActsAsTenant.with_tenant(other) do
+        oscan = create(:complete_scan, company: other)
+        orpt = create(:report, :completed, company: other, scan: oscan, target: create(:target, company: other))
+        op = create(:probe, name: 'attack.theirs')
+        create(:probe_result, report: orpt, probe: op, passed: 9, total: 10)
+      end
+
+      result = described_class.new(probe_scope: Probe.all).call
+      expect(result.to_a).to eq([ mine.id ])
+    end
+  end
+end


### PR DESCRIPTION
Port of 0din-ai/scanner#557.

Pre-selects the top-10 probes most successful against this tenant's own past targets on the new-scan form, so users get a sensible starting scan they can adjust.

## How
- New `Scans::DefaultProbeSelector`: GROUP BY over the tenant's `Report.completed` `probe_results`, top-10 by `SUM(passed)/SUM(total)`, `HAVING SUM(total) > 0 AND >= 5` (min-attempts floor), accessible non-custom probes, returns a `Set` of probe ids. Mirrors this repo's `Stats::TopFiveAttacksData` (which also filters on `Report.completed`).
- `ScansController#new` sets `@default_probe_ids`, threaded through `_form → _probe_selection → _probe_category_item`. Checkbox uses `scan.probes.any? ? scan.probes.include?(probe) : default_probe_ids.include?(probe.id)` so fresh new scan → defaults, edit → persisted selection, failed-`#create` → submitted selection preserved.
- One-line UX note when a non-empty default set is applied.
- No DB column, no migration, no JS (the `probe_category` Stimulus `connect()` recomputes counts + token estimate from checked boxes).

## Port adaptation
ai-scanner has no `customer_visible`/`validation_run`, so the service and spec use `Report.completed` (matching this repo's `TopFiveAttacksData`); no custom-probe section to thread.

## Test plan
- [x] Service spec (9 ex) + `#new`/`#create` controller specs ported & adapted to ai-scanner factories (detector-backed, source garak)
- [ ] CI green