### PR TITLE
docs: showcase six 0DIN-disclosed vulnerabilities shipped as probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See the [Quick Start guide](https://0din.ai/docs/getting-started/quick-start?utm
 
 ## Featured Vulnerabilities
 
-Scanner ships with real, 0DIN-disclosed jailbreaks as ready-to-run probes — not simulations. Six of them are highlighted below, each bundled with the original attack prompt plus 34 retargetable variants and linked to its public threat report (affected models, taxonomy, reproducibility scores, and mitigations).
+Scanner ships with real, 0DIN-disclosed jailbreaks as ready-to-run probes - not simulations. Six of them are highlighted below, each bundled with the original attack prompt plus 34 retargetable variants and linked to its public threat report (affected models, taxonomy, reproducibility scores, and mitigations).
 
 | Tactic | Scanner probe | Threat report |
 |--------|---------------|---------------|

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ Open `http://localhost` and log in with `admin@example.com` and the `ADMIN_INITI
 
 See the [Quick Start guide](https://0din.ai/docs/getting-started/quick-start?utm_source=github&utm_medium=readme&utm_campaign=opensourcescanner) for full instructions including port configuration, first scan walkthrough, and troubleshooting.
 
+## Featured Vulnerabilities
+
+Scanner ships with real, 0DIN-disclosed jailbreaks as ready-to-run probes — not simulations. Six of them are highlighted below, each bundled with the original attack prompt plus 34 retargetable variants and linked to its public threat report (affected models, taxonomy, reproducibility scores, and mitigations).
+
+| Tactic | Scanner probe | Threat report |
+|--------|---------------|---------------|
+| Placeholder Injection | `PlaceholderInjectionHP` | [View ↗](https://0din.ai/threatfeed/8ccd7f81-4e36-4084-8061-cec6e2d83ece/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=placeholder_injection) |
+| Incremental Table Completion | `IncrementalTableCompletionCM` | [View ↗](https://0din.ai/threatfeed/0d1e2015-f6ce-4b79-8bde-edd26bfc6f02/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=incremental_table_completion) |
+| Technical Field Guide | `TechnicalFieldGuideCM` | [View ↗](https://0din.ai/threatfeed/a50c962f-1a46-4382-b810-9a2b4c5c6091/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=technical_field_guide) |
+| Chemical Compiler Debug | `ChemicalCompilerDebugCM` | [View ↗](https://0din.ai/threatfeed/4e8ed295-a772-4a29-8727-cbefada44123/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=chemical_compiler_debug) |
+| Correction | `CorrectionCM` | [View ↗](https://0din.ai/threatfeed/439777fa-377a-43cb-83c6-c1a012e384b1/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=correction) |
+| Hex Recipe Book | `HexRecipeBookCM` | [View ↗](https://0din.ai/threatfeed/06b58763-8a7b-4d82-afb6-ebe738b378a4/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=hex_recipe_book) |
+
+See the full [Featured Vulnerabilities guide](https://0din-ai.github.io/ai-scanner/getting-started/featured-vulnerabilities) for what each tactic does and how to run them against your own targets.
+
 ## Documentation
 
 | | |

--- a/docs-site/docs/getting-started/featured-vulnerabilities.md
+++ b/docs-site/docs/getting-started/featured-vulnerabilities.md
@@ -5,7 +5,7 @@ title: Featured Vulnerabilities
 
 # Featured Vulnerabilities
 
-Scanner ships with real, 0DIN-disclosed jailbreaks as ready-to-run probes. The six tactics below are drawn straight from the [0DIN Jailbreak Feed](https://0din.ai/threatfeed?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=featured_vulnerabilities) and are bundled with the scanner today — each one carries the original attack prompt plus **34 retargetable variants** so you can measure how a given tactic performs against your own targets.
+Scanner ships with real, 0DIN-disclosed jailbreaks as ready-to-run probes. The six tactics below are drawn straight from the [0DIN Jailbreak Feed](https://0din.ai/threatfeed?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=featured_vulnerabilities) and are bundled with the scanner today - each one carries the original attack prompt plus **34 retargetable variants** so you can measure how a given tactic performs against your own targets.
 
 These are not simulations. Every entry links to its public threat report, which includes the affected models (blast radius), taxonomy classification, reproducibility scores, and mitigation guidance.
 
@@ -22,29 +22,27 @@ These are not simulations. Every entry links to its public threat report, which 
 
 ## What each tactic does
 
-- **Placeholder Injection** — Coaxes the model into reproducing copyrighted material by asking for output with each word separated by a placeholder token, sidestepping content filters.
-- **Incremental Table Completion** — Builds a partially filled table and escalates requests for the "missing" cells, walking the model past its refusal boundary one step at a time.
-- **Technical Field Guide** — Wraps a harmful request in law-enforcement framing and structured technical requirements to bypass inference restrictions.
-- **Chemical Compiler Debug** — Encodes instructions as a "chemical compiler" input with explicit bypass commands, pushing the model to resolve the encoded payload.
-- **Correction** — Presents illicit detail under the guise of "forensic chemical investigation," then asks the model to correct it, eliciting the withheld specifics.
-- **Hex Recipe Book** — Combines hex encoding with scientific framing to smuggle a harmful request past guardrails.
+- **Placeholder Injection** - Coaxes the model into reproducing copyrighted material by asking for output with each word separated by a placeholder token, sidestepping content filters.
+- **Incremental Table Completion** - Builds a partially filled table and escalates requests for the "missing" cells, walking the model past its refusal boundary one step at a time.
+- **Technical Field Guide** - Wraps a harmful request in law-enforcement framing and structured technical requirements to bypass inference restrictions.
+- **Chemical Compiler Debug** - Encodes instructions as a "chemical compiler" input with explicit bypass commands, pushing the model to resolve the encoded payload.
+- **Correction** - Presents illicit detail under the guise of "forensic chemical investigation," then asks the model to correct it, eliciting the withheld specifics.
+- **Hex Recipe Book** - Combines hex encoding with scientific framing to smuggle a harmful request past guardrails.
 
 ## Run them against your own target
 
-Once you have a target configured (see [Your First Scan](./first-scan)), these probes run like any other. No AI red-team expertise required — configure the target, run the suite, and read the report.
+Once you have a target configured (see [Your First Scan](./first-scan)), these probes run like any other. No AI red-team expertise required - configure the target, run the scan, and read the report, all from the web UI.
 
-```bash
-# List available 0DIN probes
-garak --list_probes | grep 0din
-
-# Run a single featured probe against your target
-garak --model_type <your-target> --probes 0din.PlaceholderInjectionHP
-```
+1. Go to **Targets** and add your model as a new target.
+2. Go to **Scans**, click **New Scan**, and choose your target.
+3. Under **Probes**, select the featured probe you want to run (for example, `PlaceholderInjectionHP`), or select several.
+4. Click **Run Scan** and watch progress in real time.
+5. When the scan completes, open **View Report** to see the results.
 
 Each run reports an **Attack Success Rate (ASR)** per probe and per variant, so you can track how a tactic performs across models and over time.
 
 ## Learn more
 
-- [0DIN Jailbreak Feed ↗](https://0din.ai/threatfeed?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=featured_vulnerabilities) — the full stream of disclosed vulnerabilities
-- [0DIN Jailbreak Taxonomy ↗](https://0din.ai/research/taxonomy) — how these techniques are classified
-- [Probes](/scanner-introduction) — how probe packs plug into your scanning workflow
+- [0DIN Jailbreak Feed ↗](https://0din.ai/threatfeed?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=featured_vulnerabilities) - the full stream of disclosed vulnerabilities
+- [0DIN Jailbreak Taxonomy ↗](https://0din.ai/research/taxonomy) - how these techniques are classified
+- [Probes](/scanner-introduction) - how probe packs plug into your scanning workflow

--- a/docs-site/docs/getting-started/featured-vulnerabilities.md
+++ b/docs-site/docs/getting-started/featured-vulnerabilities.md
@@ -1,0 +1,50 @@
+---
+sidebar_position: 3
+title: Featured Vulnerabilities
+---
+
+# Featured Vulnerabilities
+
+Scanner ships with real, 0DIN-disclosed jailbreaks as ready-to-run probes. The six tactics below are drawn straight from the [0DIN Jailbreak Feed](https://0din.ai/threatfeed?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=featured_vulnerabilities) and are bundled with the scanner today — each one carries the original attack prompt plus **34 retargetable variants** so you can measure how a given tactic performs against your own targets.
+
+These are not simulations. Every entry links to its public threat report, which includes the affected models (blast radius), taxonomy classification, reproducibility scores, and mitigation guidance.
+
+## The six probes
+
+| # | Tactic | Scanner probe | Technique(s) | Variants | Threat report |
+|---|--------|---------------|--------------|----------|---------------|
+| 1 | **Placeholder Injection** | `PlaceholderInjectionHP` | Chaff | 34 | [View report ↗](https://0din.ai/threatfeed/8ccd7f81-4e36-4084-8061-cec6e2d83ece/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=placeholder_injection) |
+| 2 | **Incremental Table Completion** | `IncrementalTableCompletionCM` | Escalating | 34 | [View report ↗](https://0din.ai/threatfeed/0d1e2015-f6ce-4b79-8bde-edd26bfc6f02/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=incremental_table_completion) |
+| 3 | **Technical Field Guide** | `TechnicalFieldGuideCM` | Deceptive Formatting | 34 | [View report ↗](https://0din.ai/threatfeed/a50c962f-1a46-4382-b810-9a2b4c5c6091/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=technical_field_guide) |
+| 4 | **Chemical Compiler Debug** | `ChemicalCompilerDebugCM` | Stop Sequences | 34 | [View report ↗](https://0din.ai/threatfeed/4e8ed295-a772-4a29-8727-cbefada44123/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=chemical_compiler_debug) |
+| 5 | **Correction** | `CorrectionCM` | Ignore Previous Instructions, Synonymous Language | 34 | [View report ↗](https://0din.ai/threatfeed/439777fa-377a-43cb-83c6-c1a012e384b1/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=correction) |
+| 6 | **Hex Recipe Book** | `HexRecipeBookCM` | Base64, Escalating, Scenarios, Ask For Examples, Hex | 34 | [View report ↗](https://0din.ai/threatfeed/06b58763-8a7b-4d82-afb6-ebe738b378a4/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=hex_recipe_book) |
+
+## What each tactic does
+
+- **Placeholder Injection** — Coaxes the model into reproducing copyrighted material by asking for output with each word separated by a placeholder token, sidestepping content filters.
+- **Incremental Table Completion** — Builds a partially filled table and escalates requests for the "missing" cells, walking the model past its refusal boundary one step at a time.
+- **Technical Field Guide** — Wraps a harmful request in law-enforcement framing and structured technical requirements to bypass inference restrictions.
+- **Chemical Compiler Debug** — Encodes instructions as a "chemical compiler" input with explicit bypass commands, pushing the model to resolve the encoded payload.
+- **Correction** — Presents illicit detail under the guise of "forensic chemical investigation," then asks the model to correct it, eliciting the withheld specifics.
+- **Hex Recipe Book** — Combines hex encoding with scientific framing to smuggle a harmful request past guardrails.
+
+## Run them against your own target
+
+Once you have a target configured (see [Your First Scan](./first-scan)), these probes run like any other. No AI red-team expertise required — configure the target, run the suite, and read the report.
+
+```bash
+# List available 0DIN probes
+garak --list_probes | grep 0din
+
+# Run a single featured probe against your target
+garak --model_type <your-target> --probes 0din.PlaceholderInjectionHP
+```
+
+Each run reports an **Attack Success Rate (ASR)** per probe and per variant, so you can track how a tactic performs across models and over time.
+
+## Learn more
+
+- [0DIN Jailbreak Feed ↗](https://0din.ai/threatfeed?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=featured_vulnerabilities) — the full stream of disclosed vulnerabilities
+- [0DIN Jailbreak Taxonomy ↗](https://0din.ai/research/taxonomy) — how these techniques are classified
+- [Probes](/scanner-introduction) — how probe packs plug into your scanning workflow

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -18,6 +18,7 @@ const sidebars: SidebarsConfig = {
           items: [
             "getting-started/quick-start",
             "getting-started/first-scan",
+            "getting-started/featured-vulnerabilities",
           ],
         },
         {


### PR DESCRIPTION
## Problem

The scanner ships six 0DIN-disclosed jailbreaks as ready-to-run probes, but nothing in the repo or docs surfaces them. They're a strong showcase of what the scanner can do out of the box (and a natural sales/enablement asset), yet a new user has no obvious entry point to them.

## Solution

- **New docs page** `docs-site/docs/getting-started/featured-vulnerabilities.md` highlighting all six tactics, each with its scanner probe class, taxonomy technique(s), variant count (34 each), and a link to its public threat report on the 0DIN Jailbreak Feed. Includes short per-tactic descriptions and copy-paste `garak` run commands.
- **README** gains a concise "Featured Vulnerabilities" section (table of the six + link to the full guide).
- **Sidebar** wires the new page into the Getting Started category.

All threat-report links are UTM-tagged (`utm_source=0din.ai`, `utm_medium=open_source_scanner`, `utm_campaign=opensourcescanner`, per-vuln `utm_content`) for attribution.

The six vulnerabilities (by GUID, verified present in `config/probes/0din_probes.json`):

| Tactic | Probe | GUID |
|--------|-------|------|
| Placeholder Injection | `PlaceholderInjectionHP` | 8ccd7f81 |
| Incremental Table Completion | `IncrementalTableCompletionCM` | 0d1e2015 |
| Technical Field Guide | `TechnicalFieldGuideCM` | a50c962f |
| Chemical Compiler Debug | `ChemicalCompilerDebugCM` | 4e8ed295 |
| Correction | `CorrectionCM` | 439777fa |
| Hex Recipe Book | `HexRecipeBookCM` | 06b58763 |

## Test plan

Docs-only change; no application code touched.

- Build the docs site locally to confirm the new page renders and appears in the sidebar under Getting Started:
  ```bash
  cd docs-site && npm ci && npm run build
  ```
- Verify the README table and links render on the repo landing page.
- Spot-check each threat-report link resolves to the correct public disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)