### PR TITLE
feat(reports): lead the customer report with a goal-oriented narrative band

### DIFF
--- a/app/decorators/report_decorator.rb
+++ b/app/decorators/report_decorator.rb
@@ -17,6 +17,19 @@ class ReportDecorator < SimpleDelegator
     probe_results.size
   end
 
+  # Highest-ASR probe results for the narrative band's "Top findings" list.
+  # Reuses the already-loaded probe_results array. A "finding" is a probe the
+  # report treats as vulnerable — keyed on any_detector_passed (consistent with
+  # the VULNERABLE badge), so multi-detector probes bypassed with a zero
+  # canonical `passed` count still count. Skip zero-attempt and defended rows.
+  def top_findings(limit: 3)
+    probe_results
+      .select { |pr| pr.total.to_i.positive? && pr.any_detector_passed }
+      .sort_by { |pr| -pr.asr_percentage.to_f }
+      .first(limit)
+      .map { |pr| { name: pr.probe&.name, asr: pr.asr_percentage } }
+  end
+
   # Variant methods (variants_by_industry, variant_probe_results, etc.)
   # are provided by the engine decorator override when variant features are enabled.
 end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,4 +1,8 @@
 module ReportsHelper
+  # Risk grade label boundaries, aligned to the ASR color bands (0...25, 25...50,
+  # 50...75, 75+) so the grade word always matches the ASR number.
+  RISK_GRADE_THRESHOLDS = [ [ 25, "Low" ], [ 50, "Medium" ], [ 75, "High" ] ].freeze
+
   VARIANT_INDUSTRY_EMOJIS = {
     "automotive" => "🚗",
     "finance" => "💰",
@@ -101,6 +105,25 @@ module ReportsHelper
       industry: industry.name,
       subindustry: subindustry.name
     }
+  end
+
+  # 4-tier risk grade label for an ASR percentage. nil when asr is nil.
+  def report_risk_grade_label(asr)
+    return nil if asr.nil?
+    RISK_GRADE_THRESHOLDS.each { |max, label| return label if asr.to_f < max }
+    "Critical"
+  end
+
+  # Light-theme pill classes for the risk grade chip on the (light) customer
+  # report band, aligned to the same 4 thresholds. nil when asr is nil.
+  def report_risk_grade_classes(asr)
+    return nil if asr.nil?
+    case asr.to_f
+    when 0...25 then "bg-zinc-100 text-zinc-700"
+    when 25...50 then "bg-yellow-100 text-yellow-800"
+    when 50...75 then "bg-orange-100 text-orange-800"
+    else "bg-red-100 text-red-800"
+    end
   end
 
   # Format report duration as human-readable text

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -220,6 +220,36 @@ class Report < ApplicationRecord
     asr == 0 ? "N/A" : "#{asr}%"
   end
 
+  # The most recent prior completed parent (non-variant) report of the same
+  # scan + target — the run this report is compared against in the narrative
+  # band. Scoped via scan.reports so it works without an ambient tenant (PDF
+  # render). Variant child reports are not part of the run-over-run timeline,
+  # so they have no "previous run" (and must never compare against their own
+  # base).
+  def previous_completed_report
+    return nil if is_variant_report?
+
+    scan.reports
+        .parent_reports
+        .completed
+        .where(target_id: target_id)
+        .where.not(id: id)
+        .where("reports.created_at < ?", created_at)
+        .order(created_at: :desc, id: :desc)
+        .first
+  end
+
+  # Signed ASR delta vs the previous completed report (positive = ASR rose =
+  # worse). nil when there is no prior completed report to compare against.
+  # NOTE: calls attack_success_rate on self and on the prior report; each
+  # falls back to two detector_results queries when not preloaded.
+  # Multi-report callers should preload.
+  def asr_delta_vs_previous
+    prev = previous_completed_report
+    return nil unless prev
+    (attack_success_rate - prev.attack_success_rate).round(2)
+  end
+
   def total_successful_attacks
     cached_passed
   end

--- a/app/views/report_details/_narrative_band.html.erb
+++ b/app/views/report_details/_narrative_band.html.erb
@@ -1,0 +1,52 @@
+<%#
+  Auto-computed narrative band — leads the customer report.
+  locals: report (decorated Report), pdf_mode (boolean)
+%>
+<% asr = report.attack_success_rate %>
+<% has_scores = report.detector_results.exists? %>
+<% grade = report_risk_grade_label(asr) %>
+<% delta = report.asr_delta_vs_previous %>
+<% findings = report.top_findings %>
+<% if has_scores %>
+  <div data-narrative-band class="<%= pdf_mode ? 'px-6 py-5 bg-white border-b border-gray-200' : 'px-8 py-6 bg-gradient-to-r from-indigo-50 via-white to-white border-b border-gray-200' %>">
+    <h2 class="<%= pdf_mode ? 'text-lg font-bold text-gray-800 mb-3' : 'text-xl font-bold text-gray-800 mb-4' %>">Summary</h2>
+
+    <div class="flex flex-wrap items-center gap-3 mb-4">
+      <% if grade %>
+        <span class="inline-flex items-center px-3 py-1 rounded-lg font-bold text-sm <%= report_risk_grade_classes(asr) %>">
+          <%= grade %> Risk
+        </span>
+      <% end %>
+      <span class="flex items-baseline gap-1">
+        <span class="<%= pdf_mode ? 'text-xl font-bold text-gray-900' : 'text-2xl font-bold text-gray-900' %>"><%= asr.round %>%</span>
+        <span class="text-xs text-gray-500">attack success rate</span>
+      </span>
+      <% unless delta.nil? %>
+        <% pts = delta.round %>
+        <% worse = pts.positive? %>
+        <% better = pts.negative? %>
+        <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold <%= worse ? 'bg-red-50 text-red-700' : (better ? 'bg-emerald-50 text-emerald-700' : 'bg-gray-100 text-gray-600') %>" title="Change vs the previous completed scan of this target">
+          <% if pts.zero? %>
+            &#9632; no change vs last scan
+          <% else %>
+            <%= worse ? '▲' : '▼' %> <%= pts.abs %> pts <span class="sr-only"><%= worse ? 'higher' : 'lower' %> </span>vs last scan
+          <% end %>
+        </span>
+      <% end %>
+    </div>
+
+    <% if findings.any? %>
+      <div>
+        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Top findings</h3>
+        <ul class="space-y-1 max-w-2xl">
+          <% findings.each do |f| %>
+            <li class="flex items-center justify-between text-sm border-b border-dashed border-gray-200 pb-1">
+              <span class="text-gray-700"><%= f[:name] %></span>
+              <span class="font-semibold <%= f[:asr].to_f >= 50 ? 'text-red-600' : 'text-gray-700' %>"><%= f[:asr] %>%</span>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/report_details/show.html.erb
+++ b/app/views/report_details/show.html.erb
@@ -76,6 +76,8 @@
     <%= render partial: 'reports/failure_summary', locals: { report: @report, pdf_mode: pdf_mode } %>
   <% end %>
 
+  <%= render partial: 'report_details/narrative_band', locals: { report: @report, pdf_mode: pdf_mode } %>
+
   <% if @report.detector_results.exists? %>
     <div class="<%= pdf_mode ? 'px-6 py-5 bg-gray-50 border-b border-gray-200' : 'px-8 py-6 bg-gradient-to-r from-gray-100 via-white to-gray-50 border-b border-gray-200' %>">
       <div class="<%= pdf_mode ? 'mb-3' : 'mb-4' %>">

--- a/spec/decorators/report_decorator_spec.rb
+++ b/spec/decorators/report_decorator_spec.rb
@@ -111,4 +111,78 @@ RSpec.describe ReportDecorator, type: :decorator do
       end
     end
   end
+
+  describe '#top_findings' do
+    let(:probe_a) { create(:probe, name: 'ProbeA') }
+    let(:probe_b) { create(:probe, name: 'ProbeB') }
+    let(:probe_c) { create(:probe, name: 'ProbeC') }
+    let(:probe_d) { create(:probe, name: 'ProbeD') }
+
+    it 'returns highest-ASR findings first, up to the limit' do
+      # 80% ASR
+      create(:probe_result, report: report, probe: probe_a, passed: 8, total: 10,
+             any_detector_passed: true)
+      # 60% ASR
+      create(:probe_result, report: report, probe: probe_b, passed: 6, total: 10,
+             any_detector_passed: true)
+      # 40% ASR — below limit
+      create(:probe_result, report: report, probe: probe_c, passed: 4, total: 10,
+             any_detector_passed: true)
+
+      results = described_class.new(report).top_findings
+      expect(results.map { |f| f[:name] }).to eq(%w[ProbeA ProbeB ProbeC])
+    end
+
+    it 'limits to 3 by default' do
+      [ probe_a, probe_b, probe_c, probe_d ].each do |probe|
+        create(:probe_result, report: report, probe: probe, passed: 5, total: 10,
+               any_detector_passed: true)
+      end
+
+      expect(described_class.new(report).top_findings.size).to eq(3)
+    end
+
+    it 'accepts a custom limit' do
+      [ probe_a, probe_b ].each do |probe|
+        create(:probe_result, report: report, probe: probe, passed: 5, total: 10,
+               any_detector_passed: true)
+      end
+
+      expect(described_class.new(report).top_findings(limit: 1).size).to eq(1)
+    end
+
+    it 'skips zero-attempt probe results' do
+      create(:probe_result, report: report, probe: probe_a, passed: 0, total: 0,
+             any_detector_passed: false)
+      create(:probe_result, report: report, probe: probe_b, passed: 5, total: 10,
+             any_detector_passed: true)
+
+      results = described_class.new(report).top_findings
+      expect(results.map { |f| f[:name] }).to eq([ 'ProbeB' ])
+    end
+
+    it 'skips defended (any_detector_passed = false) rows' do
+      create(:probe_result, report: report, probe: probe_a, passed: 0, total: 10,
+             any_detector_passed: false)
+
+      expect(described_class.new(report).top_findings).to eq([])
+    end
+
+    it 'includes multi-detector probes where any_detector_passed is true but passed is 0' do
+      create(:probe_result, report: report, probe: probe_a, passed: 0, total: 10,
+             any_detector_passed: true)
+
+      results = described_class.new(report).top_findings
+      expect(results.map { |f| f[:name] }).to eq([ 'ProbeA' ])
+    end
+
+    it 'returns [] when all rows are defended' do
+      create(:probe_result, report: report, probe: probe_a, passed: 0, total: 10,
+             any_detector_passed: false)
+      create(:probe_result, report: report, probe: probe_b, passed: 0, total: 5,
+             any_detector_passed: false)
+
+      expect(described_class.new(report).top_findings).to eq([])
+    end
+  end
 end

--- a/spec/helpers/reports_helper_spec.rb
+++ b/spec/helpers/reports_helper_spec.rb
@@ -369,6 +369,70 @@ RSpec.describe ReportsHelper, type: :helper do
     end
   end
 
+  describe '#report_risk_grade_label' do
+    it 'returns nil for a nil ASR' do
+      expect(helper.report_risk_grade_label(nil)).to be_nil
+    end
+
+    it 'returns Low for 0%' do
+      expect(helper.report_risk_grade_label(0)).to eq('Low')
+    end
+
+    it 'returns Low for 24.9%' do
+      expect(helper.report_risk_grade_label(24.9)).to eq('Low')
+    end
+
+    it 'returns Medium at the 25% boundary' do
+      expect(helper.report_risk_grade_label(25)).to eq('Medium')
+    end
+
+    it 'returns Medium for 49.9%' do
+      expect(helper.report_risk_grade_label(49.9)).to eq('Medium')
+    end
+
+    it 'returns High at the 50% boundary' do
+      expect(helper.report_risk_grade_label(50)).to eq('High')
+    end
+
+    it 'returns High for 74.9%' do
+      expect(helper.report_risk_grade_label(74.9)).to eq('High')
+    end
+
+    it 'returns Critical at the 75% boundary' do
+      expect(helper.report_risk_grade_label(75)).to eq('Critical')
+    end
+
+    it 'returns Critical for 100%' do
+      expect(helper.report_risk_grade_label(100)).to eq('Critical')
+    end
+  end
+
+  describe '#report_risk_grade_classes' do
+    it 'returns nil for a nil ASR' do
+      expect(helper.report_risk_grade_classes(nil)).to be_nil
+    end
+
+    it 'returns zinc classes for the Low tier (0...25)' do
+      expect(helper.report_risk_grade_classes(0)).to eq('bg-zinc-100 text-zinc-700')
+      expect(helper.report_risk_grade_classes(24.9)).to eq('bg-zinc-100 text-zinc-700')
+    end
+
+    it 'returns yellow classes for the Medium tier (25...50)' do
+      expect(helper.report_risk_grade_classes(25)).to eq('bg-yellow-100 text-yellow-800')
+      expect(helper.report_risk_grade_classes(49.9)).to eq('bg-yellow-100 text-yellow-800')
+    end
+
+    it 'returns orange classes for the High tier (50...75)' do
+      expect(helper.report_risk_grade_classes(50)).to eq('bg-orange-100 text-orange-800')
+      expect(helper.report_risk_grade_classes(74.9)).to eq('bg-orange-100 text-orange-800')
+    end
+
+    it 'returns red classes for the Critical tier (75+)' do
+      expect(helper.report_risk_grade_classes(75)).to eq('bg-red-100 text-red-800')
+      expect(helper.report_risk_grade_classes(100)).to eq('bg-red-100 text-red-800')
+    end
+  end
+
   describe '#variant_industry_tag' do
     it 'returns nil when the threat_variant is nil' do
       expect(helper.variant_industry_tag(nil)).to be_nil

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1032,4 +1032,121 @@ RSpec.describe Report, type: :model do
       expect(Report.new).not_to respond_to(:preloaded_variant_data)
     end
   end
+
+  describe '#previous_completed_report' do
+    let(:company) { create(:company) }
+    let(:target) { create(:target, company: company) }
+    let(:scan) do
+      build(:scan, company: company).tap do |s|
+        s.targets << target
+        s.save!(validate: false)
+      end
+    end
+
+    before do
+      allow_any_instance_of(RunGarakScan).to receive(:call)
+      allow(ToastNotifier).to receive(:call)
+    end
+
+    it 'returns the most recent prior completed report for the same scan + target' do
+      older = create(:report, :completed, company: company, target: target, scan: scan,
+                     created_at: 2.days.ago)
+      newer = create(:report, :completed, company: company, target: target, scan: scan,
+                     created_at: 1.day.ago)
+      current = create(:report, :completed, company: company, target: target, scan: scan)
+
+      expect(current.previous_completed_report).to eq(newer)
+    end
+
+    it 'ignores reports for a different target' do
+      other_target = create(:target, company: company)
+      other_scan = build(:scan, company: company).tap do |s|
+        s.targets << other_target
+        s.save!(validate: false)
+      end
+      create(:report, :completed, company: company, target: other_target, scan: other_scan,
+             created_at: 1.day.ago)
+      current = create(:report, :completed, company: company, target: target, scan: scan)
+
+      expect(current.previous_completed_report).to be_nil
+    end
+
+    it 'ignores incomplete (non-completed) reports' do
+      create(:report, :failed, company: company, target: target, scan: scan,
+             created_at: 1.day.ago)
+      current = create(:report, :completed, company: company, target: target, scan: scan)
+
+      expect(current.previous_completed_report).to be_nil
+    end
+
+    it 'ignores variant child reports' do
+      parent = create(:report, :completed, company: company, target: target, scan: scan,
+                      created_at: 1.day.ago)
+      # child report (non-nil parent_report_id) should be excluded from the timeline
+      create(:report, :completed, company: company, target: target, scan: scan,
+             parent_report_id: parent.id, created_at: 12.hours.ago)
+      current = create(:report, :completed, company: company, target: target, scan: scan)
+
+      # The only eligible prior parent report is `parent`
+      expect(current.previous_completed_report).to eq(parent)
+    end
+
+    it 'returns nil when current report is a variant child' do
+      parent = create(:report, :completed, company: company, target: target, scan: scan,
+                      created_at: 2.days.ago)
+      variant = create(:report, :completed, company: company, target: target, scan: scan,
+                       parent_report_id: parent.id)
+
+      expect(variant.previous_completed_report).to be_nil
+    end
+
+    it 'returns nil when no prior completed report exists' do
+      current = create(:report, :completed, company: company, target: target, scan: scan)
+
+      expect(current.previous_completed_report).to be_nil
+    end
+  end
+
+  describe '#asr_delta_vs_previous' do
+    let(:company) { create(:company) }
+    let(:target) { create(:target, company: company) }
+    let(:scan) do
+      build(:scan, company: company).tap do |s|
+        s.targets << target
+        s.save!(validate: false)
+      end
+    end
+
+    before do
+      allow_any_instance_of(RunGarakScan).to receive(:call)
+      allow(ToastNotifier).to receive(:call)
+    end
+
+    it 'returns nil when there is no prior completed report' do
+      report = create(:report, :completed, company: company, target: target, scan: scan)
+      expect(report.asr_delta_vs_previous).to be_nil
+    end
+
+    it 'returns a positive delta when ASR rose (got worse)' do
+      prev = create(:report, :completed, company: company, target: target, scan: scan,
+                    created_at: 1.day.ago)
+      create(:detector_result, report: prev, passed: 2, total: 10)   # 20%
+
+      current = create(:report, :completed, company: company, target: target, scan: scan)
+      create(:detector_result, report: current, passed: 5, total: 10) # 50%
+
+      expect(current.asr_delta_vs_previous).to eq(30.0)
+    end
+
+    it 'returns a negative delta when ASR fell (improved)' do
+      prev = create(:report, :completed, company: company, target: target, scan: scan,
+                    created_at: 1.day.ago)
+      create(:detector_result, report: prev, passed: 5, total: 10)   # 50%
+
+      current = create(:report, :completed, company: company, target: target, scan: scan)
+      create(:detector_result, report: current, passed: 2, total: 10) # 20%
+
+      expect(current.asr_delta_vs_previous).to eq(-30.0)
+    end
+  end
 end

--- a/spec/requests/report_details_spec.rb
+++ b/spec/requests/report_details_spec.rb
@@ -114,6 +114,66 @@ RSpec.describe "ReportDetails", type: :request do
       end
     end
 
+    context "narrative band" do
+      let(:company) { create(:company) }
+      let(:target) { create(:target, company: company) }
+      let(:scan) do
+        build(:scan, company: company).tap do |s|
+          s.targets << target
+          s.save!(validate: false)
+        end
+      end
+      let(:current_report) { create(:report, :completed, company: company, target: target, scan: scan) }
+
+      let(:pdf_token) do
+        Rails.application.message_verifier(Reports::PdfGenerator::RENDER_TOKEN_VERIFIER_KEY).generate(
+          current_report.id,
+          expires_in: Reports::PdfGenerator::RENDER_TOKEN_TTL,
+          purpose: Reports::PdfGenerator::RENDER_TOKEN_PURPOSE
+        )
+      end
+
+      before do
+        allow_any_instance_of(RunGarakScan).to receive(:call)
+        allow(ToastNotifier).to receive(:call)
+      end
+
+      it "renders [data-narrative-band] with the risk grade, ASR, and top findings" do
+        probe = create(:probe, name: 'TopProbe')
+        ActsAsTenant.with_tenant(company) do
+          current_report.scan.probes << probe unless current_report.scan.probes.exists?(probe.id)
+          create(:detector_result, report: current_report, passed: 6, total: 10)  # 60% => High
+          create(:probe_result, report: current_report, probe: probe,
+                 passed: 6, total: 10, any_detector_passed: true)
+        end
+
+        get report_detail_path(current_report, pdf: 'true', pdf_token: pdf_token)
+
+        expect(response).to have_http_status(:ok)
+        doc = Nokogiri::HTML(response.body)
+        band = doc.at_css('[data-narrative-band]')
+        expect(band).to be_present
+        expect(band.text).to include('High Risk')
+        expect(band.text).to include('60%')
+        expect(band.text).to include('TopProbe')
+      end
+
+      it "renders a ▲ delta chip when ASR rose vs the previous completed report" do
+        previous_report = create(:report, :completed, company: company, target: target,
+                                 scan: scan, created_at: 1.day.ago)
+        ActsAsTenant.with_tenant(company) do
+          create(:detector_result, report: previous_report, passed: 2, total: 10) # 20%
+          create(:detector_result, report: current_report, passed: 6, total: 10)  # 60%
+        end
+
+        get report_detail_path(current_report, pdf: 'true', pdf_token: pdf_token)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('▲')
+        expect(response.body).to include('pts')
+      end
+    end
+
     context "with pdf=true but an invalid pdf_token" do
       it "redirects to sign in" do
         get report_detail_path(report, pdf: "true", pdf_token: "invalid-token")


### PR DESCRIPTION
## Summary
Port of scanner #560. Leads the customer report with an auto-computed narrative band: risk grade (4 tiers on the ASR color bands) + overall ASR + ▲/▼ ASR delta vs the previous completed report of the same scan + target + top-3 findings. No schema change, no new writable surface.

## Test plan
- [x] RSpec coverage added (model/helper/decorator/request specs); ruby -c + ERB parse clean locally
- [x] Adapted for ai-scanner: no `customer_visible` scope; `Reports::PdfGenerator::RENDER_TOKEN_*` token pattern in request spec
- [ ] CI green