### PR TITLE
chore: fix CODEOWNERS (SOC 2 sweep)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @0din-ai/0din-developers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @0din-ai/0din-developers
+* @LegaKh

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @0din-ai/0din-developers


### PR DESCRIPTION
Part of the SOC2 CODEOWNERS consistency sweep (2026-07-20).

Moves CODEOWNERS from the repo root to the canonical `.github/CODEOWNERS` location and sets the individual owner to @LegaKh (Oleh Perevertailo), consistent with the individual-ownership model adopted across all 11 in-scope SOC2 repos (see companion PRs on scanner, scanner-0din-engine, garak-0din-plugins, etc).

The final `.github/CODEOWNERS` content is:
```
* @LegaKh
```