### PR TITLE
docs: move Featured Vulnerabilities above Features in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ An open-source web application for AI model security assessments, built with Rub
   <img src="https://static.0din.ai/assets/marketing/scanner-0356fb6d.png" alt="0DIN Scanner" width="800">
 </p>
 
+## Featured Vulnerabilities
+
+Scanner ships with real, 0DIN-disclosed jailbreaks as ready-to-run probes - not simulations. Six of them are highlighted below, each bundled with the original attack prompt plus 34 retargetable variants and linked to its public threat report (affected models, taxonomy, reproducibility scores, and mitigations).
+
+| Tactic | Scanner probe | Threat report |
+|--------|---------------|---------------|
+| Placeholder Injection | `PlaceholderInjectionHP` | [View ↗](https://0din.ai/threatfeed/8ccd7f81-4e36-4084-8061-cec6e2d83ece/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=placeholder_injection) |
+| Incremental Table Completion | `IncrementalTableCompletionCM` | [View ↗](https://0din.ai/threatfeed/0d1e2015-f6ce-4b79-8bde-edd26bfc6f02/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=incremental_table_completion) |
+| Technical Field Guide | `TechnicalFieldGuideCM` | [View ↗](https://0din.ai/threatfeed/a50c962f-1a46-4382-b810-9a2b4c5c6091/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=technical_field_guide) |
+| Chemical Compiler Debug | `ChemicalCompilerDebugCM` | [View ↗](https://0din.ai/threatfeed/4e8ed295-a772-4a29-8727-cbefada44123/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=chemical_compiler_debug) |
+| Correction | `CorrectionCM` | [View ↗](https://0din.ai/threatfeed/439777fa-377a-43cb-83c6-c1a012e384b1/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=correction) |
+| Hex Recipe Book | `HexRecipeBookCM` | [View ↗](https://0din.ai/threatfeed/06b58763-8a7b-4d82-afb6-ebe738b378a4/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=hex_recipe_book) |
+
+See the full [Featured Vulnerabilities guide](https://0din-ai.github.io/ai-scanner/getting-started/featured-vulnerabilities) for what each tactic does and how to run them against your own targets.
+
 ## Features
 
 - **179 community probes** across 35 vulnerability families, aligned with the [OWASP LLM Top 10](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
@@ -43,21 +58,6 @@ docker compose up -d
 Open `http://localhost` and log in with `admin@example.com` and the `ADMIN_INITIAL_PASSWORD` value from your `.env` file. **Change the initial password immediately.**
 
 See the [Quick Start guide](https://0din.ai/docs/getting-started/quick-start?utm_source=github&utm_medium=readme&utm_campaign=opensourcescanner) for full instructions including port configuration, first scan walkthrough, and troubleshooting.
-
-## Featured Vulnerabilities
-
-Scanner ships with real, 0DIN-disclosed jailbreaks as ready-to-run probes - not simulations. Six of them are highlighted below, each bundled with the original attack prompt plus 34 retargetable variants and linked to its public threat report (affected models, taxonomy, reproducibility scores, and mitigations).
-
-| Tactic | Scanner probe | Threat report |
-|--------|---------------|---------------|
-| Placeholder Injection | `PlaceholderInjectionHP` | [View ↗](https://0din.ai/threatfeed/8ccd7f81-4e36-4084-8061-cec6e2d83ece/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=placeholder_injection) |
-| Incremental Table Completion | `IncrementalTableCompletionCM` | [View ↗](https://0din.ai/threatfeed/0d1e2015-f6ce-4b79-8bde-edd26bfc6f02/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=incremental_table_completion) |
-| Technical Field Guide | `TechnicalFieldGuideCM` | [View ↗](https://0din.ai/threatfeed/a50c962f-1a46-4382-b810-9a2b4c5c6091/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=technical_field_guide) |
-| Chemical Compiler Debug | `ChemicalCompilerDebugCM` | [View ↗](https://0din.ai/threatfeed/4e8ed295-a772-4a29-8727-cbefada44123/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=chemical_compiler_debug) |
-| Correction | `CorrectionCM` | [View ↗](https://0din.ai/threatfeed/439777fa-377a-43cb-83c6-c1a012e384b1/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=correction) |
-| Hex Recipe Book | `HexRecipeBookCM` | [View ↗](https://0din.ai/threatfeed/06b58763-8a7b-4d82-afb6-ebe738b378a4/public?utm_source=0din.ai&utm_medium=open_source_scanner&utm_campaign=opensourcescanner&utm_content=hex_recipe_book) |
-
-See the full [Featured Vulnerabilities guide](https://0din-ai.github.io/ai-scanner/getting-started/featured-vulnerabilities) for what each tactic does and how to run them against your own targets.
 
 ## Documentation
 


### PR DESCRIPTION
Moves the **Featured Vulnerabilities** section above the **Features** section in the README so the six 0DIN-disclosed jailbreaks that ship as ready-to-run probes are the first thing readers see after the intro.

Section order is now:

1. Featured Vulnerabilities
2. Features
3. Community & Enterprise
4. Quick Start
5. Documentation

Content is unchanged - this is purely a reorder (15 insertions / 15 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)