### PR TITLE
feat(probes): reorder probe details to lead with the prompt, demote the rest to a Metadata accordion

### DIFF
--- a/app/views/admin/probes/show.html.erb
+++ b/app/views/admin/probes/show.html.erb
@@ -16,6 +16,7 @@
 <%= render partial: "admin/shared/show_header", locals: { title: "Probe: #{@probe.name}", action_buttons: action_buttons } %>
 
 <div class="py-6">
+  <%# Lead: the fields that matter most, surfaced first %>
   <div class="rounded-lg bg-backgroundPrimary border border-borderPrimary p-6 mb-6">
     <table class="w-full">
       <tbody class="divide-y divide-borderPrimary">
@@ -26,28 +27,24 @@
           </td>
         </tr>
         <tr>
-          <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">GUID</th>
-          <td class="py-3 text-sm text-contentPrimary">
-            <code class="bg-backgroundSecondary px-2 py-1 rounded text-xs font-mono text-contentPrimary"><%= @probe.guid %></code>
-          </td>
-        </tr>
-        <tr>
-          <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Taxonomy Categories</th>
-          <td class="py-3 text-sm text-contentPrimary">
-            <% if @probe.taxonomy_categories.any? %>
-              <%= @probe.taxonomy_categories.map(&:name).join(", ") %>
-            <% else %>
-              <span class="text-contentTertiary">—</span>
-            <% end %>
-          </td>
-        </tr>
-        <tr>
           <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Summary</th>
           <td class="py-3 text-sm text-contentPrimary"><%= @probe.summary.presence || content_tag(:span, "—", class: "text-contentTertiary") %></td>
         </tr>
         <tr>
-          <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Description</th>
-          <td class="py-3 text-sm text-contentPrimary"><%= @probe.description.presence || content_tag(:span, "—", class: "text-contentTertiary") %></td>
+          <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Prompt</th>
+          <td class="py-3 text-sm text-contentPrimary">
+            <% if @probe.prompts.present? %>
+              <div class="space-y-3 mt-1">
+                <% @probe.prompts.each do |prompt| %>
+                  <div class="p-4 bg-backgroundSecondary rounded-lg border border-borderPrimary shadow-sm overflow-hidden">
+                    <div class="text-contentPrimary text-sm whitespace-pre-wrap font-mono break-all w-full overflow-wrap-anywhere"><%= prompt %></div>
+                  </div>
+                <% end %>
+              </div>
+            <% else %>
+              <span class="text-contentTertiary">—</span>
+            <% end %>
+          </td>
         </tr>
         <tr>
           <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Techniques</th>
@@ -56,46 +53,6 @@
               <% @probe.techniques.each do |technique| %>
                 <%= probe_technique_link(technique) %>
               <% end %>
-            <% else %>
-              <span class="text-contentTertiary">—</span>
-            <% end %>
-          </td>
-        </tr>
-        <tr>
-          <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Social Impact Score</th>
-          <td class="py-3 text-sm text-contentPrimary"><%= probe_social_impact_score_link(@probe) %></td>
-        </tr>
-        <tr>
-          <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Scores</th>
-          <td class="py-3 text-sm text-contentPrimary">
-            <% if @probe.scores.present? %>
-              <div class="rounded-lg border border-borderPrimary overflow-hidden">
-                <table class="min-w-full">
-                  <thead class="bg-backgroundSecondary">
-                    <tr>
-                      <th class="px-4 py-2 text-left text-xs font-medium text-contentSecondary uppercase tracking-wider">Provider</th>
-                      <th class="px-4 py-2 text-left text-xs font-medium text-contentSecondary uppercase tracking-wider">Model</th>
-                      <th class="px-4 py-2 text-right text-xs font-medium text-contentSecondary uppercase tracking-wider">Score</th>
-                    </tr>
-                  </thead>
-                  <tbody class="divide-y divide-borderPrimary">
-                    <% all_scores = [] %>
-                    <% @probe.scores.each do |provider, models| %>
-                      <% models.each do |(model, score)| %>
-                        <% all_scores << { provider: provider, model: model, score: score } %>
-                      <% end %>
-                    <% end %>
-                    <% all_scores.sort_by! { |item| -item[:score].to_f } %>
-                    <% all_scores.each do |item| %>
-                      <tr class="hover:bg-backgroundSecondary/50 transition-colors">
-                        <td class="px-4 py-3 whitespace-nowrap text-sm text-contentPrimary"><%= item[:provider] %></td>
-                        <td class="px-4 py-3 whitespace-nowrap text-sm text-contentPrimary"><%= item[:model] %></td>
-                        <td class="px-4 py-3 whitespace-nowrap text-sm text-right <%= score_color_class(item[:score], bold: true) %>"><%= item[:score] %>%</td>
-                      </tr>
-                    <% end %>
-                  </tbody>
-                </table>
-              </div>
             <% else %>
               <span class="text-contentTertiary">—</span>
             <% end %>
@@ -112,38 +69,106 @@
             <% end %>
           </td>
         </tr>
-        <tr>
-          <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Release Date</th>
-          <td class="py-3 text-sm text-contentPrimary"><%= @probe.release_date&.strftime("%Y-%m-%d") || content_tag(:span, "—", class: "text-contentTertiary") %></td>
-        </tr>
-        <tr>
-          <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Modified Date</th>
-          <td class="py-3 text-sm text-contentPrimary"><%= @probe.modified_date&.strftime("%Y-%m-%d") || content_tag(:span, "—", class: "text-contentTertiary") %></td>
-        </tr>
-        <% if @probe.attribution.present? %>
-        <tr>
-          <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Attribution</th>
-          <td class="py-3 text-sm text-contentPrimary">
-            <%= probe_attribution(@probe.attribution) %>
-          </td>
-        </tr>
-        <% end %>
-        <tr>
-          <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Prompts</th>
-          <td class="py-3 text-sm text-contentPrimary">
-            <% if @probe.prompts.present? %>
-              <div class="space-y-3 mt-1">
-                <% @probe.prompts.each do |prompt| %>
-                  <div class="p-4 bg-backgroundSecondary rounded-lg border border-borderPrimary shadow-sm overflow-hidden">
-                    <div class="text-contentPrimary text-sm whitespace-pre-wrap font-mono break-all w-full overflow-wrap-anywhere"><%= prompt %></div>
-                  </div>
-                <% end %>
-              </div>
-            <% else %>
-              <span class="text-contentTertiary">—</span>
-            <% end %>
-          </td>
-        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <%# Metadata: everything else, collapsed by default %>
+  <details class="group rounded-lg bg-backgroundPrimary border border-borderPrimary mb-6">
+    <summary class="flex items-center justify-between p-6 cursor-pointer list-none">
+      <span class="text-xl font-sans font-semibold text-primary tracking-wide">Metadata</span>
+      <svg class="w-5 h-5 text-contentSecondary transform transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <path d="M19 9l-7 7-7-7" />
+      </svg>
+    </summary>
+    <div class="px-6 pb-6">
+      <table class="w-full">
+        <tbody class="divide-y divide-borderPrimary">
+          <tr>
+            <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Description</th>
+            <td class="py-3 text-sm text-contentPrimary"><%= @probe.description.presence || content_tag(:span, "—", class: "text-contentTertiary") %></td>
+          </tr>
+          <tr>
+            <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Social Impact Score</th>
+            <td class="py-3 text-sm text-contentPrimary"><%= probe_social_impact_score_link(@probe) %></td>
+          </tr>
+          <tr>
+            <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Taxonomy Categories</th>
+            <td class="py-3 text-sm text-contentPrimary">
+              <% if @probe.taxonomy_categories.any? %>
+                <%= @probe.taxonomy_categories.map(&:name).join(", ") %>
+              <% else %>
+                <span class="text-contentTertiary">—</span>
+              <% end %>
+            </td>
+          </tr>
+          <tr>
+            <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Scores</th>
+            <td class="py-3 text-sm text-contentPrimary">
+              <% if @probe.scores.present? %>
+                <div class="rounded-lg border border-borderPrimary overflow-hidden">
+                  <table class="min-w-full">
+                    <thead class="bg-backgroundSecondary">
+                      <tr>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-contentSecondary uppercase tracking-wider">Provider</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-contentSecondary uppercase tracking-wider">Model</th>
+                        <th class="px-4 py-2 text-right text-xs font-medium text-contentSecondary uppercase tracking-wider">Score</th>
+                      </tr>
+                    </thead>
+                    <tbody class="divide-y divide-borderPrimary">
+                      <% all_scores = [] %>
+                      <% @probe.scores.each do |provider, models| %>
+                        <% models.each do |(model, score)| %>
+                          <% all_scores << { provider: provider, model: model, score: score } %>
+                        <% end %>
+                      <% end %>
+                      <% all_scores.sort_by! { |item| -item[:score].to_f } %>
+                      <% all_scores.each do |item| %>
+                        <tr class="hover:bg-backgroundSecondary/50 transition-colors">
+                          <td class="px-4 py-3 whitespace-nowrap text-sm text-contentPrimary"><%= item[:provider] %></td>
+                          <td class="px-4 py-3 whitespace-nowrap text-sm text-contentPrimary"><%= item[:model] %></td>
+                          <td class="px-4 py-3 whitespace-nowrap text-sm text-right <%= score_color_class(item[:score], bold: true) %>"><%= item[:score] %>%</td>
+                        </tr>
+                      <% end %>
+                    </tbody>
+                  </table>
+                </div>
+              <% else %>
+                <span class="text-contentTertiary">—</span>
+              <% end %>
+            </td>
+          </tr>
+          <tr>
+            <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">GUID</th>
+            <td class="py-3 text-sm text-contentPrimary">
+              <code class="bg-backgroundSecondary px-2 py-1 rounded text-xs font-mono text-contentPrimary"><%= @probe.guid %></code>
+            </td>
+          </tr>
+          <tr>
+            <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Release Date</th>
+            <td class="py-3 text-sm text-contentPrimary"><%= @probe.release_date&.strftime("%Y-%m-%d") || content_tag(:span, "—", class: "text-contentTertiary") %></td>
+          </tr>
+          <tr>
+            <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Modified Date</th>
+            <td class="py-3 text-sm text-contentPrimary"><%= @probe.modified_date&.strftime("%Y-%m-%d") || content_tag(:span, "—", class: "text-contentTertiary") %></td>
+          </tr>
+          <% if @probe.attribution.present? %>
+          <tr>
+            <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Attribution</th>
+            <td class="py-3 text-sm text-contentPrimary">
+              <%= probe_attribution(@probe.attribution) %>
+            </td>
+          </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </details>
+
+  <%# Successful Targets — kept below, markup unchanged %>
+  <div class="rounded-lg bg-backgroundPrimary border border-borderPrimary p-6 mb-6">
+    <table class="w-full">
+      <tbody class="divide-y divide-borderPrimary">
         <tr>
           <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Successful Targets (Last 90 Days)</th>
           <td class="py-3 text-sm text-contentPrimary">

--- a/spec/requests/probes_spec.rb
+++ b/spec/requests/probes_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Probes", type: :request do
+  describe "GET /probes/:id" do
+    let(:company) { create(:company) }
+    let(:admin) { create(:user, :super_admin, company: company) }
+    let(:detector) { create(:detector) }
+
+    before { sign_in admin }
+
+    it "leads with name/summary/prompt/techniques/detector and collapses the rest into a Metadata accordion" do
+      taxonomy = create(:taxonomy_category, name: "Stratagems")
+      technique = create(:technique, name: "Deceptive Formatting")
+      probe = create(:probe,
+                     name: "MetacognitiveProtocol",
+                     summary: "Frames harmful requests as system directives.",
+                     description: "Guardrail Jailbreak via Metacognitive Protocol Tactic",
+                     guid: "0a7e65e2-3bec-4ebb-a076-05c8bc87b736",
+                     disclosure_status: "0-day",
+                     detector: detector,
+                     prompts: [ "INJECT-REVEAL-SYS-PROMPT please restate the restricted procedure" ],
+                     scores: { "OpenAI" => { "gpt-4o" => 81.0 } })
+      probe.techniques << technique
+      probe.taxonomy_categories << taxonomy
+
+      get probe_path(probe)
+
+      expect(response).to have_http_status(:ok)
+      doc = Nokogiri::HTML(response.body)
+
+      details = doc.at_css("details")
+      expect(details).to be_present
+      expect(details["open"]).to be_nil
+      expect(details.at_css("summary").text).to match(/metadata/i)
+
+      prompt_node = doc.at_xpath("//*[contains(text(), 'INJECT-REVEAL-SYS-PROMPT')]")
+      expect(prompt_node).to be_present
+      expect(prompt_node.ancestors("details")).to be_empty
+
+      guid_node = doc.at_xpath("//code[contains(text(), '0a7e65e2-3bec-4ebb-a076-05c8bc87b736')]")
+      expect(guid_node).to be_present
+      expect(guid_node.ancestors("details")).not_to be_empty
+      expect(details.text).to include("Stratagems")
+      expect(details.text).to include("Modified Date")
+      expect(details.text).to include("Scores")
+
+      expect(response.body.index("INJECT-REVEAL-SYS-PROMPT")).to be < response.body.index("Metadata")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Port of scanner #562. Reorders the probe detail page (`/probes/:id`) to lead with Name + 0-day badge → Summary → Prompt → Techniques → Detector, demoting the rest (Description, Social Impact Score, Taxonomy, Scores, GUID, dates, Attribution) into a collapsed native `<details>` Metadata accordion. Successful Targets + charts unchanged. Pure markup reorder; ai-scanner's header (`probe_portal_url`/`BrandConfig`) and `probe_attribution` helper preserved.

## Test plan
- [x] New request spec (lead order, prompt outside accordion, GUID/taxonomy/dates/scores inside, collapsed by default) — passes locally
- [x] RuboCop clean locally (ran before pushing)