### PR TITLE
fix(security): re-check webchat URLs at scan launch

### DIFF
--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -121,13 +121,16 @@ class Target < ApplicationRecord
   # stop DNS rebinding (the host may point at an internal address by the time garak
   # fetches it), so the scan runner re-checks right before launching. Returns true for
   # non-REST targets (no uri to fetch).
-  def rest_uri_safe?
-    uri = rest_generator_uri
-    return true if uri.nil?
-    return false unless uri.is_a?(String) && uri.present?
-    return false if uri_host_has_placeholder?(uri)
+  # Launch-time safety for whichever URL the scan will actually reach. Webchat targets
+  # are driven by a browser rather than a RestGenerator, so checking only the latter
+  # passes them vacuously and leaves the rebinding window open for the browser path.
+  def scan_launch_url_safe?
+    url_safe_for_scan_launch?(scan_launch_url)
+  end
 
-    UrlSafetyValidator.safe_url?(uri, allow_localhost: UrlSafetyValidator.allow_localhost?).safe?
+  # REST-only compatibility predicate for callers that do not need webchat coverage.
+  def rest_uri_safe?
+    url_safe_for_scan_launch?(rest_generator_uri)
   end
 
   # Normalize Hash/Array to JSON string before the encrypted attribute type
@@ -216,6 +219,18 @@ class Target < ApplicationRecord
     return if result.safe?
 
     errors.add(:json_config, "target URL is not allowed: #{result.error}")
+  end
+
+  def url_safe_for_scan_launch?(uri)
+    return true if uri.nil?
+    return false unless uri.is_a?(String) && uri.present?
+    return false if uri_host_has_placeholder?(uri)
+
+    UrlSafetyValidator.safe_url?(uri, allow_localhost: UrlSafetyValidator.allow_localhost?).safe?
+  end
+
+  def scan_launch_url
+    webchat? ? web_chat_url : rest_generator_uri
   end
 
   def uri_host_has_placeholder?(uri)

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -30,10 +30,12 @@ class RunGarakScan
       return
     end
 
-    # Re-validate the RestGenerator URL just before launch. Save-time validation can't
-    # stop DNS rebinding — the host may resolve to an internal address by now even if it
-    # was safe when the target was saved. Only reached when garak will actually run.
-    unless target.rest_uri_safe?
+    # Re-validate the URL the scan will actually reach, just before launch. Save-time
+    # validation can't stop DNS rebinding — the host may resolve to an internal address
+    # by now even if it was safe when the target was saved. Covers the webchat URL as
+    # well as the RestGenerator one; the browser path is reachable the same way.
+    # Only reached when garak will actually run.
+    unless target.scan_launch_url_safe?
       handle_unsafe_target_uri
       return
     end
@@ -146,7 +148,7 @@ class RunGarakScan
 
   def handle_unsafe_target_uri
     error_message = "Target '#{target.name}' URL failed a safety check (it may resolve to a disallowed address). The scan was aborted."
-    Rails.logger.error("[RunGarakScan] aborting report #{report.id}: target #{target.id} (#{target.name}) RestGenerator URL failed the SSRF recheck")
+    Rails.logger.error("[RunGarakScan] aborting report #{report.id}: target #{target.id} (#{target.name}) URL failed the SSRF recheck")
     sanitized = Reports::FailureClassifier.sanitize_text(error_message)
     report.update(
       status: :failed,

--- a/spec/models/ssrf_hardening_spec.rb
+++ b/spec/models/ssrf_hardening_spec.rb
@@ -10,6 +10,19 @@ RSpec.describe "SSRF hardening" do
       build(:target, company: company, json_config: { rest: { RestGenerator: { uri: uri } } }.to_json)
     end
 
+    def webchat_target(url)
+      build(
+        :target,
+        company: company,
+        target_type: "webchat",
+        model_type: "web_chatbot",
+        web_config: {
+          url: url,
+          selectors: { input_field: "#input", response_container: "#response" }
+        }.to_json
+      )
+    end
+
     it "rejects a RestGenerator uri that resolves to internal/metadata addresses" do
       ActsAsTenant.with_tenant(company) do
         # 169.254 (cloud metadata) + RFC1918 are blocked regardless of env. Loopback is
@@ -58,6 +71,27 @@ RSpec.describe "SSRF hardening" do
 
         # non-REST target (no uri to fetch) is considered safe
         expect(build(:target, company: company).rest_uri_safe?).to be(true)
+      end
+    end
+
+    it "Target#scan_launch_url_safe? re-validates a webchat URL at launch time" do
+      # Save-time validation cannot stop DNS rebinding, which is why the launch-time
+      # recheck exists. It has to cover webchat targets too: rest_uri_safe? inspects
+      # the RestGenerator uri, which is nil for webchat, so it passes vacuously.
+      ActsAsTenant.with_tenant(company) do
+        internal = webchat_target("http://169.254.169.254/chat")
+        expect(internal.scan_launch_url_safe?).to be(false)
+
+        # IP literal, like the REST cases above: hostnames do not resolve in CI.
+        public_t = webchat_target("http://8.8.8.8/widget")
+        expect(public_t.scan_launch_url_safe?).to be(true)
+
+        # A REST target still resolves through its RestGenerator uri.
+        expect(api_target("http://169.254.169.254/").scan_launch_url_safe?).to be(false)
+        expect(api_target("http://8.8.8.8/v1").scan_launch_url_safe?).to be(true)
+
+        # A target with neither URL has nothing to reach.
+        expect(build(:target, company: company).scan_launch_url_safe?).to be(true)
       end
     end
   end

--- a/spec/services/run_garak_scan_spec.rb
+++ b/spec/services/run_garak_scan_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe RunGarakScan, type: :service do
       allow(service).to receive(:call).and_call_original
       allow(service).to receive(:target).and_return(target)
       allow(service).to receive(:all_probes_completed?).and_return(false)
-      allow(target).to receive(:rest_uri_safe?).and_return(false)
+      allow(target).to receive(:scan_launch_url_safe?).and_return(false)
 
       expect(service).not_to receive(:execute_scan)
 
@@ -473,7 +473,7 @@ RSpec.describe RunGarakScan, type: :service do
     describe '#call launch-failure cleanup' do
       it 'removes the web config file if the scan process fails to launch' do
         allow(service).to receive(:call).and_call_original
-        allow(service).to receive(:target).and_return(instance_double(Target, status: 'good', webchat?: true, rest_uri_safe?: true))
+        allow(service).to receive(:target).and_return(instance_double(Target, status: 'good', webchat?: true, scan_launch_url_safe?: true))
         allow(service).to receive(:all_probes_completed?).and_return(false)
         allow(service).to receive(:build_argv).and_return([ 'echo' ])
         allow(service).to receive(:build_env).and_return({})
@@ -491,7 +491,7 @@ RSpec.describe RunGarakScan, type: :service do
 
       it 'removes the web config file when the scan process exits immediately (ImmediateExitError)' do
         allow(service).to receive(:call).and_call_original
-        allow(service).to receive(:target).and_return(instance_double(Target, status: 'good', webchat?: true, rest_uri_safe?: true))
+        allow(service).to receive(:target).and_return(instance_double(Target, status: 'good', webchat?: true, scan_launch_url_safe?: true))
         allow(service).to receive(:all_probes_completed?).and_return(false)
         allow(service).to receive(:build_argv).and_return([ 'echo' ])
         allow(service).to receive(:build_env).and_return({})


### PR DESCRIPTION
The launch-time recheck in `RunGarakScan` exists because save-time validation cannot stop DNS rebinding: a host that was public when the target was saved may resolve to an internal address by the time the scan runs.

It consulted `Target#rest_uri_safe?`, which reads the `RestGenerator` uri — `nil` for a webchat target — so webchat targets passed it vacuously and the browser path kept the rebinding window open. Save-time validation does reject internal webchat URLs; nothing re-checked them at launch.

Adds `Target#scan_launch_url_safe?`, which validates whichever URL the scan will actually reach, and calls that at launch. `rest_uri_safe?` remains for callers that only need REST coverage.

Related to #130, which reports a separate gap on the same surface: nothing re-validates where the browser navigates *after* the initial URL (redirects, in-page `fetch()`). That needs request interception and is not addressed here.