### PR TITLE
fix(report): reconcile probe count with detector evaluations in Detector Statistics header

### DIFF
--- a/app/decorators/report_decorator.rb
+++ b/app/decorators/report_decorator.rb
@@ -17,6 +17,17 @@ class ReportDecorator < SimpleDelegator
     probe_results.size
   end
 
+  # Total per-detector evaluations across the run (Σ detector_results.total).
+  # Reconciles with probe_count in the Detector Statistics header: each probe runs
+  # multiple prompts and each prompt can be scored by multiple detectors, so this
+  # exceeds the probe count. Counts evaluation events, not distinct prompts (a prompt
+  # scored by two detectors is counted once per detector).
+  def detector_evaluation_count
+    # `total` is a nullable column; SUM returns nil when rows exist but every total
+    # is NULL, so coerce to 0 to keep the reconciling line well-formed.
+    __getobj__.detector_results.sum(:total) || 0
+  end
+
   # Highest-ASR probe results for the narrative band's "Top findings" list.
   # Reuses the already-loaded probe_results array. A "finding" is a probe the
   # report treats as vulnerable — keyed on any_detector_passed (consistent with

--- a/app/views/report_details/show.html.erb
+++ b/app/views/report_details/show.html.erb
@@ -83,6 +83,11 @@
       <div class="<%= pdf_mode ? 'mb-3' : 'mb-4' %>">
         <h2 class="<%= pdf_mode ? 'text-lg font-bold text-gray-800' : 'text-xl font-bold text-gray-800' %>">Detector Statistics</h2>
         <p class="<%= pdf_mode ? 'text-xs text-gray-500' : 'text-sm text-gray-500' %>">Security test success rates by detector</p>
+        <p data-detector-reconcile class="<%= pdf_mode ? 'text-xs text-gray-500 mt-0.5' : 'text-sm text-gray-500 mt-1' %>">
+          <%= number_with_delimiter(@report.probe_count) %> <%= 'probe'.pluralize(@report.probe_count) %>
+          ·
+          <%= number_with_delimiter(@report.detector_evaluation_count) %> detector <%= 'evaluation'.pluralize(@report.detector_evaluation_count) %>
+        </p>
       </div>
 
       <div class="<%= pdf_mode ? 'grid grid-cols-2 gap-3' : 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3' %>">
@@ -114,12 +119,13 @@
               <% end %>
             </div>
             <div class="<%= pdf_mode ? 'flex items-center gap-1.5 ml-3 mt-0.5' : 'flex items-center gap-2 ml-4' %>">
-              <div class="flex items-center gap-1">
+              <div data-detector-stat class="flex items-center gap-1">
                 <span class="<%= pdf_mode ? 'font-medium' : 'font-semibold' %> <%= result.passed.to_i > 0 ? 'text-red-600' : 'text-emerald-600' %>">
                   <%= result.passed %>
                 </span>
                 <span class="text-gray-500">/</span>
                 <span class="<%= pdf_mode ? 'text-gray-600' : 'font-medium text-gray-600' %>"><%= result.total %></span>
+                <span class="text-gray-500 <%= pdf_mode ? 'text-[10px]' : 'text-xs' %>"><%= 'evaluation'.pluralize(result.total.to_i) %></span>
               </div>
               <div class="<%= pdf_mode ? 'text-[10px] bg-gray-100 px-1.5 py-0.5 rounded-full' : 'text-xs bg-gray-100 px-2 py-0.5 rounded-full' %>">
                 <%= result.asr_percentage %>% Attack Success Rate (ASR)

--- a/spec/decorators/report_decorator_spec.rb
+++ b/spec/decorators/report_decorator_spec.rb
@@ -112,6 +112,33 @@ RSpec.describe ReportDecorator, type: :decorator do
     end
   end
 
+  describe '#detector_evaluation_count' do
+    it 'sums total across all detector results' do
+      ActsAsTenant.with_tenant(company) do
+        r = create(:report, company: company)
+        d1 = create(:detector, name: 'detector.0din.EvalA')
+        d2 = create(:detector, name: 'detector.0din.EvalB')
+        create(:detector_result, report: r, detector: d1, passed: 100, total: 990)
+        create(:detector_result, report: r, detector: d2, passed: 50, total: 374)
+
+        expect(described_class.new(r).detector_evaluation_count).to eq(1364)
+      end
+    end
+
+    it 'returns zero when there are no detector results' do
+      expect(decorated_report.detector_evaluation_count).to eq(0)
+    end
+
+    it 'returns zero when detector results have nil totals' do
+      ActsAsTenant.with_tenant(company) do
+        r = create(:report, company: company)
+        create(:detector_result, report: r, detector: create(:detector, name: 'detector.0din.NilTotal'), passed: 0, total: nil)
+
+        expect(described_class.new(r).detector_evaluation_count).to eq(0)
+      end
+    end
+  end
+
   describe '#top_findings' do
     let(:probe_a) { create(:probe, name: 'ProbeA') }
     let(:probe_b) { create(:probe, name: 'ProbeB') }

--- a/spec/requests/report_details_spec.rb
+++ b/spec/requests/report_details_spec.rb
@@ -174,6 +174,42 @@ RSpec.describe "ReportDetails", type: :request do
       end
     end
 
+    context "detector statistics reconcile line" do
+      let(:company) { create(:company) }
+      let(:report) { create(:report, :completed, company: company) }
+      let(:pdf_token) do
+        Rails.application.message_verifier(Reports::PdfGenerator::RENDER_TOKEN_VERIFIER_KEY).generate(
+          report.id,
+          expires_in: Reports::PdfGenerator::RENDER_TOKEN_TTL,
+          purpose: Reports::PdfGenerator::RENDER_TOKEN_PURPOSE
+        )
+      end
+
+      it "reconciles the probe count with detector evaluations in the Detector Statistics header" do
+        detector = create(:detector, name: "detector.0din.ReconcileD")
+        probe = create(:probe, name: "ReconcileProbe")
+
+        ActsAsTenant.with_tenant(company) do
+          report.scan.probes << probe unless report.scan.probes.exists?(probe.id)
+          create(:probe_result, report: report, probe: probe, detector: detector, passed: 5, total: 10)
+          create(:detector_result, report: report, detector: detector, passed: 612, total: 990)
+        end
+
+        get report_detail_path(report, pdf: "true", pdf_token: pdf_token)
+
+        expect(response).to have_http_status(:ok)
+        doc = Nokogiri::HTML(response.body)
+
+        reconcile = doc.at_css("[data-detector-reconcile]")
+        expect(reconcile).to be_present
+        expect(reconcile.text.gsub(/\s+/, " ").strip).to eq("1 probe · 990 detector evaluations")
+
+        stat = doc.at_css("[data-detector-stat]")
+        expect(stat).to be_present
+        expect(stat.text.gsub(/\s+/, " ").strip).to include("612 / 990 evaluations")
+      end
+    end
+
     context "with pdf=true but an invalid pdf_token" do
       it "redirects to sign in" do
         get report_detail_path(report, pdf: "true", pdf_token: "invalid-token")


### PR DESCRIPTION
On the customer report, the hero "N Probes" badge counts distinct probes while the Detector Statistics tile denominators are per-detector evaluation totals — different units, summing higher, with nothing labeling the difference. This adds a reconciling line ("N probes · M detector evaluations") under the Detector Statistics subtitle and labels each tile denominator as "evaluations". Labeling only; no data-pipeline change.

Port of 0din-ai/scanner#564.

Test plan:
- [x] `ReportDecorator#detector_evaluation_count` spec (sum, empty, nil-total)
- [x] Request spec asserts the `data-detector-reconcile` line + `data-detector-stat` tile text
- [x] `spec/decorators/report_decorator_spec.rb` + `spec/requests/report_details_spec.rb`: 52 examples, 0 failures; RuboCop clean