### PR TITLE
fix(reports): stamp each variant prompt with its industry tag in the report output

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,4 +1,16 @@
 module ReportsHelper
+  VARIANT_INDUSTRY_EMOJIS = {
+    "automotive" => "🚗",
+    "finance" => "💰",
+    "healthcare" => "🏥",
+    "retail" => "🛍️",
+    "technology" => "💻",
+    "energy" => "⚡",
+    "education" => "🎓",
+    "government" => "🏛️",
+    "manufacturing" => "🏭"
+  }.freeze
+
   def activity_stream_active_status_for_report?(report)
     return false if report.blank?
 
@@ -73,6 +85,22 @@ module ReportsHelper
     # White if ANY subindustry was tested, grey otherwise
     tested = subindustries.any? { |sub| probe_results_map[sub.id].present? }
     tested ? "text-white" : "text-[#71717a]"
+  end
+
+  # Industry tag for a variant probe result's threat_variant.
+  # Returns nil for non-variant results; emoji falls back to 🏢 for unmapped industries.
+  def variant_industry_tag(threat_variant)
+    return nil if threat_variant.blank?
+
+    subindustry = threat_variant.threat_variant_subindustry
+    industry = subindustry&.threat_variant_industry
+    return nil if industry.blank? || subindustry.blank?
+
+    {
+      emoji: VARIANT_INDUSTRY_EMOJIS[industry.name.downcase] || "🏢",
+      industry: industry.name,
+      subindustry: subindustry.name
+    }
   end
 
   # Format report duration as human-readable text

--- a/app/views/report_details/show.html.erb
+++ b/app/views/report_details/show.html.erb
@@ -250,6 +250,7 @@
           (pdf_mode ? 'shadow-sm' : 'shadow-lg shadow-gray-500/5 hover:shadow-gray-500/10')
         indicator_color = is_vulnerable ? 'bg-red-500' : 'bg-emerald-500'
         indicator_animation = is_vulnerable && !pdf_mode ? 'animate-pulse' : ''
+        industry_tag = variant_industry_tag(result.threat_variant)
       %>
 
       <details id="probe-<%= probe.id %>" class="group" data-report-target="details" <%= 'open' if pdf_mode && result.any_detector_passed %>>
@@ -383,23 +384,34 @@
             <% (result.attempts || []).each do |attempt| %>
               <% attempt_res = attempt_result(attempt) %>
               <div id="<%= attempt["uuid"] %>" class="<%= pdf_mode ? 'bg-gray-50/50 rounded p-4 border border-gray-100 break-inside-avoid' : 'bg-gray-50/50 rounded-lg p-5 shadow-sm border border-gray-100' %>">
-                <div class="<%= pdf_mode ? 'flex items-center justify-end gap-2 mb-3' : 'flex items-center justify-end gap-2 mb-4' %>">
-                  <% unless attempt_res[:succeeded].nil? %>
-                    <% if attempt_res[:succeeded] %>
-                      <span class="<%= pdf_mode ? 'text-[10px] font-semibold bg-red-50 text-red-700 px-2 py-0.5 rounded-full' : 'text-xs font-semibold bg-red-50 text-red-700 px-3 py-1 rounded-full' %>" title="The probe successfully elicited a vulnerable response from the target model">
-                        Attack Successful
+                <% attempt_justify = industry_tag.present? ? "justify-between" : "justify-end" %>
+                <div class="<%= pdf_mode ? "flex items-center #{attempt_justify} gap-2 mb-3" : "flex items-center #{attempt_justify} gap-2 mb-4" %>">
+                  <% if industry_tag.present? %>
+                    <div class="flex items-center gap-2">
+                      <span class="<%= pdf_mode ? 'inline-flex items-center gap-1 px-2 py-0.5 bg-orange-100 text-orange-700 rounded text-[10px] font-medium' : 'inline-flex items-center gap-1.5 px-2.5 py-1 bg-orange-100 text-orange-700 rounded-lg text-xs font-medium' %>" title="Industry-specific variant of the probe">
+                        <span><%= industry_tag[:emoji] %></span>
+                        <%= industry_tag[:industry] %> / <%= industry_tag[:subindustry] %>
                       </span>
-                    <% else %>
-                      <span class="<%= pdf_mode ? 'text-[10px] font-semibold bg-green-50 text-green-700 px-2 py-0.5 rounded-full' : 'text-xs font-semibold bg-green-50 text-green-700 px-3 py-1 rounded-full' %>" title="The target model successfully defended against this probe attempt">
-                        Blocked
+                    </div>
+                  <% end %>
+                  <div class="flex items-center gap-2">
+                    <% unless attempt_res[:succeeded].nil? %>
+                      <% if attempt_res[:succeeded] %>
+                        <span class="<%= pdf_mode ? 'text-[10px] font-semibold bg-red-50 text-red-700 px-2 py-0.5 rounded-full' : 'text-xs font-semibold bg-red-50 text-red-700 px-3 py-1 rounded-full' %>" title="The probe successfully elicited a vulnerable response from the target model">
+                          Attack Successful
+                        </span>
+                      <% else %>
+                        <span class="<%= pdf_mode ? 'text-[10px] font-semibold bg-green-50 text-green-700 px-2 py-0.5 rounded-full' : 'text-xs font-semibold bg-green-50 text-green-700 px-3 py-1 rounded-full' %>" title="The target model successfully defended against this probe attempt">
+                          Blocked
+                        </span>
+                      <% end %>
+                    <% end %>
+                    <% if attempt_res[:score_percentage].present? %>
+                      <span class="<%= pdf_mode ? 'text-[10px] font-semibold bg-blue-50 text-blue-700 px-2 py-0.5 rounded-full' : 'text-xs font-semibold bg-blue-50 text-blue-700 px-3 py-1 rounded-full' %>" title="JEF match score for this attempt">
+                        Score: <%= attempt_res[:score_percentage] %>
                       </span>
                     <% end %>
-                  <% end %>
-                  <% if attempt_res[:score_percentage].present? %>
-                    <span class="<%= pdf_mode ? 'text-[10px] font-semibold bg-blue-50 text-blue-700 px-2 py-0.5 rounded-full' : 'text-xs font-semibold bg-blue-50 text-blue-700 px-3 py-1 rounded-full' %>" title="JEF match score for this attempt">
-                      Score: <%= attempt_res[:score_percentage] %>
-                    </span>
-                  <% end %>
+                  </div>
                 </div>
 
                 <div class="<%= pdf_mode ? 'space-y-3' : 'space-y-4' %>">

--- a/spec/helpers/reports_helper_spec.rb
+++ b/spec/helpers/reports_helper_spec.rb
@@ -368,4 +368,28 @@ RSpec.describe ReportsHelper, type: :helper do
       expect(result[:score_percentage]).to be_nil
     end
   end
+
+  describe '#variant_industry_tag' do
+    it 'returns nil when the threat_variant is nil' do
+      expect(helper.variant_industry_tag(nil)).to be_nil
+    end
+
+    it 'returns emoji, industry and subindustry for a mapped industry' do
+      industry = create(:threat_variant_industry, name: 'Healthcare')
+      subindustry = create(:threat_variant_subindustry, threat_variant_industry: industry, name: 'Medical Devices')
+      threat_variant = create(:threat_variant, threat_variant_subindustry: subindustry)
+
+      expect(helper.variant_industry_tag(threat_variant)).to eq(
+        emoji: '🏥', industry: 'Healthcare', subindustry: 'Medical Devices'
+      )
+    end
+
+    it 'falls back to the office emoji for an unmapped industry name' do
+      industry = create(:threat_variant_industry, name: 'Aerospace')
+      subindustry = create(:threat_variant_subindustry, threat_variant_industry: industry, name: 'Avionics')
+      threat_variant = create(:threat_variant, threat_variant_subindustry: subindustry)
+
+      expect(helper.variant_industry_tag(threat_variant)[:emoji]).to eq('🏢')
+    end
+  end
 end

--- a/spec/requests/report_details_spec.rb
+++ b/spec/requests/report_details_spec.rb
@@ -82,6 +82,36 @@ RSpec.describe "ReportDetails", type: :request do
         expect(response.body).to include("Blocked")
         expect(response.body).to include("Score: 90.00%")
       end
+
+      it "stamps each variant prompt with its industry tag" do
+        industry = create(:threat_variant_industry, name: "Healthcare")
+        subindustry = create(:threat_variant_subindustry, threat_variant_industry: industry, name: "Medical Devices")
+        variant_probe = create(:probe, name: "VariantProbe")
+        threat_variant = create(:threat_variant, probe: variant_probe, threat_variant_subindustry: subindustry)
+
+        variant_report = ActsAsTenant.with_tenant(company) do
+          parent = create(:report, :completed, company: company)
+          create(:report, :completed, company: company, parent_report_id: parent.id)
+        end
+        ActsAsTenant.with_tenant(company) do
+          create(:probe_result, report: variant_report, probe: variant_probe, threat_variant: threat_variant,
+                 passed: 1, total: 1, attempts: [
+                   { "uuid" => "variant-att-1", "prompt" => "p1", "outputs" => [ "o1" ], "notes" => {}, "attack_succeeded" => true }
+                 ])
+        end
+
+        variant_pdf_token = Rails.application.message_verifier(Reports::PdfGenerator::RENDER_TOKEN_VERIFIER_KEY).generate(
+          variant_report.id,
+          expires_in: Reports::PdfGenerator::RENDER_TOKEN_TTL,
+          purpose: Reports::PdfGenerator::RENDER_TOKEN_PURPOSE
+        )
+
+        get report_detail_path(variant_report, pdf: "true", pdf_token: variant_pdf_token)
+
+        expect(response).to have_http_status(:success)
+        doc = Nokogiri::HTML(response.body)
+        expect(doc.at_css("#variant-att-1").text).to include("Healthcare / Medical Devices")
+      end
     end
 
     context "with pdf=true but an invalid pdf_token" do


### PR DESCRIPTION
Port of 0din-ai/scanner#559.

## Bug
An industry-variants scan's report didn't make the retargeting evident while reading individual prompts — no per-prompt industry tag.

## Fix
- New `ReportsHelper#variant_industry_tag(threat_variant)` → `{emoji:, industry:, subindustry:}` (or nil; 🏢 fallback).
- `report_details/show.html.erb`: compute `industry_tag` once per result; add a per-attempt orange pill `🏥 Healthcare / Medical Devices` at the top-left of each variant attempt row (`justify-between`; non-variant rows keep `justify-end`, no extra div). The `threat_variant → subindustry → industry` chain is preloaded by `variant_probe_results` — no model/query change.

## Port adaptation
ai-scanner has no per-result header pill (its variant industry shows in a separate variants-by-industry overview section), so this is **helper + per-attempt stamp only** — no header refactor, overview section untouched. report_details request-spec auth uses ai-scanner's `RENDER_TOKEN_*` verifier.

## Test plan
- [x] Helper spec; request spec asserting the tag inside the attempt div (`#variant-att-1`); ruby+ERB static checks green
- [ ] CI green