### PR TITLE
fix(deps): bump http-proxy-middleware to 2.0.10 (Dependabot #79)

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -10694,9 +10694,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",


### PR DESCRIPTION
Clears Dependabot alert **#79** (medium, `GHSA-64mm-vxmg-q3vj`): host-header-driven backend routing bypass in `http-proxy-middleware`'s `router` host+path substring matching.

- **Path:** `@docusaurus/core → webpack-dev-server → http-proxy-middleware` (transitive, **dev-server only** — not in the production static build).
- **Change:** 2.0.9 → 2.0.10 (same-major patch, within webpack-dev-server's existing range). Lockfile-only, single version line.
- **Verified:** `npm run build` (Docusaurus production build) is green.

After this, the only remaining open alert is **#56 (js-yaml)**, which is knowingly left open — the residual `gray-matter → js-yaml 3.14.2` has no 3.x patch and can't be forced to 4.x without breaking the Docusaurus build.

Note: commit is unsigned (gpg pinentry unavailable in this environment).