### PR TITLE
fix(report): keep probe cards together in PDF export (break-inside-avoid)

### DIFF
--- a/app/views/report_details/show.html.erb
+++ b/app/views/report_details/show.html.erb
@@ -261,8 +261,8 @@
         industry_tag = variant_industry_tag(result.threat_variant)
       %>
 
-      <details id="probe-<%= probe.id %>" class="group" data-report-target="details" <%= 'open' if pdf_mode && result.any_detector_passed %>>
-        <summary class="<%= pdf_mode ? 'bg-white/90 backdrop-blur-sm rounded-lg border p-4 cursor-pointer list-none' : 'bg-white/90 backdrop-blur-sm rounded-xl border p-5 cursor-pointer list-none transition-all duration-300' %> <%= card_border_class %> <%= card_shadow_class %>">
+      <details id="probe-<%= probe.id %>" class="<%= pdf_mode ? 'group break-inside-avoid' : 'group' %>" data-report-target="details" <%= 'open' if pdf_mode && result.any_detector_passed %>>
+        <summary class="<%= pdf_mode ? 'bg-white/90 backdrop-blur-sm rounded-lg border p-4 cursor-pointer list-none break-inside-avoid' : 'bg-white/90 backdrop-blur-sm rounded-xl border p-5 cursor-pointer list-none transition-all duration-300' %> <%= card_border_class %> <%= card_shadow_class %>">
           <div class="<%= pdf_mode ? 'flex items-start justify-between gap-4' : 'flex items-start justify-between gap-6' %>">
             <div class="flex-1 min-w-0">
               <div class="<%= pdf_mode ? 'flex items-center flex-wrap gap-2 mb-2' : 'flex items-center gap-3 mb-3' %>">
@@ -387,7 +387,7 @@
           </div>
         </summary>
 
-        <div class="<%= pdf_mode ? 'px-6 pb-4 page-break-inside-avoid' : 'px-8 pb-6' %>">
+        <div class="<%= pdf_mode ? 'px-6 pb-4' : 'px-8 pb-6' %>">
           <div class="<%= pdf_mode ? 'pl-4 border-l-2 border-gray-200 space-y-3' : 'pl-6 border-l-2 border-gray-200 space-y-4' %>">
             <% (result.attempts || []).each do |attempt| %>
               <% attempt_res = attempt_result(attempt) %>

--- a/spec/requests/report_details_spec.rb
+++ b/spec/requests/report_details_spec.rb
@@ -53,6 +53,34 @@ RSpec.describe "ReportDetails", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
+      it "keeps each probe card together for PDF (break-inside-avoid on details + summary, no dead class)" do
+        detector = create(:detector, name: "detector.0din.BreakD")
+        probe = create(:probe, name: "BreakProbe")
+
+        ActsAsTenant.with_tenant(company) do
+          report.scan.probes << probe unless report.scan.probes.exists?(probe.id)
+          create(:probe_result, report: report, probe: probe, detector: detector,
+                 passed: 1, total: 1, any_detector_passed: true, attempts: [
+                   { "uuid" => "brk-1", "prompt" => "p1", "outputs" => [ "o1" ], "notes" => {}, "attack_succeeded" => true }
+                 ])
+        end
+
+        get report_detail_path(report, pdf: "true", pdf_token: pdf_token)
+
+        expect(response).to have_http_status(:ok)
+        doc = Nokogiri::HTML(response.body)
+
+        details = doc.at_css("details#probe-#{probe.id}")
+        expect(details).to be_present
+        expect(details["class"].split).to include("break-inside-avoid")
+
+        summary = details.at_css("summary")
+        expect(summary["class"].split).to include("break-inside-avoid")
+
+        # The dead Tailwind-v3 class must not return (it compiles to nothing).
+        expect(response.body).not_to include("page-break-inside-avoid")
+      end
+
       it "renders historical reports whose targets have been soft-deleted" do
         target_name = report.target.name
         ActsAsTenant.with_tenant(company) { report.target.mark_deleted! }


### PR DESCRIPTION
Customer-report PDF export (Playwright/Chromium) split probe cards across page boundaries because the probe `<details>` card and its `<summary>` had no break control in pdf_mode, and the attempts container carried a dead Tailwind-v3 `page-break-inside-avoid` class (no-op in Tailwind v4). Adds layered `break-inside-avoid` to the `<details>` and `<summary>`, removes the dead class; each attempt already has a real `break-inside-avoid`.

Port of 0din-ai/scanner#567.

Test plan:
- [x] Render spec asserts `break-inside-avoid` on `<details>` + `<summary>` and that `page-break-inside-avoid` no longer appears
- [x] `spec/requests/report_details_spec.rb`: 33 examples, 0 failures; RuboCop clean