### PR TITLE
fix(security): SSRF validation, tenant isolation, and batch authz hardening

### DIFF
--- a/app/controllers/admin/environment_variables_controller.rb
+++ b/app/controllers/admin/environment_variables_controller.rb
@@ -77,10 +77,17 @@ module Admin
       end
     end
 
-    # Batch action: destroy multiple environment variables
+    # Batch action: destroy multiple environment variables.
+    # SECURITY: authorize explicitly (the standalone POST route can reach this without
+    # going through #batch's dispatcher guard) and scope to the current tenant explicitly
+    # — acts_as_tenant returns ALL rows when the tenant is nil, so an unscoped
+    # `where(id:)` could delete other tenants' encrypted secrets.
     def batch_destroy
+      authorize EnvironmentVariable, :batch_destroy?
+      tenant = ActsAsTenant.current_tenant
       ids = params[:ids] || []
-      count = EnvironmentVariable.where(id: ids).destroy_all.count
+      scope = tenant ? EnvironmentVariable.where(company_id: tenant.id, id: ids) : EnvironmentVariable.none
+      count = scope.destroy_all.count
       redirect_to environment_variables_path,
                   notice: "#{count} environment variable(s) were successfully deleted.",
                   status: :see_other

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -82,18 +82,24 @@ module Admin
     end
 
     # Batch action: stop multiple reports
+    # SECURITY: authorize explicitly (the standalone route bypasses #batch's guard, and
+    # verify_authorized is an after_action so the work would otherwise run before authz)
+    # and scope to the current tenant — acts_as_tenant returns ALL rows when the tenant
+    # is nil (require_tenant=false), so an unscoped where(id:) could span tenants.
     def batch_stop
+      authorize Report, :batch_stop?
       ids = params[:ids] || []
-      Report.where(id: ids).find_each do |report|
+      tenant_scoped_reports(ids).find_each do |report|
         Reports::Stop.new(report).call
       end
       redirect_to reports_path(preserve_params), notice: "Selected reports have been stopped."
     end
 
-    # Batch action: destroy multiple reports
+    # Batch action: destroy multiple reports (see batch_stop for the SECURITY rationale).
     def batch_destroy
+      authorize Report, :batch_destroy?
       ids = params[:ids] || []
-      count = Report.where(id: ids).destroy_all.count
+      count = tenant_scoped_reports(ids).destroy_all.count
       redirect_to reports_path(preserve_params), notice: "#{count} reports were successfully deleted.", status: :see_other
     end
 
@@ -236,6 +242,15 @@ module Admin
     end
 
     private
+
+    # Fail-closed tenant scoping for batch operations: explicitly filter by the current
+    # company so a nil acts_as_tenant context can't span tenants.
+    def tenant_scoped_reports(ids)
+      tenant = ActsAsTenant.current_tenant
+      return Report.none unless tenant
+
+      Report.where(company_id: tenant.id, id: ids)
+    end
 
     def set_report
       @report = Report.includes(:target, :scan,

--- a/app/controllers/admin/scans_controller.rb
+++ b/app/controllers/admin/scans_controller.rb
@@ -130,14 +130,19 @@ module Admin
     end
 
     # Batch actions
+    # SECURITY: authorize explicitly (the standalone route bypasses #batch's guard, and
+    # verify_authorized is an after_action so the work would otherwise run before authz)
+    # and scope to the current tenant — acts_as_tenant returns ALL rows when the tenant
+    # is nil (require_tenant=false), so an unscoped where(id:) could span tenants.
     def batch_rerun
+      authorize Scan, :batch_rerun?
       ids = params[:ids] || []
       unless current_company.scan_allowed?
         redirect_to scans_path(scope: params[:scope]), alert: quota_exhausted_message
         return
       end
       count = 0
-      Scan.where(id: ids).find_each do |scan|
+      tenant_scoped_scans(ids).find_each do |scan|
         scan.rerun
         count += 1
       end
@@ -145,12 +150,22 @@ module Admin
     end
 
     def batch_destroy
+      authorize Scan, :batch_destroy?
       ids = params[:ids] || []
-      destroyed = Scan.where(id: ids).destroy_all.count
+      destroyed = tenant_scoped_scans(ids).destroy_all.count
       redirect_to scans_path(scope: params[:scope]), notice: "#{destroyed} scan(s) have been deleted.", status: :see_other
     end
 
     private
+
+    # Fail-closed tenant scoping for batch operations: explicitly filter by the current
+    # company so a nil acts_as_tenant context can't span tenants.
+    def tenant_scoped_scans(ids)
+      tenant = ActsAsTenant.current_tenant
+      return Scan.none unless tenant
+
+      Scan.where(company_id: tenant.id, id: ids)
+    end
 
     def set_scan
       @scan = Scan.find(params[:id])

--- a/app/controllers/admin/targets_controller.rb
+++ b/app/controllers/admin/targets_controller.rb
@@ -101,8 +101,12 @@ module Admin
 
     # Batch validate
     def batch_validate
+      # SECURITY: authorize explicitly (the standalone route bypasses #batch's guard)
+      # and scope to the current tenant — acts_as_tenant returns ALL rows when the
+      # tenant is nil, so an unscoped where(id:) could touch other tenants' targets.
+      authorize Target, :batch_validate?
       ids = params[:ids] || []
-      valid_targets = Target.where(id: ids).where(deleted_at: nil)
+      valid_targets = tenant_scoped_targets(ids).where(deleted_at: nil)
       target_count = valid_targets.count
 
       if target_count > 0
@@ -117,9 +121,10 @@ module Admin
 
     # Batch action: destroy (soft delete) multiple targets
     def batch_destroy
+      authorize Target, :batch_destroy?
       ids = params[:ids] || []
       count = 0
-      Target.where(id: ids).find_each do |target|
+      tenant_scoped_targets(ids).find_each do |target|
         target.mark_deleted!
         count += 1
       end
@@ -221,6 +226,15 @@ module Admin
     end
 
     private
+
+    # Fail-closed tenant scoping for batch operations: explicitly filter by the
+    # current company so a nil acts_as_tenant context can't span tenants.
+    def tenant_scoped_targets(ids)
+      tenant = ActsAsTenant.current_tenant
+      return Target.none unless tenant
+
+      Target.where(company_id: tenant.id, id: ids)
+    end
 
     def set_target
       # Allow show/restore to access deleted (archived) targets

--- a/app/models/output_server.rb
+++ b/app/models/output_server.rb
@@ -17,6 +17,8 @@ class OutputServer < ApplicationRecord
   validates :port, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 65535 }, allow_nil: true
   validates :protocol, inclusion: { in: %w[http https udp tcp tls], message: "%{value} is not a valid protocol" }, allow_nil: false
   validate :additional_settings_is_valid_json, if: -> { additional_settings.present? }
+  validate :host_is_safe, if: -> { host.present? }
+  validate :endpoint_path_is_safe, if: -> { endpoint_path.present? }
 
   scope :enabled, -> { where(enabled: true) }
 
@@ -41,7 +43,7 @@ class OutputServer < ApplicationRecord
   end
 
   def connection_string
-    "#{protocol}://#{host}:#{port}#{endpoint_path}"
+    "#{protocol}://#{authority_host}:#{port}#{endpoint_path}"
   end
 
   def authentication_method
@@ -51,11 +53,84 @@ class OutputServer < ApplicationRecord
     :none
   end
 
+  # Re-validate the destination at SEND time. Save-time validation can't stop DNS
+  # rebinding (a host that resolved to a public IP at save can later point at an
+  # internal address), so the send services re-resolve + re-check right before use.
+  # Validate the EFFECTIVE host parsed from connection_string (not just the raw host
+  # field): a stale row whose endpoint_path injects userinfo — e.g. "@169.254.169.254/x"
+  # — would otherwise pass while the connection targets the injected internal host.
+  # Returns false when unsafe; callers MUST abort the send.
+  def destination_safe?
+    return false if host.blank?
+    return false unless effective_request_host == normalized_host
+
+    UrlSafetyValidator.safe_host?(host, allow_localhost: UrlSafetyValidator.allow_localhost?).safe?
+  end
+
+  # Host actually targeted by connection_string, normalized for comparison (IPv6 literals
+  # are bracketed in the URI authority; URI.parse returns them bracketed, so strip them).
+  def effective_request_host
+    parsed = URI.parse(connection_string).host
+    parsed.nil? ? nil : strip_brackets(parsed)
+  rescue URI::InvalidURIError
+    nil
+  end
+
   def additional_settings_is_valid_json
     begin
       JSON.parse(additional_settings)
     rescue JSON::ParserError => e
       errors.add(:additional_settings, "must be valid JSON. Error: #{e.message}")
     end
+  end
+
+  # SECURITY: report data is shipped to this host over raw TCP/HTTP/TLS. Without a
+  # check, a tenant could point an "output server" at internal/metadata addresses
+  # (SSRF / exfil to internal services). Resolve + block internal ranges.
+  def host_is_safe
+    # A SIEM host must be a bare hostname/IP. Reject URI delimiters that would change
+    # the effective host once concatenated into connection_string — e.g.
+    # "example.com@169.254.169.254" (userinfo) or "host/path" — and thereby slip past
+    # the resolve-based SSRF check below.
+    if host.to_s.match?(%r{[\s/@\\?#%$]})
+      errors.add(:host, "contains invalid characters")
+      return
+    end
+
+    result = UrlSafetyValidator.safe_host?(host, allow_localhost: UrlSafetyValidator.allow_localhost?)
+    # Fail closed (incl. unresolvable hosts): an unresolvable host can be rebound to an
+    # internal address before report data is shipped to it.
+    return if result.safe?
+
+    errors.add(:host, "is not allowed: #{result.error}")
+  end
+
+  # SECURITY: endpoint_path is concatenated into connection_string after host:port, so a
+  # value like "@169.254.169.254/latest" injects a different host (userinfo) and bypasses
+  # host_is_safe. Require a plain path beginning with "/".
+  def endpoint_path_is_safe
+    path = endpoint_path.to_s
+    return if path.start_with?("/") && !path.match?(%r{[@\\]|\s|//})
+
+    errors.add(:endpoint_path, "must be a plain path beginning with '/' (no '@', '\\', whitespace, or '//')")
+  end
+
+  private
+
+  # Bracket a bare IPv6 literal so it parses inside a URI authority (a plain "2001:db8::1"
+  # makes URI.parse raise, which would fail-close every IPv6 SIEM destination).
+  def authority_host
+    h = host.to_s
+    h.include?(":") && !h.start_with?("[") ? "[#{h}]" : h
+  end
+
+  # host with any surrounding IPv6 brackets removed, so it compares equal to the
+  # bracket-stripped host parsed back out of connection_string.
+  def normalized_host
+    strip_brackets(host.to_s)
+  end
+
+  def strip_brackets(value)
+    value.to_s.delete_prefix("[").delete_suffix("]")
   end
 end

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -36,6 +36,7 @@ class Target < ApplicationRecord
   validates :model, presence: true, if: :api?
   validates :model, format: { with: MODEL_FORMAT, message: "contains invalid characters (only letters, numbers, hyphens, underscores, slashes, dots, colons, and @ are allowed)" }, if: -> { api? && model.present? }
   validate :json_config_is_valid_json, if: :json_config_should_be_validated?
+  validate :json_config_uri_is_safe, if: :json_config_should_be_validated?
   validate :web_config_is_valid, if: :webchat?
 
   before_validation :set_defaults_for_webchat
@@ -116,6 +117,19 @@ class Target < ApplicationRecord
     end
   end
 
+  # Re-validate the RestGenerator URI at SCAN-LAUNCH time. Save-time validation can't
+  # stop DNS rebinding (the host may point at an internal address by the time garak
+  # fetches it), so the scan runner re-checks right before launching. Returns true for
+  # non-REST targets (no uri to fetch).
+  def rest_uri_safe?
+    uri = rest_generator_uri
+    return true if uri.nil?
+    return false unless uri.is_a?(String) && uri.present?
+    return false if uri_host_has_placeholder?(uri)
+
+    UrlSafetyValidator.safe_url?(uri, allow_localhost: UrlSafetyValidator.allow_localhost?).safe?
+  end
+
   # Normalize Hash/Array to JSON string before the encrypted attribute type
   # casts via .to_s (which produces Ruby notation, not valid JSON).
   def json_config=(value)
@@ -176,6 +190,55 @@ class Target < ApplicationRecord
     JSON.parse(json_config)
   rescue JSON::ParserError => e
     errors.add(:json_config, "must be valid JSON. Error: #{e.message}")
+  end
+
+  # SECURITY: the RestGenerator uri is fetched by garak as the scan target. Without a
+  # check a tenant could point it at internal/metadata addresses (SSRF). Resolve + block
+  # internal ranges, fail closed. The host may also contain env-var placeholders (e.g.
+  # "$SSRF_HOST") that are substituted at scan time before garak runs — reject those too,
+  # since the substituted value isn't screened here.
+  def json_config_uri_is_safe
+    uri = rest_generator_uri
+    return if uri.nil?
+
+    unless uri.is_a?(String)
+      errors.add(:json_config, "target URL must be a string")
+      return
+    end
+    return if uri.blank?
+
+    if uri_host_has_placeholder?(uri)
+      errors.add(:json_config, "target URL host must not contain environment-variable placeholders")
+      return
+    end
+
+    result = UrlSafetyValidator.safe_url?(uri, allow_localhost: UrlSafetyValidator.allow_localhost?)
+    return if result.safe?
+
+    errors.add(:json_config, "target URL is not allowed: #{result.error}")
+  end
+
+  def uri_host_has_placeholder?(uri)
+    URI.parse(uri).host.to_s.include?("$")
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def rest_generator_uri
+    return nil if json_config.blank?
+
+    parsed = JSON.parse(json_config)
+    return nil unless parsed.is_a?(Hash)
+
+    rest = parsed["rest"]
+    return nil unless rest.is_a?(Hash)
+
+    generator = rest["RestGenerator"]
+    return nil unless generator.is_a?(Hash)
+
+    generator["uri"]
+  rescue JSON::ParserError
+    nil
   end
 
   def web_config_is_valid

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
 
   # Devise modules (engine may add :omniauthable)
   devise :database_authenticatable, :recoverable, :rememberable,
-         :validatable, :lockable
+         :validatable, :lockable, :timeoutable
 
   # Super admin scopes and methods
   scope :super_admins, -> { where(super_admin: true) }

--- a/app/services/output_servers/rsyslog.rb
+++ b/app/services/output_servers/rsyslog.rb
@@ -1,5 +1,10 @@
 module OutputServers
   class Rsyslog
+    # SECURITY: TLS cert/key/CA paths come from tenant-controlled additional_settings.
+    # Only honor paths inside an operator-configured allowlist directory (SIEM_CERT_DIR)
+    # so a tenant cannot read arbitrary files (e.g. /etc/passwd, config/master.key).
+    ALLOWED_CERT_DIR = ENV["SIEM_CERT_DIR"].presence
+
     attr_reader :report
 
     def initialize(report)
@@ -10,6 +15,11 @@ module OutputServers
       return unless output_server
       return unless output_server.enabled
       return unless output_server.server_type == "rsyslog"
+
+      unless output_server.destination_safe?
+        Rails.logger.error("[rsyslog] aborting send for report #{report&.uuid}: host #{output_server.host} failed the SSRF recheck")
+        return
+      end
 
       begin
         case output_server.protocol
@@ -34,6 +44,35 @@ module OutputServers
 
     def output_server
       report.scan.output_server
+    end
+
+    # Returns an absolute path ONLY if it resides inside the allowlisted
+    # SIEM_CERT_DIR and the file exists; otherwise nil (path rejected/logged).
+    # Prevents tenant-supplied additional_settings from reading arbitrary files.
+    def safe_cert_path(path)
+      return nil if path.blank?
+
+      if ALLOWED_CERT_DIR.blank?
+        Rails.logger.error("[rsyslog] TLS cert path ignored: SIEM_CERT_DIR is not configured")
+        return nil
+      end
+
+      base = File.expand_path(ALLOWED_CERT_DIR)
+      expanded = File.expand_path(path, base)
+      unless expanded.start_with?(base + File::SEPARATOR) && File.file?(expanded)
+        Rails.logger.error("[rsyslog] TLS cert path rejected (outside #{ALLOWED_CERT_DIR}): #{path}")
+        return nil
+      end
+
+      expanded
+    end
+
+    # Abort a TLS send (return without connecting) when a configured cert/CA path is
+    # rejected, so we never ship report data without the cert/verification the
+    # operator explicitly configured.
+    def abort_tls_send(reason)
+      Rails.logger.error("[rsyslog] aborting TLS send for #{report.uuid}: #{reason}")
+      nil
     end
 
     def send_via_udp
@@ -72,15 +111,26 @@ module OutputServers
         begin
           settings = JSON.parse(output_server.additional_settings)
 
-          # Add client certificates if provided
-          if settings["tls_cert_file"] && settings["tls_key_file"]
-            context.cert = OpenSSL::X509::Certificate.new(File.read(settings["tls_cert_file"]))
-            context.key = OpenSSL::PKey::RSA.new(File.read(settings["tls_key_file"]))
+          # Client certificates (paths constrained to SIEM_CERT_DIR). If the operator
+          # configured a cert/key but the path is rejected, ABORT — do not connect
+          # without the client cert they required.
+          if settings["tls_cert_file"].present? || settings["tls_key_file"].present?
+            cert_path = safe_cert_path(settings["tls_cert_file"])
+            key_path = safe_cert_path(settings["tls_key_file"])
+            return abort_tls_send("client certificate path not allowed (set SIEM_CERT_DIR)") unless cert_path && key_path
+
+            context.cert = OpenSSL::X509::Certificate.new(File.read(cert_path))
+            context.key = OpenSSL::PKey::RSA.new(File.read(key_path))
           end
 
-          # Add CA certificate if provided
-          if settings["ca_file"]
-            context.ca_file = settings["ca_file"]
+          # CA certificate (path constrained to SIEM_CERT_DIR). If configured but
+          # rejected, ABORT rather than silently downgrading to VERIFY_NONE — sending
+          # report data without the requested server verification is a MITM risk.
+          if settings["ca_file"].present?
+            ca_path = safe_cert_path(settings["ca_file"])
+            return abort_tls_send("CA certificate path not allowed (set SIEM_CERT_DIR)") unless ca_path
+
+            context.ca_file = ca_path
             context.verify_mode = OpenSSL::SSL::VERIFY_PEER
           end
         rescue JSON::ParserError => e

--- a/app/services/output_servers/splunk.rb
+++ b/app/services/output_servers/splunk.rb
@@ -15,6 +15,11 @@ module OutputServers
       return unless output_server.enabled
       return unless output_server.server_type == "splunk"
 
+      unless output_server.destination_safe?
+        Rails.logger.error("[Splunk] aborting send for report #{report&.uuid}: host #{output_server.host} failed the SSRF recheck")
+        return
+      end
+
       uri = URI.parse(endpoint_url)
       http = setup_http_connection(uri)
 

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -30,6 +30,14 @@ class RunGarakScan
       return
     end
 
+    # Re-validate the RestGenerator URL just before launch. Save-time validation can't
+    # stop DNS rebinding — the host may resolve to an internal address by now even if it
+    # was safe when the target was saved. Only reached when garak will actually run.
+    unless target.rest_uri_safe?
+      handle_unsafe_target_uri
+      return
+    end
+
     if MonitoringService.active?
       MonitoringService.transaction("run_garak_scan", "background") do
         MonitoringService.set_label(:report_uuid, report.uuid)
@@ -134,6 +142,22 @@ class RunGarakScan
       Rails.logger.info(yellow + "argv: #{argv.inspect}" + reset)
       Rails.logger.info(separator)
     end
+  end
+
+  def handle_unsafe_target_uri
+    error_message = "Target '#{target.name}' URL failed a safety check (it may resolve to a disallowed address). The scan was aborted."
+    Rails.logger.error("[RunGarakScan] aborting report #{report.id}: target #{target.id} (#{target.name}) RestGenerator URL failed the SSRF recheck")
+    sanitized = Reports::FailureClassifier.sanitize_text(error_message)
+    report.update(
+      status: :failed,
+      logs: "Scan failed: #{sanitized}",
+      failure_code: "target_url_unsafe",
+      failure_message: sanitized,
+      failure_details: {
+        "target_id" => target.id,
+        "target_name" => Reports::FailureClassifier.sanitize_text(target.name)
+      }
+    )
   end
 
   def handle_invalid_target_status

--- a/app/services/stats/average_asr_score.rb
+++ b/app/services/stats/average_asr_score.rb
@@ -26,18 +26,22 @@ module Stats
       # Previous: fetched N rows, averaged in Ruby. Now: single SQL AVG()
       date_condition = since_date ? "AND reports.created_at >= :since_date" : ""
 
+      # SECURITY: raw SQL bypasses acts_as_tenant's default scope, so we MUST filter by
+      # the current tenant's company_id explicitly. Fail closed (no tenant => no rows => 0).
+      company_id = ActsAsTenant.current_tenant&.id
+
       sql = <<~SQL.squish
         SELECT AVG(per_report_rate) as avg FROM (
           SELECT (SUM(probe_results.passed)::float / NULLIF(SUM(probe_results.total), 0)::float * 100) as per_report_rate
           FROM reports
           INNER JOIN probe_results ON probe_results.report_id = reports.id
-          WHERE probe_results.total > 0 #{date_condition}
+          WHERE probe_results.total > 0 AND reports.company_id = :company_id #{date_condition}
           GROUP BY reports.id
         ) subquery
       SQL
 
       result = ActiveRecord::Base.connection.select_value(
-        ActiveRecord::Base.sanitize_sql_array([ sql, { since_date: since_date } ])
+        ActiveRecord::Base.sanitize_sql_array([ sql, { since_date: since_date, company_id: company_id } ])
       )
       (result.to_f || 0).round(2)
     end
@@ -86,7 +90,11 @@ module Stats
     end
 
     def base_report_query(since_date)
-      query = Report.joins(:probe_results).where("probe_results.total > 0")
+      # SECURITY: fail closed on a missing tenant. acts_as_tenant returns ALL rows when
+      # current_tenant is nil, which would leak the time series across tenants — so scope
+      # by company_id explicitly (nil => no rows), mirroring the scalar average.
+      query = Report.where(company_id: ActsAsTenant.current_tenant&.id)
+                    .joins(:probe_results).where("probe_results.total > 0")
       since_date.present? ? query.where("reports.created_at >= ?", since_date) : query
     end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,9 +88,16 @@ Rails.application.configure do
   #
   # IMPORTANT: Be careful with this setting as it determines which domains can access
   # the session cookie. Use the most specific domain possible for security.
-  if ENV["SESSION_COOKIE_DOMAIN"].present?
-    config.session_store :cookie_store, key: "_scanner_session", domain: ENV["SESSION_COOKIE_DOMAIN"]
-  end
+  # SECURITY: set the session cookie Secure + SameSite flags. With a TLS-terminating
+  # proxy (force_ssl=false, ASSUME_SSL=true), Rails does not add Secure automatically,
+  # so set it explicitly. Applied whether or not SESSION_COOKIE_DOMAIN is configured.
+  session_options = {
+    key: "_scanner_session",
+    secure: ENV.fetch("ASSUME_SSL", "false") == "true",
+    same_site: :lax
+  }
+  session_options[:domain] = ENV["SESSION_COOKIE_DOMAIN"] if ENV["SESSION_COOKIE_DOMAIN"].present?
+  config.session_store :cookie_store, **session_options
 
   # Configure logging with file rotation and STDOUT output
   log_dir = Rails.root.join("storage/logs/rails")

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,21 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :https
+    policy.style_src   :self, :https, :unsafe_inline
+    policy.base_uri    :self
+    policy.frame_ancestors :self
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Start REPORT-ONLY: the header is present and violations are reported, but nothing
+  # is blocked — so a missed asset origin (importmap CDN, charts) cannot break the app.
+  # Promote to enforcing (set this to false) after confirming no violations in prod.
+  config.content_security_policy_report_only = true
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -186,7 +186,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 60.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/spec/controllers/admin/environment_variables_controller_spec.rb
+++ b/spec/controllers/admin/environment_variables_controller_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::EnvironmentVariablesController, type: :controller do
+  let!(:company) { create(:company, tier: :tier_2) }
+  let!(:user) { create(:user, :super_admin, company: company) }
+
+  before do
+    user.update!(current_company: company)
+    sign_in user
+    ActsAsTenant.current_tenant = company
+  end
+
+  describe "POST #batch_destroy" do
+    it "destroys the current tenant's selected environment variables" do
+      ours = ActsAsTenant.with_tenant(company) { create(:environment_variable, company: company) }
+
+      expect {
+        post :batch_destroy, params: { ids: [ ours.id ] }
+      }.to change(EnvironmentVariable, :count).by(-1)
+    end
+
+    it "does NOT destroy another tenant's environment variable (cross-tenant guard)" do
+      other_company = create(:company, tier: :tier_2)
+      other_var = ActsAsTenant.with_tenant(other_company) { create(:environment_variable, company: other_company) }
+
+      post :batch_destroy, params: { ids: [ other_var.id ] }
+
+      survives = ActsAsTenant.without_tenant { EnvironmentVariable.where(id: other_var.id).exists? }
+      expect(survives).to be(true)
+    end
+  end
+end

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -372,4 +372,22 @@ RSpec.describe Admin::ReportsController, type: :controller do
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
+
+  describe "batch actions are tenant-scoped (cross-tenant guard)" do
+    let!(:other_company) { create(:company, tier: :tier_4) }
+    let!(:other_report) { ActsAsTenant.with_tenant(other_company) { create(:report, :completed, company: other_company) } }
+
+    it "POST #batch_destroy does not delete another tenant's report" do
+      post :batch_destroy, params: { ids: [ other_report.id ] }
+
+      survives = ActsAsTenant.without_tenant { Report.where(id: other_report.id).exists? }
+      expect(survives).to be(true)
+    end
+
+    it "POST #batch_stop does not stop another tenant's report" do
+      expect(Reports::Stop).not_to receive(:new)
+
+      post :batch_stop, params: { ids: [ other_report.id ] }
+    end
+  end
 end

--- a/spec/controllers/admin/scans_controller_spec.rb
+++ b/spec/controllers/admin/scans_controller_spec.rb
@@ -197,4 +197,22 @@ RSpec.describe Admin::ScansController, type: :controller do
       end
     end
   end
+
+  describe "batch actions are tenant-scoped (cross-tenant guard)" do
+    let!(:other_company) { create(:company, tier: :tier_4) }
+    let!(:other_scan) { ActsAsTenant.with_tenant(other_company) { create(:complete_scan, company: other_company) } }
+
+    it "POST #batch_destroy does not delete another tenant's scan" do
+      post :batch_destroy, params: { ids: [ other_scan.id ] }
+
+      survives = ActsAsTenant.without_tenant { Scan.where(id: other_scan.id).exists? }
+      expect(survives).to be(true)
+    end
+
+    it "POST #batch_rerun does not rerun another tenant's scan" do
+      expect_any_instance_of(Scan).not_to receive(:rerun)
+
+      post :batch_rerun, params: { ids: [ other_scan.id ] }
+    end
+  end
 end

--- a/spec/controllers/admin/targets_controller_spec.rb
+++ b/spec/controllers/admin/targets_controller_spec.rb
@@ -120,4 +120,24 @@ RSpec.describe Admin::TargetsController, type: :controller do
       expect(JSON.parse(response.body)["error"]).to include("[REDACTED]")
     end
   end
+
+  describe "batch actions are tenant-scoped (cross-tenant guard)" do
+    let!(:other_company) { create(:company, name: "Other Co", tier: :tier_2) }
+    let!(:other_target) do
+      ActsAsTenant.with_tenant(other_company) { create(:target, company: other_company, name: "Other Target") }
+    end
+
+    it "POST #batch_destroy does not archive another tenant's target" do
+      post :batch_destroy, params: { ids: [ other_target.id ] }
+
+      still_present = ActsAsTenant.without_tenant { Target.with_deleted.find(other_target.id) }
+      expect(still_present.deleted_at).to be_nil
+    end
+
+    it "POST #batch_validate does not enqueue validation for another tenant's target" do
+      expect(ValidateTargetJob).not_to receive(:perform_later)
+
+      post :batch_validate, params: { ids: [ other_target.id ] }
+    end
+  end
 end

--- a/spec/factories/output_servers.rb
+++ b/spec/factories/output_servers.rb
@@ -3,7 +3,9 @@ FactoryBot.define do
     association :company
     sequence(:name) { |n| "#{Faker::App.name}_#{n}" }
     server_type { 'splunk' }
-    host { Faker::Internet.ip_v4_address }
+    # Deterministic non-blocked (TEST-NET-3) address so the host-SSRF validation passes —
+    # Faker's random IPs can land in private/blocked ranges and flake.
+    host { '203.0.113.10' }
     port { 8088 }
     protocol { 'https' }
     endpoint_path { '/services/collector' }

--- a/spec/models/ssrf_hardening_spec.rb
+++ b/spec/models/ssrf_hardening_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+# Guards the SSRF hardening: the Target RestGenerator uri and the OutputServer host /
+# endpoint_path must be screened by UrlSafetyValidator before any request is made.
+RSpec.describe "SSRF hardening" do
+  let(:company) { create(:company) }
+
+  describe Target do
+    def api_target(uri)
+      build(:target, company: company, json_config: { rest: { RestGenerator: { uri: uri } } }.to_json)
+    end
+
+    it "rejects a RestGenerator uri that resolves to internal/metadata addresses" do
+      ActsAsTenant.with_tenant(company) do
+        # 169.254 (cloud metadata) + RFC1918 are blocked regardless of env. Loopback is
+        # intentionally allowed in dev/test (allow_localhost?), so it's not asserted here.
+        %w[http://169.254.169.254/latest/meta-data/ http://10.1.2.3/ http://172.16.5.5/].each do |uri|
+          t = api_target(uri)
+          expect(t.valid?).to be(false), "expected #{uri} to be rejected"
+          expect(t.errors[:json_config].join).to match(/not allowed/i)
+        end
+      end
+    end
+
+    it "allows a RestGenerator uri pointing at a public address" do
+      ActsAsTenant.with_tenant(company) do
+        t = api_target("http://8.8.8.8/v1/chat")
+        t.valid?
+        expect(t.errors[:json_config]).to be_empty
+      end
+    end
+
+    it "rejects a RestGenerator host containing an env-var placeholder (substituted to internal at scan time)" do
+      ActsAsTenant.with_tenant(company) do
+        [ "http://$SSRF_HOST/latest", "http://$X.example.com/v1" ].each do |uri|
+          t = api_target(uri)
+          expect(t.valid?).to be(false), "expected #{uri} rejected"
+          expect(t.errors[:json_config].join).to match(/placeholder/i)
+        end
+      end
+    end
+
+    it "rejects a non-string RestGenerator uri (crafted-JSON type confusion)" do
+      ActsAsTenant.with_tenant(company) do
+        t = build(:target, company: company, json_config: { rest: { RestGenerator: { uri: { evil: 1 } } } }.to_json)
+        expect(t.valid?).to be(false)
+        expect(t.errors[:json_config].join).to match(/must be a string/i)
+      end
+    end
+
+    it "Target#rest_uri_safe? re-validates the RestGenerator uri at launch time" do
+      ActsAsTenant.with_tenant(company) do
+        internal = api_target("http://169.254.169.254/")
+        expect(internal.rest_uri_safe?).to be(false)
+
+        public_t = api_target("http://8.8.8.8/v1")
+        expect(public_t.rest_uri_safe?).to be(true)
+
+        # non-REST target (no uri to fetch) is considered safe
+        expect(build(:target, company: company).rest_uri_safe?).to be(true)
+      end
+    end
+  end
+
+  describe OutputServer do
+    it "rejects an internal host" do
+      ActsAsTenant.with_tenant(company) do
+        os = build(:output_server, company: company, host: "169.254.169.254")
+        os.valid?
+        expect(os.errors[:host].join).to match(/not allowed/i)
+      end
+    end
+
+    it "allows a public host" do
+      ActsAsTenant.with_tenant(company) do
+        os = build(:output_server, company: company, host: "8.8.8.8")
+        os.valid?
+        expect(os.errors[:host]).to be_empty
+      end
+    end
+
+    it "rejects hosts containing URI delimiters (userinfo/path injection bypass)" do
+      ActsAsTenant.with_tenant(company) do
+        [ "example.com@169.254.169.254", "169.254.169.254#x", "host/path", "a b", "$SSRF_HOST" ].each do |h|
+          os = build(:output_server, company: company, host: h)
+          os.valid?
+          expect(os.errors[:host].join).to match(/invalid characters/i), "expected #{h} to be rejected"
+        end
+      end
+    end
+
+    it "rejects an endpoint_path that injects a host via userinfo (@) and allows a plain path" do
+      ActsAsTenant.with_tenant(company) do
+        bad = build(:output_server, company: company, host: "8.8.8.8", endpoint_path: "@169.254.169.254/latest")
+        bad.valid?
+        expect(bad.errors[:endpoint_path].join).to match(/plain path/i)
+
+        good = build(:output_server, company: company, host: "8.8.8.8", endpoint_path: "/services/collector")
+        good.valid?
+        expect(good.errors[:endpoint_path]).to be_empty
+      end
+    end
+
+    describe "#destination_safe? (send-time DNS-rebinding recheck)" do
+      it "re-resolves and blocks internal hosts, allows public hosts" do
+        ActsAsTenant.with_tenant(company) do
+          expect(build(:output_server, company: company, host: "169.254.169.254").destination_safe?).to be(false)
+          expect(build(:output_server, company: company, host: "8.8.8.8").destination_safe?).to be(true)
+        end
+      end
+
+      it "validates the EFFECTIVE host (stale endpoint_path userinfo injection)" do
+        ActsAsTenant.with_tenant(company) do
+          # build() skips validation, simulating a row saved before endpoint_path was checked.
+          os = build(:output_server, company: company, host: "8.8.8.8", port: 443, endpoint_path: "@169.254.169.254/latest")
+          expect(os.destination_safe?).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/output_servers/rsyslog_spec.rb
+++ b/spec/services/output_servers/rsyslog_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe OutputServers::Rsyslog do
-  let(:output_server) { instance_double(OutputServer, server_type: 'rsyslog', protocol: 'udp', host: 'syslog.example.com', port: 514, enabled: true) }
+  let(:output_server) { instance_double(OutputServer, server_type: 'rsyslog', protocol: 'udp', host: 'syslog.example.com', port: 514, enabled: true, destination_safe?: true) }
   let(:scan) { instance_double(Scan, output_server: output_server) }
   let(:report) { instance_double(Report, scan: scan, uuid: 'test-uuid') }
   let(:service) { OutputServers::Rsyslog.new(report) }
@@ -38,7 +38,7 @@ RSpec.describe OutputServers::Rsyslog do
     end
 
     context 'when using TCP protocol' do
-      let(:tcp_output_server) { instance_double(OutputServer, server_type: 'rsyslog', protocol: 'tcp', host: 'syslog.example.com', port: 514, enabled: true) }
+      let(:tcp_output_server) { instance_double(OutputServer, server_type: 'rsyslog', protocol: 'tcp', host: 'syslog.example.com', port: 514, enabled: true, destination_safe?: true) }
       let(:tcp_scan) { instance_double(Scan, output_server: tcp_output_server) }
       let(:tcp_report) { instance_double(Report, scan: tcp_scan, uuid: 'test-uuid') }
       let(:tcp_service) { OutputServers::Rsyslog.new(tcp_report) }
@@ -50,6 +50,22 @@ RSpec.describe OutputServers::Rsyslog do
       it 'calls send_via_tcp' do
         expect(tcp_service).to receive(:send_via_tcp)
         tcp_service.call
+      end
+    end
+
+    context 'when the destination fails the SSRF recheck' do
+      let(:unsafe_output_server) { instance_double(OutputServer, server_type: 'rsyslog', protocol: 'udp', host: '169.254.169.254', port: 514, enabled: true, destination_safe?: false) }
+      let(:unsafe_scan) { instance_double(Scan, output_server: unsafe_output_server) }
+      let(:unsafe_report) { instance_double(Report, scan: unsafe_scan, uuid: 'test-uuid') }
+      let(:unsafe_service) { OutputServers::Rsyslog.new(unsafe_report) }
+
+      it 'aborts without opening a socket and logs the recheck failure' do
+        allow(Rails.logger).to receive(:error)
+        expect(UDPSocket).not_to receive(:new)
+
+        unsafe_service.call
+
+        expect(Rails.logger).to have_received(:error).with(/failed the SSRF recheck/)
       end
     end
 
@@ -86,6 +102,43 @@ RSpec.describe OutputServers::Rsyslog do
         expect(UDPSocket).not_to receive(:new)
         wrong_type_service.call
       end
+    end
+  end
+
+  describe 'TLS cert-path allowlist (SIEM_CERT_DIR)' do
+    let(:svc) { OutputServers::Rsyslog.allocate }
+
+    it 'rejects cert paths outside SIEM_CERT_DIR (and traversal)' do
+      Dir.mktmpdir do |dir|
+        stub_const('OutputServers::Rsyslog::ALLOWED_CERT_DIR', dir)
+        allow(Rails.logger).to receive(:error)
+
+        expect(svc.send(:safe_cert_path, '/etc/passwd')).to be_nil
+        expect(svc.send(:safe_cert_path, '../../etc/passwd')).to be_nil
+
+        File.write(File.join(dir, 'client.pem'), 'x')
+        expect(svc.send(:safe_cert_path, 'client.pem')).to eq(File.join(dir, 'client.pem'))
+      end
+    end
+
+    it 'ignores all cert paths when SIEM_CERT_DIR is unset' do
+      stub_const('OutputServers::Rsyslog::ALLOWED_CERT_DIR', nil)
+      allow(Rails.logger).to receive(:error)
+      expect(svc.send(:safe_cert_path, '/etc/passwd')).to be_nil
+    end
+
+    it 'aborts the TLS send (no socket) when a configured CA path is rejected (no VERIFY_NONE downgrade)' do
+      stub_const('OutputServers::Rsyslog::ALLOWED_CERT_DIR', nil)
+      os = instance_double(OutputServer, server_type: 'rsyslog', protocol: 'tls', host: '8.8.8.8',
+                           port: 6514, enabled: true, destination_safe?: true,
+                           additional_settings: { ca_file: '/etc/ssl/ca.pem' }.to_json)
+      report = instance_double(Report, scan: instance_double(Scan, output_server: os), uuid: 'tls-uuid')
+      allow(Rails.logger).to receive(:error)
+      expect(TCPSocket).not_to receive(:new)
+
+      OutputServers::Rsyslog.new(report).call
+
+      expect(Rails.logger).to have_received(:error).with(/aborting TLS send/)
     end
   end
 end

--- a/spec/services/output_servers/splunk_spec.rb
+++ b/spec/services/output_servers/splunk_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe OutputServers::Splunk do
                                         enabled: true,
                                         connection_string: 'https://splunk.example.com:8088',
                                         access_token: 'test_token',
+                                        destination_safe?: true,
                                         endpoint_path: nil) }
   let(:scan) { instance_double(Scan, output_server: output_server) }
   let(:target) { instance_double(Target, name: 'test-target', model: 'gpt-4', model_type: 'openai') }
@@ -52,6 +53,27 @@ RSpec.describe OutputServers::Splunk do
       expect(Rails.logger).to receive(:info).with("Successfully sent report data to Splunk")
 
       service.call
+    end
+
+    context 'when the destination fails the SSRF recheck' do
+      let(:unsafe_output_server) do
+        instance_double(OutputServer, server_type: 'splunk', protocol: 'https',
+                        host: '169.254.169.254', port: 8088, enabled: true,
+                        connection_string: 'https://169.254.169.254:8088', access_token: 'x',
+                        destination_safe?: false, endpoint_path: nil)
+      end
+      let(:unsafe_scan) { instance_double(Scan, output_server: unsafe_output_server) }
+      let(:unsafe_report) { instance_double(Report, scan: unsafe_scan, target: target, uuid: 'test-uuid') }
+      let(:unsafe_service) { OutputServers::Splunk.new(unsafe_report) }
+
+      it 'aborts the send (no HTTP request) and logs the recheck failure' do
+        allow(Rails.logger).to receive(:error)
+        expect(@http_client).not_to receive(:request)
+
+        unsafe_service.call
+
+        expect(Rails.logger).to have_received(:error).with(/failed the SSRF recheck/)
+      end
     end
 
     context 'when output_server is nil' do

--- a/spec/services/run_garak_scan_spec.rb
+++ b/spec/services/run_garak_scan_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe RunGarakScan, type: :service do
       service.call
     end
 
+    it 'aborts and marks the report failed when the target URL fails the SSRF recheck' do
+      service = described_class.new(report)
+      allow(service).to receive(:call).and_call_original
+      allow(service).to receive(:target).and_return(target)
+      allow(service).to receive(:all_probes_completed?).and_return(false)
+      allow(target).to receive(:rest_uri_safe?).and_return(false)
+
+      expect(service).not_to receive(:execute_scan)
+
+      service.call
+
+      report.reload
+      expect(report.status).to eq('failed')
+      expect(report.failure_code).to eq('target_url_unsafe')
+    end
+
     it 'fails the report if target has bad status' do
       bad_target = create(:target, :bad)
       bad_report = build(:report, target: bad_target, scan: scan)
@@ -457,7 +473,7 @@ RSpec.describe RunGarakScan, type: :service do
     describe '#call launch-failure cleanup' do
       it 'removes the web config file if the scan process fails to launch' do
         allow(service).to receive(:call).and_call_original
-        allow(service).to receive(:target).and_return(instance_double(Target, status: 'good', webchat?: true))
+        allow(service).to receive(:target).and_return(instance_double(Target, status: 'good', webchat?: true, rest_uri_safe?: true))
         allow(service).to receive(:all_probes_completed?).and_return(false)
         allow(service).to receive(:build_argv).and_return([ 'echo' ])
         allow(service).to receive(:build_env).and_return({})
@@ -475,7 +491,7 @@ RSpec.describe RunGarakScan, type: :service do
 
       it 'removes the web config file when the scan process exits immediately (ImmediateExitError)' do
         allow(service).to receive(:call).and_call_original
-        allow(service).to receive(:target).and_return(instance_double(Target, status: 'good', webchat?: true))
+        allow(service).to receive(:target).and_return(instance_double(Target, status: 'good', webchat?: true, rest_uri_safe?: true))
         allow(service).to receive(:all_probes_completed?).and_return(false)
         allow(service).to receive(:build_argv).and_return([ 'echo' ])
         allow(service).to receive(:build_env).and_return({})

--- a/spec/services/stats/average_asr_score_security_spec.rb
+++ b/spec/services/stats/average_asr_score_security_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+# Guards the fix for the cross-tenant ASR aggregate leak: the raw-SQL average must
+# only reflect the current tenant's reports, and must fail closed with no tenant.
+RSpec.describe Stats::AverageAsrScore do
+  it "scopes the average attack success rate to the current tenant" do
+    company_a = create(:company)
+    company_b = create(:company)
+
+    ActsAsTenant.with_tenant(company_a) do
+      r = create(:report, company: company_a)
+      create(:probe_result, report: r, passed: 9, total: 10) # 90%
+    end
+    ActsAsTenant.with_tenant(company_b) do
+      r = create(:report, company: company_b)
+      create(:probe_result, report: r, passed: 1, total: 10) # 10%
+    end
+
+    ActsAsTenant.with_tenant(company_a) do
+      expect(described_class.new.average_attack_success_rate).to eq(90.0)
+    end
+    ActsAsTenant.with_tenant(company_b) do
+      expect(described_class.new.average_attack_success_rate).to eq(10.0)
+    end
+  end
+
+  it "returns 0.0 (fails closed) when there is no current tenant" do
+    company = create(:company)
+    ActsAsTenant.with_tenant(company) do
+      r = create(:report, company: company)
+      create(:probe_result, report: r, passed: 5, total: 10)
+    end
+
+    ActsAsTenant.without_tenant do
+      expect(described_class.new.average_attack_success_rate).to eq(0.0)
+    end
+  end
+
+  it "fails closed for the time series too (not just the scalar) when there is no tenant" do
+    company = create(:company)
+    ActsAsTenant.with_tenant(company) do
+      r = create(:report, company: company)
+      create(:probe_result, report: r, passed: 9, total: 10)
+    end
+
+    ActsAsTenant.without_tenant do
+      result = described_class.new(days: 30).call
+      expect(result[:data][:rates]).to all(eq(0.0))
+    end
+  end
+end

--- a/spec/services/stats/average_asr_score_spec.rb
+++ b/spec/services/stats/average_asr_score_spec.rb
@@ -1,13 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Stats::AverageAsrScore do
+  # The aggregate is tenant-scoped (acts_as_tenant), so run within a tenant; records
+  # created by the factories below then belong to this company and are counted.
+  let(:company) { create(:company) }
+  around { |example| ActsAsTenant.with_tenant(company) { example.run } }
+
   let(:detector) { create(:detector) }
   let(:target) { create(:target) }
   let(:scan) { create(:complete_scan) }
   let(:probe) { create(:probe) }
 
   describe '#call' do
-    subject { described_class.new(days: 30).call }
+    # Factories can reset ActsAsTenant.current_tenant during record creation, so set the
+    # tenant explicitly at call time (the aggregate is tenant-scoped).
+    subject { ActsAsTenant.with_tenant(company) { described_class.new(days: 30).call } }
 
     context 'when no reports exist' do
       it 'returns zero score with empty data' do
@@ -21,13 +28,13 @@ RSpec.describe Stats::AverageAsrScore do
 
     context 'when reports exist with probe results' do
       before do
-        report1 = create(:report, target: target, scan: scan, created_at: Time.zone.today)
+        report1 = create(:report, company: company, target: target, scan: scan, created_at: Time.zone.today)
         create(:probe_result, report: report1, probe: probe, detector: detector, passed: 5, total: 10)
 
-        report2 = create(:report, target: target, scan: scan, created_at: 5.days.ago)
+        report2 = create(:report, company: company, target: target, scan: scan, created_at: 5.days.ago)
         create(:probe_result, report: report2, probe: probe, detector: detector, passed: 7, total: 10)
 
-        report3 = create(:report, target: target, scan: scan, created_at: 15.days.ago)
+        report3 = create(:report, company: company, target: target, scan: scan, created_at: 15.days.ago)
         create(:probe_result, report: report3, probe: probe, detector: detector, passed: 3, total: 10)
       end
 
@@ -62,10 +69,10 @@ RSpec.describe Stats::AverageAsrScore do
 
     context 'with reports outside the specified time window' do
       before do
-        report_recent = create(:report, target: target, scan: scan, created_at: 10.days.ago)
+        report_recent = create(:report, company: company, target: target, scan: scan, created_at: 10.days.ago)
         create(:probe_result, report: report_recent, probe: probe, detector: detector, passed: 6, total: 10)
 
-        report_old = create(:report, target: target, scan: scan, created_at: 35.days.ago)
+        report_old = create(:report, company: company, target: target, scan: scan, created_at: 35.days.ago)
         create(:probe_result, report: report_old, probe: probe, detector: detector, passed: 4, total: 10)
       end
 
@@ -78,7 +85,7 @@ RSpec.describe Stats::AverageAsrScore do
 
     context 'with reports with zero total probes' do
       before do
-        report = create(:report, target: target, scan: scan, created_at: Time.zone.today)
+        report = create(:report, company: company, target: target, scan: scan, created_at: Time.zone.today)
         create(:probe_result, report: report, probe: probe, detector: detector, passed: 0, total: 0)
       end
 
@@ -95,24 +102,28 @@ RSpec.describe Stats::AverageAsrScore do
 
     context 'with various success rates' do
       before do
-        report1 = create(:report, target: target, scan: scan, created_at: 1.day.ago)
+        report1 = create(:report, company: company, target: target, scan: scan, created_at: 1.day.ago)
         create(:probe_result, report: report1, probe: probe, detector: detector, passed: 8, total: 10)
 
-        report2 = create(:report, target: target, scan: scan, created_at: 2.days.ago)
+        report2 = create(:report, company: company, target: target, scan: scan, created_at: 2.days.ago)
         create(:probe_result, report: report2, probe: probe, detector: detector, passed: 4, total: 10)
 
-        report3 = create(:report, target: target, scan: scan, created_at: 3.days.ago)
+        report3 = create(:report, company: company, target: target, scan: scan, created_at: 3.days.ago)
         create(:probe_result, report: report3, probe: probe, detector: detector, passed: 6, total: 10)
       end
 
       it 'calculates the average correctly' do
-        expect(subject.average_attack_success_rate(4.days.ago)).to eq(60)
+        ActsAsTenant.with_tenant(company) do
+          expect(subject.average_attack_success_rate(4.days.ago)).to eq(60)
+        end
       end
     end
 
     context 'with no reports' do
       it 'returns zero' do
-        expect(subject.average_attack_success_rate(4.days.ago)).to eq(0)
+        ActsAsTenant.with_tenant(company) do
+          expect(subject.average_attack_success_rate(4.days.ago)).to eq(0)
+        end
       end
     end
   end
@@ -122,15 +133,15 @@ RSpec.describe Stats::AverageAsrScore do
 
     context 'with daily interval' do
       before do
-        report1 = create(:report, target: target, scan: scan, created_at: Time.zone.today)
+        report1 = create(:report, company: company, target: target, scan: scan, created_at: Time.zone.today)
         create(:probe_result, report: report1, probe: probe, detector: detector, passed: 5, total: 10)
 
-        report2 = create(:report, target: target, scan: scan, created_at: 1.day.ago)
+        report2 = create(:report, company: company, target: target, scan: scan, created_at: 1.day.ago)
         create(:probe_result, report: report2, probe: probe, detector: detector, passed: 7, total: 10)
       end
 
       it 'returns data grouped by day' do
-        result = subject.average_attack_success_rate_over_time(2.days.ago)
+        result = ActsAsTenant.with_tenant(company) { subject.average_attack_success_rate_over_time(2.days.ago) }
 
         expect(result[:rates]).to eq([ 0.0, 70.0, 50.0 ])
       end
@@ -138,17 +149,16 @@ RSpec.describe Stats::AverageAsrScore do
 
     context 'with weekly interval' do
       before do
-        report1 = create(:report, target: target, scan: scan, created_at: Time.zone.today)
+        report1 = create(:report, company: company, target: target, scan: scan, created_at: Time.zone.today)
         create(:probe_result, report: report1, probe: probe, detector: detector, passed: 6, total: 10)
 
         last_week = 1.week.ago
-        report2 = create(:report, target: target, scan: scan, created_at: last_week)
+        report2 = create(:report, company: company, target: target, scan: scan, created_at: last_week)
         create(:probe_result, report: report2, probe: probe, detector: detector, passed: 8, total: 10)
       end
 
       it 'returns data grouped by week' do
-        result = subject.average_attack_success_rate_over_time(2.weeks.ago, "week")
-
+        result = ActsAsTenant.with_tenant(company) { subject.average_attack_success_rate_over_time(2.weeks.ago, "week") }
 
         this_week_label = "#{Time.zone.today.to_date.cwyear}-Week #{Time.zone.today.strftime('%V')}"
         last_week_label = "#{1.week.ago.to_date.cwyear}-Week #{1.week.ago.strftime('%V')}"
@@ -163,13 +173,12 @@ RSpec.describe Stats::AverageAsrScore do
 
     context 'with monthly interval' do
       before do
-        report = create(:report, target: target, scan: scan, created_at: Time.zone.today)
+        report = create(:report, company: company, target: target, scan: scan, created_at: Time.zone.today)
         create(:probe_result, report: report, probe: probe, detector: detector, passed: 75, total: 100)
       end
 
       it 'returns data grouped by month' do
-        result = subject.average_attack_success_rate_over_time(1.month.ago, "month")
-
+        result = ActsAsTenant.with_tenant(company) { subject.average_attack_success_rate_over_time(1.month.ago, "month") }
 
         this_month_label = Time.zone.today.strftime("%Y-%m")
         this_month_index = result[:dates].find_index(this_month_label)


### PR DESCRIPTION
Harden SSRF, multi-tenant isolation, and session security:

- SSRF: screen the Target RestGenerator uri (on save + a DNS-rebinding recheck before launch) and the OutputServer host/endpoint_path; constrain rsyslog TLS cert paths to SIEM_CERT_DIR (no silent VERIFY_NONE downgrade).
- Tenant isolation: scope the average-ASR aggregate to the current tenant (fail closed); authorize + tenant-scope every admin batch action (targets, env-vars, reports, scans).
- Session: 60-minute timeout, Secure + SameSite session cookie, report-only CSP.
