### PR TITLE
fix(scanner): fence scan execution attempts across pods

### DIFF
--- a/app/jobs/check_stale_reports_job.rb
+++ b/app/jobs/check_stale_reports_job.rb
@@ -225,6 +225,7 @@ class CheckStaleReportsJob < ApplicationJob
     Report.transaction do
       report.update!(
         status: :pending,
+        execution_token: nil,
         retry_count: report.retry_count + 1,
         last_retry_at: Time.current,
         logs: append_log(
@@ -246,6 +247,7 @@ class CheckStaleReportsJob < ApplicationJob
 
     report.update!(
       status: :interrupted,
+      execution_token: nil,
       logs: append_log(logs_with_live_tail(report), "Interrupted: #{reason}")
     )
   end
@@ -255,6 +257,7 @@ class CheckStaleReportsJob < ApplicationJob
 
     report.update!(
       status: :failed,
+      execution_token: nil,
       logs: append_log(logs_with_live_tail(report), reason)
     )
   end

--- a/app/jobs/generate_variant_reports_job.rb
+++ b/app/jobs/generate_variant_reports_job.rb
@@ -59,7 +59,7 @@ class GenerateVariantReportsJob < ApplicationJob
   rescue ActiveRecord::RecordNotUnique
     Rails.logger.info("Variant report already exists for parent #{parent_report.id}, skipping")
   rescue StandardError => e
-    child_report&.update(status: :failed) if child_report&.persisted?
+    child_report&.update(status: :failed, execution_token: nil) if child_report&.persisted?
     Rails.logger.error("Failed to create combined variant report: #{e.message}")
     Rails.logger.error(e.backtrace.join("\n"))
     raise

--- a/app/jobs/retry_interrupted_reports_job.rb
+++ b/app/jobs/retry_interrupted_reports_job.rb
@@ -60,6 +60,7 @@ class RetryInterruptedReportsJob < ApplicationJob
         last_retry_at: Time.current,
         heartbeat_at: nil, # Reset heartbeat for fresh start
         pid: nil, # Clear stale PID so new run gets a fresh process identity
+        execution_token: nil, # Revoke writes from the interrupted process attempt
         logs: append_log(
           report.logs,
           "Auto-retry #{report.retry_count + 1}: Requeued after interruption"

--- a/app/jobs/start_pending_scans_job.rb
+++ b/app/jobs/start_pending_scans_job.rb
@@ -117,8 +117,15 @@ class StartPendingScansJob < ApplicationJob
   def claim_for_starting(report)
     updated_count = 0
     Report.transaction do
+      # The execution token identifies THIS start attempt. Container-local PIDs are
+      # reused by a replacement pod, so a PID alone cannot tell a live scan from a
+      # dead one; every write the scanner makes is fenced on this token instead.
       updated_count = Report.where(id: report.id, status: :pending)
-                            .update_all(status: :starting, updated_at: Time.current)
+                            .update_all(
+                              status: :starting,
+                              execution_token: SecureRandom.uuid,
+                              updated_at: Time.current
+                            )
       ReportDebugLog.clear_tail_for_report(report.id) if updated_count.positive?
     end
     claimed = updated_count.positive?

--- a/app/services/reports/stop.rb
+++ b/app/services/reports/stop.rb
@@ -17,7 +17,7 @@ module Reports
     end
 
     def call
-      report.update(status: :stopped)
+      report.update(status: :stopped, execution_token: nil)
       Cleanup.new(report).call
       # Widget update handled by Report#broadcast_running_stats_if_needed callback
     end

--- a/app/services/run_command.rb
+++ b/app/services/run_command.rb
@@ -38,15 +38,38 @@ class RunCommand
     stdout
   end
 
-  def call_async(log_file: nil)
+  # on_spawn is invoked the moment a child process exists. Callers need that boundary
+  # to know whether a failure left something running: popen3 itself can raise without
+  # spawning anything at all (a missing interpreter, EAGAIN from process creation),
+  # and everything that can fail with a live child is either moved ahead of the spawn
+  # (the log file) or handled without raising (closing stdin).
+  def call_async(log_file: nil, on_spawn: nil)
     Rails.logger.info("RunCommand.call_async executing: #{sanitize_for_logging}")
 
-    stdin, stdout, stderr, wait_thr = Open3.popen3(env, *command)
-    stdin.close
-
+    # Open the log BEFORE spawning. Anything fallible between popen3 and the drain
+    # threads below can leave a live child whose stdout nobody reads: the process
+    # fills the pipe buffer and blocks forever, while its own heartbeat thread keeps
+    # the report looking healthy. Failing here instead means no child exists yet.
     log_io = if log_file
       FileUtils.mkdir_p(File.dirname(log_file))
       File.open(log_file, "a")
+    end
+
+    begin
+      stdin, stdout, stderr, wait_thr = Open3.popen3(env, *command)
+    rescue StandardError
+      log_io&.close
+      raise
+    end
+
+    on_spawn&.call
+
+    begin
+      stdin.close
+    rescue IOError, SystemCallError => e
+      # The child is already running; a failure to close its stdin is not a launch
+      # failure and must not be raised as one.
+      Rails.logger.warn("RunCommand: could not close child stdin: #{e.class}: #{e.message}")
     end
 
     stdout_thread = Thread.new do

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -46,24 +46,80 @@ class RunGarakScan
         MonitoringService.set_label(:scan_name, report.scan.name)
         MonitoringService.set_label(:target_name, target.name)
 
-        report.update(status: :starting) unless report.starting?
+        return unless start_execution_attempt!
 
         execute_scan
       end
     else
-      report.update(status: :starting) unless report.starting?
+      return unless start_execution_attempt!
+
       execute_scan
     end
   rescue StandardError
-    # The garak process never took ownership of the credential file (launch failure
-    # or a crash during module import/arg parsing), so the Python-side cleanup will
-    # never run. Remove the web config file (cookies/headers/storageState) here
-    # instead of orphaning it on disk, then re-raise so the caller marks the report failed.
-    remove_web_config_file
+    # Remove the credential-bearing web config (cookies/headers/storageState) only
+    # when nothing was spawned: in that case the Python-side cleanup will never run
+    # and the file would be orphaned. Once call_async has been entered the process may
+    # be alive and may not have read its --generator_option_file yet, so deleting it
+    # would race a live scan; that process removes the file on its own exit paths.
+    remove_web_config_file unless @scan_process_may_be_running
     raise
   end
 
   private
+
+  # Claim this report for one execution attempt, returning false when someone else
+  # already holds it.
+  #
+  # The normal path claims in StartPendingScansJob and arrives here already starting,
+  # so this is a no-op. A caller arriving in any other status (a variant child, a mock
+  # target) would otherwise launch a process that cannot prove ownership of the
+  # attempt, and the process refuses to run without a token.
+  #
+  # The claim is a single conditional UPDATE rather than a read-then-write: those
+  # callers create a *pending* report, which StartPendingScansJob is free to claim in
+  # between, and a read-then-write would overwrite that attempt's token and leave two
+  # garak processes running for one report.
+  def start_execution_attempt!
+    return true if report.starting?
+
+    token = SecureRandom.uuid
+    claimed = Report.where(id: report.id).where.not(status: :starting).update_all(
+      status: :starting,
+      execution_token: token,
+      updated_at: Time.current
+    ).positive?
+
+    if claimed
+      # Reflect the claim in memory rather than reloading: a reload would also drop
+      # the loaded target association and re-query it under whatever tenant happens
+      # to be current here, which is outside the with_tenant block below.
+      report.assign_attributes(status: :starting, execution_token: token)
+      report.changes_applied
+    else
+      Rails.logger.info(
+        "[RunGarakScan] report #{report.id} was claimed by another process; " \
+        "not launching a second scan for it"
+      )
+    end
+
+    claimed
+  end
+
+  # Release the attempt after a failure that happened BEFORE anything was spawned, so
+  # a retry can claim it immediately instead of waiting out the stuck-starting reaper.
+  # Never call this once the process may be alive: revoking under a running scanner
+  # makes its own running-claim match zero rows and the process exits.
+  #
+  # update_columns: the report may be mid-failure elsewhere, and this must not fire
+  # callbacks or fail on validation. Losing the revoke is not fatal -- the stale
+  # reaper clears it -- so failure is logged rather than raised over the original error.
+  def revoke_execution_token_after_launch_failure
+    report.update_columns(execution_token: nil)
+  rescue StandardError => e
+    Rails.logger.warn(
+      "[RunGarakScan] failed to revoke execution token for #{report.uuid}: #{e.class}: #{e.message}"
+    )
+  end
 
   # Deletes the per-scan web config file written by temp_web_config_file_path.
   # Safe no-op for API targets (no such file) or when it was never created.
@@ -80,14 +136,25 @@ class RunGarakScan
       env = build_env
       log_path = scan_log_path
       log_scan_debug_info(argv)
-      RunCommand.new(argv, env: env).call_async(log_file: log_path)
+      # on_spawn fires once a child actually exists. popen3 can raise before that -- a
+      # missing interpreter, EAGAIN from process creation -- and those failures leave
+      # nothing running, so the attempt and its credential file must be released.
+      RunCommand.new(argv, env: env).call_async(
+        log_file: log_path,
+        on_spawn: -> { @scan_process_may_be_running = true }
+      )
     rescue RunCommand::ImmediateExitError => e
+      # The process exited immediately, so it is definitively dead: releasing the
+      # attempt and deleting its credential file are both safe.
       remove_web_config_file
       Rails.logger.error("Scan process failed to start for report #{report.uuid}: #{e.message}")
       stderr_tail = read_log_tail
       message = "Scan process failed to start (exit status #{e.exit_status})."
       message += " Output: #{stderr_tail}" if stderr_tail.present?
-      report.update(status: :failed, logs: message)
+      report.update(status: :failed, execution_token: nil, logs: message)
+    rescue StandardError
+      revoke_execution_token_after_launch_failure unless @scan_process_may_be_running
+      raise
     end
   end
 
@@ -116,6 +183,10 @@ class RunGarakScan
       end
 
       env["REPORT_UUID"] = report.uuid
+      # Unconditional: merged_env_vars above is tenant-controlled and has no reserved
+      # name blocklist, so a conditional assignment would let a tenant row named
+      # SCAN_EXECUTION_TOKEN survive and defeat the scanner's fail-closed guard.
+      env["SCAN_EXECUTION_TOKEN"] = report.execution_token.to_s
       env["SCAN_ID"] = report.scan.id.to_s
       env["SCAN_NAME"] = report.scan.name
       env["TARGET_ID"] = target.id.to_s
@@ -152,6 +223,7 @@ class RunGarakScan
     sanitized = Reports::FailureClassifier.sanitize_text(error_message)
     report.update(
       status: :failed,
+      execution_token: nil,
       logs: "Scan failed: #{sanitized}",
       failure_code: "target_url_unsafe",
       failure_message: sanitized,
@@ -180,6 +252,7 @@ class RunGarakScan
     sanitized_error_message = Reports::FailureClassifier.sanitize_text(error_message)
     report.update(
       status: :failed,
+      execution_token: nil,
       logs: "Scan failed: #{sanitized_error_message}",
       failure_code: "target_validation_failed",
       failure_message: sanitized_error_message,
@@ -479,6 +552,9 @@ class RunGarakScan
       "enqueuing ProcessReportJob directly"
     )
     persist_existing_logs
+    # Non-raising: this scan is already finished, and losing the revoke here would
+    # otherwise strand a complete result set in `starting` until the reaper failed it.
+    revoke_execution_token_after_launch_failure
     ProcessReportJob.perform_later(report.id)
   end
 

--- a/db/migrate/20260811120000_add_execution_token_to_reports.rb
+++ b/db/migrate/20260811120000_add_execution_token_to_reports.rb
@@ -1,0 +1,5 @@
+class AddExecutionTokenToReports < ActiveRecord::Migration[8.1]
+  def change
+    add_column :reports, :execution_token, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_19_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -288,6 +288,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_000000) do
     t.bigint "company_id", null: false
     t.datetime "created_at", null: false
     t.datetime "end_time"
+    t.uuid "execution_token"
     t.string "failure_code"
     t.jsonb "failure_details", default: {}, null: false
     t.text "failure_message"

--- a/script/db_notifier.py
+++ b/script/db_notifier.py
@@ -7,9 +7,11 @@ for multi-pod deployment support. Python writes to shared database, Rails
 reads and processes via Solid Queue jobs.
 
 Functions:
-    notify_report_running(report_uuid, pid): Mark report as running with PID
-    notify_report_ready(report_uuid): Store report data and enqueue processing job
-    notify_report_stopped(report_uuid): Clear PID from report
+    notify_report_running(report_uuid, pid, execution_token): Claim running state
+    notify_report_ready(report_uuid, *, execution_token): Store data and hand off
+    notify_report_ready_from_synced(report_uuid, *, execution_token): Hand off
+    notify_report_stopped(report_uuid, expected_pid=None, *, execution_token):
+        Release this attempt's PID and ownership
 
 Dependencies:
     psycopg2-binary>=2.9.0
@@ -67,7 +69,26 @@ STATUS_PROCESSING = 1
 # Note: STATUS_COMPLETED not needed - records are deleted after processing
 
 # Report status enum values (matching Rails Report model)
+REPORT_STATUS_PENDING = 0
 REPORT_STATUS_RUNNING = 1
+REPORT_STATUS_PROCESSING = 2
+REPORT_STATUS_FAILED = 4
+REPORT_STATUS_STOPPED = 5
+REPORT_STATUS_STARTING = 6
+REPORT_STATUS_INTERRUPTED = 7
+
+# Statuses in which a write from an attempt whose token Rails already revoked is
+# still wanted: the report is either in flight or queued to be retried, so keeping
+# its progress is the point. A stopped or failed report has been cleaned up
+# deliberately -- Reports::Cleanup deletes its raw_report_data -- and writing again
+# would resurrect exactly what the user cancelled. A report already handed off to
+# processing is owned by that job.
+RESUMABLE_STATUSES = [
+    REPORT_STATUS_PENDING,
+    REPORT_STATUS_RUNNING,
+    REPORT_STATUS_STARTING,
+    REPORT_STATUS_INTERRUPTED,
+]
 
 # Live execution log tail sync configuration
 DEFAULT_DEBUG_LOG_TAIL_BYTES = 131072
@@ -229,7 +250,7 @@ class HeartbeatThread:
     allowing Rails to detect stale/crashed scans in multi-pod deployments.
 
     Usage:
-        heartbeat = HeartbeatThread(report_uuid)
+        heartbeat = HeartbeatThread(report_uuid, execution_token=token)
         heartbeat.start()
         # ... run scan ...
         heartbeat.stop()
@@ -237,15 +258,17 @@ class HeartbeatThread:
 
     DEFAULT_INTERVAL = 30  # seconds
 
-    def __init__(self, report_uuid: str, interval: int = None):
+    def __init__(self, report_uuid: str, *, execution_token: str, interval: int = None):
         """
         Initialize heartbeat thread.
 
         Args:
             report_uuid: UUID of the report to send heartbeats for
+            execution_token: UUID Rails minted when it claimed this scan attempt
             interval: Seconds between heartbeats (default: 30)
         """
         self.report_uuid = report_uuid
+        self.execution_token = execution_token
         self.interval = interval if interval is not None else self.DEFAULT_INTERVAL
         self._running = False
         self._thread: Optional[threading.Thread] = None
@@ -337,9 +360,13 @@ class HeartbeatThread:
                         """
                         UPDATE reports
                         SET heartbeat_at = NOW()
-                        WHERE uuid = %s AND status = %s
+                        WHERE uuid = %s AND status = %s AND execution_token = %s
                         """,
-                        (self.report_uuid, REPORT_STATUS_RUNNING),
+                        (
+                            self.report_uuid,
+                            REPORT_STATUS_RUNNING,
+                            self.execution_token,
+                        ),
                     )
                     rows_affected = cur.rowcount
                 conn.commit()
@@ -373,7 +400,7 @@ class JournalSyncThread:
     tail to report_debug_logs for live debug streaming.
 
     Usage:
-        journal = JournalSyncThread(report_uuid, jsonl_path)
+        journal = JournalSyncThread(report_uuid, jsonl_path, execution_token=token)
         journal.start()
         # ... run scan ...
         journal.final_sync()  # After garak completes
@@ -389,6 +416,8 @@ class JournalSyncThread:
         prefix: str = "",
         log_path: Optional[Path] = None,
         interval: int = None,
+        *,
+        execution_token: str,
     ):
         """
         Initialize journal sync thread.
@@ -401,6 +430,7 @@ class JournalSyncThread:
             interval: Seconds between sync cycles (default: 10)
         """
         self.report_uuid = report_uuid
+        self.execution_token = execution_token
         self.jsonl_path = jsonl_path
         self.prefix = prefix
         self.log_path = Path(log_path) if log_path else None
@@ -612,20 +642,36 @@ class JournalSyncThread:
             return False
 
     def _load_report_id(self) -> Optional[int]:
-        """Resolve and memoize the database report id."""
-        if self._report_id is not None:
-            return self._report_id
+        """Resolve the report id unless a *different* attempt now owns the report.
 
+        Deliberately not memoized: a replacement attempt can claim the report at any
+        point, and re-checking each cycle is what stops this process from writing
+        over that attempt's data.
+
+        A NULL token is accepted on purpose. Rails revokes the token when an attempt
+        ends, and the final flush on SIGTERM runs right after exactly that: the stale
+        reaper marks the report interrupted, the heartbeat then terminates this
+        process, and stop() flushes. Requiring a token match here would silently
+        discard every probe result produced since the last periodic sync.
+        """
         with pooled_connection("primary") as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT id FROM reports WHERE uuid = %s",
-                    (self.report_uuid,),
+                    """
+                    SELECT id FROM reports
+                    WHERE uuid = %s
+                      AND (
+                        execution_token = %s
+                        OR (execution_token IS NULL AND status = ANY(%s))
+                      )
+                    """,
+                    (self.report_uuid, self.execution_token, RESUMABLE_STATUSES),
                 )
                 result = cur.fetchone()
                 if not result:
                     logger.warning(
-                        f"JournalSync: report not found: {self.report_uuid}"
+                        f"JournalSync: report {self.report_uuid} is no longer "
+                        f"owned by this execution attempt"
                     )
                     return None
                 self._report_id = result[0]
@@ -1104,7 +1150,7 @@ def _enqueue_broadcast_stats_job(company_id: int, queue_conn) -> int:
     return job_id
 
 
-def notify_report_running(report_uuid: str, pid: int) -> bool:
+def notify_report_running(report_uuid: str, pid: int, execution_token: str) -> bool:
     """
     Update report status to running with PID using pooled connection.
 
@@ -1115,6 +1161,7 @@ def notify_report_running(report_uuid: str, pid: int) -> bool:
     Args:
         report_uuid: UUID of the report
         pid: Process ID of the garak scanner
+        execution_token: UUID Rails minted when it claimed this scan attempt
 
     Returns:
         True on success, False on failure
@@ -1127,10 +1174,16 @@ def notify_report_running(report_uuid: str, pid: int) -> bool:
                     """
                     UPDATE reports
                     SET status = %s, pid = %s, heartbeat_at = NOW(), updated_at = NOW()
-                    WHERE uuid = %s
+                    WHERE uuid = %s AND status = %s AND execution_token = %s
                     RETURNING id, company_id
                     """,
-                    (REPORT_STATUS_RUNNING, pid, report_uuid),
+                    (
+                        REPORT_STATUS_RUNNING,
+                        pid,
+                        report_uuid,
+                        REPORT_STATUS_STARTING,
+                        execution_token,
+                    ),
                 )
                 report_row = cur.fetchone()
 
@@ -1176,7 +1229,9 @@ def notify_report_running(report_uuid: str, pid: int) -> bool:
         return False
 
 
-def notify_report_stopped(report_uuid: str, expected_pid: int = None) -> bool:
+def notify_report_stopped(
+    report_uuid: str, expected_pid: int = None, *, execution_token: str
+) -> bool:
     """
     Clear PID from report using pooled connection (owner-process guard).
 
@@ -1190,7 +1245,8 @@ def notify_report_stopped(report_uuid: str, expected_pid: int = None) -> bool:
         expected_pid: PID to match against stored PID. Defaults to os.getpid().
 
     Returns:
-        True if PID was cleared, False on mismatch or failure
+        True if ownership was cleared, False on a definitive PID/token mismatch,
+        None when the attempt could not be determined (database error)
     """
     my_pid = os.getpid()
     pid_to_match = expected_pid if expected_pid is not None else my_pid
@@ -1202,10 +1258,11 @@ def notify_report_stopped(report_uuid: str, expected_pid: int = None) -> bool:
                 cur.execute(
                     """
                     UPDATE reports
-                    SET pid = NULL, updated_at = NOW()
+                    SET pid = NULL, execution_token = NULL, updated_at = NOW()
                     WHERE uuid = %s AND pid = %s
+                      AND (execution_token = %s OR execution_token IS NULL)
                     """,
-                    (report_uuid, pid_to_match),
+                    (report_uuid, pid_to_match, execution_token),
                 )
                 rows_affected = cur.rowcount
             conn.commit()
@@ -1221,8 +1278,11 @@ def notify_report_stopped(report_uuid: str, expected_pid: int = None) -> bool:
             return True
 
     except Exception as e:
+        # None, not False: the caller cannot tell a definitive "another attempt owns
+        # this report" from "the database did not answer", and the two call for
+        # opposite handling of the report's credential file.
         logger.error(f"Error in notify_report_stopped: {e}")
-        return False
+        return None
 
 
 def _enqueue_process_report_job(report_id: int, queue_conn) -> int:
@@ -1325,7 +1385,13 @@ def _append_authoritative_completion_marker(
     return f"{logs_data}{separator}{marker}\n"
 
 
-def notify_report_ready(report_uuid: str, prefix: str = "", exit_code: Optional[int] = None) -> bool:
+def notify_report_ready(
+    report_uuid: str,
+    prefix: str = "",
+    exit_code: Optional[int] = None,
+    *,
+    execution_token: str,
+) -> bool:
     """
     Store report data in database and enqueue processing job using pooled connections.
 
@@ -1430,11 +1496,26 @@ def notify_report_ready(report_uuid: str, prefix: str = "", exit_code: Optional[
                 timeout_cur.execute("SET statement_timeout = '30s'")
 
             with primary_conn.cursor() as cur:
-                # Get report ID from UUID
-                cur.execute("SELECT id FROM reports WHERE uuid = %s", (report_uuid,))
+                # Resolve the report only while this attempt still owns it, so a
+                # superseded process cannot finalize data over a replacement run.
+                cur.execute(
+                    """
+                    SELECT id FROM reports
+                    WHERE uuid = %s
+                      AND (
+                        execution_token = %s
+                        OR (execution_token IS NULL AND status = ANY(%s))
+                      )
+                    FOR UPDATE
+                    """,
+                    (report_uuid, execution_token, RESUMABLE_STATUSES),
+                )
                 result = cur.fetchone()
                 if not result:
-                    logger.error(f"Report not found: {report_uuid}")
+                    logger.error(
+                        f"Report {report_uuid} is owned by a different execution "
+                        f"attempt; refusing to finalize over it"
+                    )
                     return False
 
                 report_id = result[0]
@@ -1500,7 +1581,12 @@ def notify_report_ready(report_uuid: str, prefix: str = "", exit_code: Optional[
         return False
 
 
-def notify_report_ready_from_synced(report_uuid: str, exit_code: Optional[int] = None) -> bool:
+def notify_report_ready_from_synced(
+    report_uuid: str,
+    exit_code: Optional[int] = None,
+    *,
+    execution_token: str,
+) -> bool:
     """
     Enqueue ProcessReportJob using already-synced raw_report_data.
 
@@ -1552,11 +1638,23 @@ def notify_report_ready_from_synced(report_uuid: str, exit_code: Optional[int] =
 
             with primary_conn.cursor() as cur:
                 cur.execute(
-                    "SELECT id FROM reports WHERE uuid = %s", (report_uuid,)
+                    """
+                    SELECT id FROM reports
+                    WHERE uuid = %s
+                      AND (
+                        execution_token = %s
+                        OR (execution_token IS NULL AND status = ANY(%s))
+                      )
+                    FOR UPDATE
+                    """,
+                    (report_uuid, execution_token, RESUMABLE_STATUSES),
                 )
                 result = cur.fetchone()
                 if not result:
-                    logger.error(f"Report not found: {report_uuid}")
+                    logger.error(
+                        f"Report {report_uuid} is owned by a different execution "
+                        f"attempt; refusing to finalize over it"
+                    )
                     return False
 
                 report_id = result[0]

--- a/script/run_garak.py
+++ b/script/run_garak.py
@@ -6,14 +6,17 @@ This script runs a Garak scan with the provided parameters and communicates with
 via PostgreSQL database operations for multi-pod deployment support.
 
 Communication Flow:
-    1. notify_report_running: UPDATE reports SET status=1, pid=X
+    1. notify_report_running: claim the matching execution attempt as running
     2. notify_report_ready: INSERT into raw_report_data, enqueue ProcessReportJob
-    3. notify_report_stopped: UPDATE reports SET pid=NULL WHERE pid matches caller (PID-match guard)
+    3. notify_report_stopped: clear this attempt's PID and ownership (PID must match
+       this process, and the report must not be owned by a different attempt)
 
 Environment Variables:
     DATABASE_URL: PostgreSQL connection string (required)
         Format: postgresql://user:password@host:port/database
     REPORT_UUID: Report UUID for correlation (optional)
+    SCAN_EXECUTION_TOKEN: UUID Rails assigned to this scan attempt (required for
+        non-validation runs)
     SCAN_ID: Scan ID for correlation (optional)
     SCAN_NAME: Scan name for correlation (optional)
     TARGET_ID: Target ID for correlation (optional)
@@ -64,6 +67,7 @@ def remove_web_config_file(report_uuid):
 
 # Global variables for signal handler cleanup
 current_report_uuid = None
+current_execution_token = None
 current_heartbeat = None
 current_journal_sync = None
 
@@ -97,7 +101,8 @@ def signal_handler(signum, frame):
     if current_heartbeat:
         current_heartbeat.stop()
     if current_report_uuid:
-        notify_report_stopped(current_report_uuid)
+        if current_execution_token:
+            notify_report_stopped(current_report_uuid, current_execution_token)
         remove_web_config_file(current_report_uuid)
     sys.exit(1)
 
@@ -131,10 +136,10 @@ def run_garak_scan(garak_params):
         traceback.print_exc(file=sys.stderr)
         return 1
 
-def notify_report_running(report_uuid, pid):
+def notify_report_running(report_uuid, pid, execution_token):
     """Notify Rails that the report is running with the given PID via PostgreSQL."""
     try:
-        result = db_notify_running(report_uuid, pid)
+        result = db_notify_running(report_uuid, pid, execution_token)
         if result:
             print(f"Report {report_uuid} marked as running (pid={pid})")
         else:
@@ -145,10 +150,15 @@ def notify_report_running(report_uuid, pid):
         return False
 
 
-def notify_report_ready(report_uuid, prefix="", exit_code=None):
+def notify_report_ready(report_uuid, prefix="", exit_code=None, *, execution_token):
     """Store report data in database and enqueue processing job."""
     try:
-        result = db_notify_ready(report_uuid, prefix=prefix, exit_code=exit_code)
+        result = db_notify_ready(
+            report_uuid,
+            prefix=prefix,
+            exit_code=exit_code,
+            execution_token=execution_token,
+        )
         if result:
             print(f"Report {report_uuid} data stored and job enqueued")
         else:
@@ -159,10 +169,14 @@ def notify_report_ready(report_uuid, prefix="", exit_code=None):
         return False
 
 
-def notify_report_ready_from_synced(report_uuid, exit_code=None):
+def notify_report_ready_from_synced(report_uuid, exit_code=None, *, execution_token):
     """Enqueue processing job using already-synced raw_report_data."""
     try:
-        result = db_notify_ready_from_synced(report_uuid, exit_code=exit_code)
+        result = db_notify_ready_from_synced(
+            report_uuid,
+            exit_code=exit_code,
+            execution_token=execution_token,
+        )
         if result:
             print(f"Report {report_uuid} job enqueued (from synced data)")
         else:
@@ -173,10 +187,14 @@ def notify_report_ready_from_synced(report_uuid, exit_code=None):
         return False
 
 
-def notify_report_stopped(report_uuid):
-    """Clear PID from report in database (only if stored PID matches caller)."""
+def notify_report_stopped(report_uuid, execution_token):
+    """Release this execution attempt in the database.
+
+    Returns True when ownership was cleared, False on a definitive mismatch (another
+    attempt owns the report), and None when it could not be determined.
+    """
     try:
-        result = db_notify_stopped(report_uuid)
+        result = db_notify_stopped(report_uuid, execution_token=execution_token)
         if result:
             print(f"Report {report_uuid} PID cleared")
         else:
@@ -184,7 +202,7 @@ def notify_report_stopped(report_uuid):
         return result
     except Exception as e:
         print(f"Error notifying report stopped: {e}", file=sys.stderr)
-        return False
+        return None
 
 def main():
     """Main function to parse arguments and run the Garak scan."""
@@ -194,12 +212,14 @@ def main():
 
     report_uuid = sys.argv[1]
     garak_params = sys.argv[2:]
+    execution_token = os.environ.get('SCAN_EXECUTION_TOKEN', '').strip() or None
     scan_id = os.environ.get('SCAN_ID', 'unknown')
     scan_name = os.environ.get('SCAN_NAME', 'unknown')
     target_id = os.environ.get('TARGET_ID', 'unknown')
     target_name = os.environ.get('TARGET_NAME', 'unknown')
-    global current_report_uuid, current_heartbeat, current_journal_sync
+    global current_report_uuid, current_execution_token, current_heartbeat, current_journal_sync
     current_report_uuid = report_uuid
+    current_execution_token = execution_token
 
     # Get the current process PID
     current_pid = os.getpid()
@@ -213,6 +233,20 @@ def main():
     logger.info(f"Starting garak scan - Report: {report_uuid}, Scan: {scan_name}, "
                 f"Target: {target_name}")
 
+    if not is_validation and not execution_token:
+        # Without the token this process cannot prove which attempt it belongs to,
+        # and every write it makes would be rejected anyway. Fail here, with a
+        # reason, rather than running a whole scan whose results are discarded.
+        logger.error(
+            f"Refusing to start report {report_uuid} without SCAN_EXECUTION_TOKEN; "
+            "the process cannot prove ownership of this execution attempt"
+        )
+        # Rails always sets SCAN_EXECUTION_TOKEN for a claimed attempt, so an empty
+        # one means no attempt owned this report when we were launched -- there is no
+        # live sibling using the credential file, and leaving it would orphan it.
+        remove_web_config_file(report_uuid)
+        sys.exit(1)
+
     if not is_validation:
         # Notify Rails that the report is running with PID (also sets initial heartbeat_at).
         #
@@ -224,7 +258,7 @@ def main():
         # MAX_START_RETRIES times and finally records "Failed after N start attempts.
         # Each attempt timed out" -- which never happened; each process started fine.
         # Failing here costs one attempt instead of four and leaves an accurate reason.
-        if not notify_report_running(report_uuid, current_pid):
+        if not notify_report_running(report_uuid, current_pid, execution_token):
             logger.error(
                 f"Failed to mark report {report_uuid} as running (pid={current_pid}); "
                 f"aborting before the scan starts, because the heartbeat would terminate "
@@ -238,11 +272,26 @@ def main():
             # running. Rails also wrote the credential-bearing <uuid>_web.json before
             # launching us, and once it has accepted the process as started its own
             # rescue no longer removes it.
-            notify_report_stopped(report_uuid)
-            remove_web_config_file(report_uuid)
+            # notify_report_stopped tolerates a revoked (NULL) token, so this still
+            # releases a PID that was recorded before the failing statement. It only
+            # declines when a *different* attempt owns the report -- which is exactly
+            # when <uuid>_web.json belongs to that attempt, so it is left in place.
+            released = notify_report_stopped(report_uuid, execution_token)
+            if released is False:
+                # Definitive mismatch: a different attempt owns the report, and
+                # <uuid>_web.json is keyed on the report uuid alone, so that file is
+                # the live attempt's. Anything else -- cleared, or undetermined
+                # because the database did not answer -- must delete it, since no
+                # other cleanup path runs after this exit.
+                logger.warning(
+                    f"Leaving credential config for {report_uuid} in place: another "
+                    f"execution attempt owns this report and may be using it"
+                )
+            else:
+                remove_web_config_file(report_uuid)
             sys.exit(1)
 
-        heartbeat = HeartbeatThread(report_uuid)
+        heartbeat = HeartbeatThread(report_uuid, execution_token=execution_token)
         current_heartbeat = heartbeat
         heartbeat.start()
 
@@ -260,6 +309,7 @@ def main():
                 jsonl_path,
                 prefix=prefix,
                 log_path=log_path,
+                execution_token=execution_token,
             )
             current_journal_sync = journal_sync
             journal_sync.start()
@@ -282,7 +332,11 @@ def main():
 
             if sync_clean:
                 # Use synced variant — JSONL already in raw_report_data, just add logs + enqueue job
-                if not notify_report_ready_from_synced(report_uuid, exit_code=exit_code):
+                if not notify_report_ready_from_synced(
+                    report_uuid,
+                    exit_code=exit_code,
+                    execution_token=execution_token,
+                ):
                     logger.error(f"Failed to enqueue ProcessReportJob for {report_uuid}")
                     exit_code = 1
             else:
@@ -292,7 +346,12 @@ def main():
                     f"JournalSync did not stop cleanly for {report_uuid}, "
                     f"falling back to full JSONL read from disk"
                 )
-                if not notify_report_ready(report_uuid, prefix=prefix, exit_code=exit_code):
+                if not notify_report_ready(
+                    report_uuid,
+                    prefix=prefix,
+                    exit_code=exit_code,
+                    execution_token=execution_token,
+                ):
                     logger.error(f"Failed to enqueue ProcessReportJob for {report_uuid}")
                     exit_code = 1
 
@@ -311,7 +370,7 @@ def main():
             heartbeat.stop()
             current_heartbeat = None
         if not is_validation:
-            notify_report_stopped(report_uuid)
+            notify_report_stopped(report_uuid, execution_token)
         remove_web_config_file(report_uuid)
 
     sys.exit(exit_code)

--- a/script/tests/test_db_notifier_broadcast_job.py
+++ b/script/tests/test_db_notifier_broadcast_job.py
@@ -29,6 +29,8 @@ if "db_notifier" in sys.modules:
 
 import db_notifier  # noqa: E402
 
+TOKEN = "11111111-2222-3333-4444-555555555555"
+
 
 class TestNotifyReportRunningBroadcastJob(unittest.TestCase):
     def _make_mock_conn(self, rowcount=1, fetchone_result=None):
@@ -54,13 +56,22 @@ class TestNotifyReportRunningBroadcastJob(unittest.TestCase):
         queue_conn, queue_cur = self._make_mock_conn(fetchone_result=(123,))
         mock_pooled.side_effect = [primary_conn, queue_conn]
 
-        result = db_notifier.notify_report_running("report-uuid", pid=456)
+        result = db_notifier.notify_report_running("report-uuid", 456, TOKEN)
 
         self.assertTrue(result)
 
         update_sql, update_params = primary_cur.execute.call_args_list[0][0]
         self.assertIn("RETURNING id, company_id", update_sql)
-        self.assertEqual(update_params, (db_notifier.REPORT_STATUS_RUNNING, 456, "report-uuid"))
+        self.assertEqual(
+            update_params,
+            (
+                db_notifier.REPORT_STATUS_RUNNING,
+                456,
+                "report-uuid",
+                db_notifier.REPORT_STATUS_STARTING,
+                TOKEN,
+            ),
+        )
 
         tail_reset_sql, tail_reset_params = primary_cur.execute.call_args_list[1][0]
         self.assertIn("UPDATE report_debug_logs", tail_reset_sql)

--- a/script/tests/test_db_notifier_debug_log_tail.py
+++ b/script/tests/test_db_notifier_debug_log_tail.py
@@ -35,6 +35,8 @@ if cached_db_notifier is not None and (
 
 import db_notifier  # noqa: E402
 
+TOKEN = "11111111-2222-3333-4444-555555555555"
+
 
 class TestDebugLogTailBytesConfig(unittest.TestCase):
     def setUp(self):
@@ -165,6 +167,7 @@ class TestJournalSyncDebugLogTail(unittest.TestCase):
             "report-uuid",
             self.jsonl_path,
             log_path=self.log_path,
+            execution_token=TOKEN,
         )
 
     def _patch_pooled_connection(self, conn):
@@ -343,7 +346,7 @@ class TestJournalSyncDebugLogTail(unittest.TestCase):
 
         with self._patch_pooled_connection(conn), \
              patch.object(db_notifier, "_enqueue_broadcast_stats_job", return_value="job-id"):
-            self.assertTrue(db_notifier.notify_report_running("report-uuid", 456))
+            self.assertTrue(db_notifier.notify_report_running("report-uuid", 456, TOKEN))
 
         tail_reset_calls = self._sql_calls_containing(cursor, "UPDATE report_debug_logs")
         self.assertEqual(len(tail_reset_calls), 1)
@@ -364,7 +367,7 @@ class TestJournalSyncDebugLogTail(unittest.TestCase):
              patch.object(db_notifier, "get_log_file_path", return_value=self.log_path), \
              patch.object(db_notifier, "_enqueue_process_report_job", return_value="job-id"), \
              patch.object(db_notifier, "cleanup_scan_files"):
-            self.assertTrue(db_notifier.notify_report_ready_from_synced("report-uuid"))
+            self.assertTrue(db_notifier.notify_report_ready_from_synced("report-uuid", execution_token=TOKEN))
 
         raw_log_updates = self._sql_calls_containing(cursor, "UPDATE raw_report_data")
         self.assertEqual(len(raw_log_updates), 1)
@@ -380,7 +383,7 @@ class TestJournalSyncDebugLogTail(unittest.TestCase):
              patch.object(db_notifier, "get_log_file_path", return_value=self.log_path), \
              patch.object(db_notifier, "_enqueue_process_report_job", return_value="job-id"), \
              patch.object(db_notifier, "cleanup_scan_files"):
-            self.assertTrue(db_notifier.notify_report_ready_from_synced("report-uuid"))
+            self.assertTrue(db_notifier.notify_report_ready_from_synced("report-uuid", execution_token=TOKEN))
 
         raw_log_updates = self._sql_calls_containing(cursor, "UPDATE raw_report_data")
         self.assertEqual(len(raw_log_updates), 1)
@@ -403,7 +406,7 @@ class TestJournalSyncDebugLogTail(unittest.TestCase):
              patch.object(db_notifier, "_enqueue_process_report_job", return_value="job-id"), \
              patch.object(db_notifier, "cleanup_scan_files"):
             self.assertTrue(
-                db_notifier.notify_report_ready_from_synced("report-uuid", exit_code=0)
+                db_notifier.notify_report_ready_from_synced("report-uuid", exit_code=0, execution_token=TOKEN)
             )
 
         logs_data = self._sql_calls_containing(cursor, "UPDATE raw_report_data")[0][1][0]
@@ -426,7 +429,7 @@ class TestJournalSyncDebugLogTail(unittest.TestCase):
              patch.object(db_notifier, "_enqueue_process_report_job", return_value="job-id"), \
              patch.object(db_notifier, "cleanup_scan_files"):
             self.assertTrue(
-                db_notifier.notify_report_ready_from_synced("report-uuid", exit_code=1)
+                db_notifier.notify_report_ready_from_synced("report-uuid", exit_code=1, execution_token=TOKEN)
             )
 
         logs_data = self._sql_calls_containing(cursor, "UPDATE raw_report_data")[0][1][0]
@@ -443,7 +446,7 @@ class TestJournalSyncDebugLogTail(unittest.TestCase):
              patch.object(db_notifier, "get_log_file_path", return_value=self.log_path), \
              patch.object(db_notifier, "_enqueue_process_report_job", return_value="job-id"), \
              patch.object(db_notifier, "cleanup_scan_files"):
-            self.assertTrue(db_notifier.notify_report_ready_from_synced("report-uuid"))
+            self.assertTrue(db_notifier.notify_report_ready_from_synced("report-uuid", execution_token=TOKEN))
 
         logs_data = self._sql_calls_containing(cursor, "UPDATE raw_report_data")[0][1][0]
         self.assertEqual(logs_data, "plain logs\n")

--- a/script/tests/test_db_notifier_execution_token.py
+++ b/script/tests/test_db_notifier_execution_token.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""
+Tests for execution-token fencing in db_notifier.
+
+A PID is local to a container. When a worker pod is drained and replaced, the
+replacement can be handed the same PID, so a PID match cannot prove that the
+process writing is the process that was started for this attempt. Rails mints an
+execution token when it claims a scan and revokes it whenever the attempt ends;
+every write the scanner makes is fenced on that token, so a superseded process
+writes nothing.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Stub psycopg2 before importing db_notifier
+# ---------------------------------------------------------------------------
+_mock_psycopg2 = ModuleType("psycopg2")
+_mock_psycopg2.OperationalError = type("OperationalError", (Exception,), {})
+_mock_psycopg2.pool = ModuleType("psycopg2.pool")
+_mock_psycopg2.pool.ThreadedConnectionPool = MagicMock
+sys.modules.setdefault("psycopg2", _mock_psycopg2)
+sys.modules.setdefault("psycopg2.pool", _mock_psycopg2.pool)
+
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__), "..")
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
+# Another test module may have cached a lightweight db_notifier mock; force the
+# real module so these tests exercise the actual SQL.
+if "db_notifier" in sys.modules:
+    cached = sys.modules["db_notifier"]
+    if not hasattr(cached, "pooled_connection"):
+        del sys.modules["db_notifier"]
+        _pool_mod = sys.modules.get("psycopg2.pool")
+        if _pool_mod and not hasattr(_pool_mod, "ThreadedConnectionPool"):
+            _pool_mod.ThreadedConnectionPool = MagicMock
+
+import db_notifier  # noqa: E402
+
+TOKEN = "11111111-2222-3333-4444-555555555555"
+UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def make_conn(fetchone=None, rowcount=1):
+    cur = MagicMock()
+    cur.rowcount = rowcount
+    cur.fetchone.return_value = fetchone
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    return conn, cur
+
+
+def executed(cur):
+    """All (sql, params) pairs passed to cursor.execute."""
+    return [(c.args[0], c.args[1] if len(c.args) > 1 else ()) for c in cur.execute.call_args_list]
+
+
+def statement_matching(cur, needle):
+    for sql, params in executed(cur):
+        if needle in sql:
+            return sql, params
+    return None, None
+
+
+class TestNotifyReportRunning(unittest.TestCase):
+    def test_claims_only_the_attempt_it_was_started_for(self):
+        conn, cur = make_conn(fetchone=(7, 3))
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            db_notifier.notify_report_running(UUID, 4321, TOKEN)
+
+        sql, params = statement_matching(cur, "UPDATE reports")
+        self.assertIn("execution_token = %s", sql)
+        # Only a report Rails has claimed and not yet revoked may be taken over.
+        self.assertIn("status = %s", sql)
+        self.assertIn(TOKEN, params)
+        self.assertIn(db_notifier.REPORT_STATUS_STARTING, params)
+
+    def test_reports_failure_when_the_attempt_was_superseded(self):
+        conn, _ = make_conn(fetchone=None, rowcount=0)
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            result = db_notifier.notify_report_running(UUID, 4321, TOKEN)
+
+        self.assertFalse(result)
+
+
+class TestNotifyReportStopped(unittest.TestCase):
+    def test_releases_only_a_matching_attempt(self):
+        conn, cur = make_conn(rowcount=1)
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            result = db_notifier.notify_report_stopped(UUID, execution_token=TOKEN)
+
+        sql, params = statement_matching(cur, "UPDATE reports")
+        self.assertIn("execution_token = %s", sql)
+        self.assertIn("execution_token = NULL", sql)
+        self.assertIn(TOKEN, params)
+        self.assertTrue(result)
+
+    def test_clears_nothing_when_the_token_no_longer_matches(self):
+        conn, _ = make_conn(rowcount=0)
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            result = db_notifier.notify_report_stopped(UUID, execution_token=TOKEN)
+
+        self.assertFalse(result)
+
+    def test_still_honours_the_explicit_pid_guard(self):
+        conn, cur = make_conn(rowcount=1)
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            db_notifier.notify_report_stopped(UUID, expected_pid=999, execution_token=TOKEN)
+
+        _, params = statement_matching(cur, "UPDATE reports")
+        self.assertIn(999, params)
+
+
+class TestRevokedButStillAlive(unittest.TestCase):
+    """Revoked is not the same as superseded.
+
+    Rails revokes the token whenever an attempt ends -- including while the garak
+    process is still running (a stop, or the stale reaper firing on a lapsed
+    heartbeat). That process must still be able to release its own PID and flush
+    what it has: nobody else owns the report. Only a *replacement* attempt, which
+    is a different non-null token, may block those writes.
+    """
+
+    def test_stopped_releases_the_pid_after_its_token_was_revoked(self):
+        conn, cur = make_conn(rowcount=1)
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            db_notifier.notify_report_stopped(UUID, execution_token=TOKEN)
+
+        sql, _ = statement_matching(cur, "UPDATE reports")
+        # Otherwise a stopped report keeps a pid pointing at a dead process, and a
+        # replacement pod can be handed that same pid.
+        self.assertIn("execution_token IS NULL", sql)
+
+    def test_journal_sync_flushes_after_its_token_was_revoked(self):
+        conn, cur = make_conn(fetchone=(7,))
+        thread = db_notifier.JournalSyncThread(
+            UUID, Path("/tmp/does-not-matter.jsonl"), execution_token=TOKEN
+        )
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            self.assertEqual(thread._load_report_id(), 7)
+
+        sql, _ = statement_matching(cur, "SELECT id FROM reports")
+        # The final flush on SIGTERM happens after Rails has already revoked; the
+        # old unconditional lookup always persisted it.
+        self.assertIn("execution_token IS NULL", sql)
+
+    def test_completion_is_allowed_after_its_token_was_revoked(self):
+        conn, cur = make_conn(fetchone=None)
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            db_notifier.notify_report_ready_from_synced(
+                UUID, exit_code=0, execution_token=TOKEN
+            )
+
+        sql, _ = statement_matching(cur, "SELECT id FROM reports")
+        self.assertIn("execution_token IS NULL", sql)
+        # ...and the row is held for the rest of the transaction, so a replacement
+        # cannot claim it between this check and the writes that follow.
+        self.assertIn("FOR UPDATE", sql)
+
+
+class TestRevokedWritesAreScopedByStatus(unittest.TestCase):
+    """A revoked token alone is not enough to justify writing.
+
+    Reports::Stop sets the report to `stopped` with a NULL token and then
+    Reports::Cleanup deletes its raw_report_data. The scanner notices a heartbeat
+    later and flushes -- which would upsert the prompts and outputs the user just
+    cancelled straight back, with nothing left to remove them again. The completion
+    paths would additionally enqueue processing for a cancelled report.
+    """
+
+    def _assert_scoped(self, sql, params):
+        self.assertIsNotNone(sql, "expected a report ownership lookup")
+        self.assertIn("execution_token IS NULL", sql)
+        self.assertIn("status = ANY", sql)
+        lists = [p for p in params if isinstance(p, (list, tuple))]
+        self.assertEqual(len(lists), 1, "expected a status allowlist parameter")
+        allowed = list(lists[0])
+        self.assertIn(db_notifier.REPORT_STATUS_RUNNING, allowed)
+        self.assertIn(db_notifier.REPORT_STATUS_INTERRUPTED, allowed)
+        self.assertNotIn(db_notifier.REPORT_STATUS_STOPPED, allowed)
+        self.assertNotIn(db_notifier.REPORT_STATUS_FAILED, allowed)
+        self.assertNotIn(db_notifier.REPORT_STATUS_PROCESSING, allowed)
+
+    def test_journal_flush_is_scoped(self):
+        conn, cur = make_conn(fetchone=(7,))
+        thread = db_notifier.JournalSyncThread(
+            UUID, Path("/tmp/does-not-matter.jsonl"), execution_token=TOKEN
+        )
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            thread._load_report_id()
+
+        self._assert_scoped(*statement_matching(cur, "SELECT id FROM reports"))
+
+    def test_completion_from_synced_is_scoped(self):
+        conn, cur = make_conn(fetchone=None)
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            db_notifier.notify_report_ready_from_synced(
+                UUID, exit_code=0, execution_token=TOKEN
+            )
+
+        self._assert_scoped(*statement_matching(cur, "SELECT id FROM reports"))
+
+
+class TestHeartbeat(unittest.TestCase):
+    def test_heartbeat_is_fenced_on_the_attempt(self):
+        conn, cur = make_conn(rowcount=1)
+        heartbeat = db_notifier.HeartbeatThread(UUID, execution_token=TOKEN)
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            heartbeat._send_heartbeat()
+
+        sql, params = statement_matching(cur, "UPDATE reports")
+        self.assertIn("execution_token = %s", sql)
+        self.assertIn(TOKEN, params)
+
+    def test_a_revoked_attempt_stops_heartbeating(self):
+        # Zero rows means this process no longer owns the report; the thread
+        # treats that as "status changed" and terminates the scan.
+        conn, _ = make_conn(rowcount=0)
+        heartbeat = db_notifier.HeartbeatThread(UUID, execution_token=TOKEN)
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            # "error" also differs from "ok" but takes 3 cycles (~90s) to terminate;
+            # only "not_running" self-terminates on the first cycle.
+            self.assertEqual(heartbeat._send_heartbeat(), "not_running")
+
+
+class TestCompletionHandoff(unittest.TestCase):
+    def test_ready_from_synced_will_not_complete_a_superseded_attempt(self):
+        conn, cur = make_conn(fetchone=None)
+
+        with patch.object(db_notifier, "pooled_connection", return_value=conn):
+            result = db_notifier.notify_report_ready_from_synced(
+                UUID, exit_code=0, execution_token=TOKEN
+            )
+
+        sql, params = statement_matching(cur, "SELECT id FROM reports")
+        self.assertIn("execution_token = %s", sql)
+        self.assertIn(TOKEN, params)
+        self.assertFalse(result)
+
+    def test_ready_will_not_complete_a_superseded_attempt(self):
+        conn, cur = make_conn(fetchone=None)
+
+        # notify_report_ready reads the scan's files before touching the database,
+        # so give it real ones and let it reach the ownership check.
+        with tempfile.TemporaryDirectory() as tmp:
+            reports_dir = Path(tmp)
+            (reports_dir / f"{UUID}.report.jsonl").write_text("{}\n", encoding="utf-8")
+            log_path = reports_dir / "scan.log"
+            log_path.write_text("", encoding="utf-8")
+
+            with patch.object(db_notifier, "REPORTS_PATH", reports_dir), \
+                    patch.object(db_notifier, "get_log_file_path", return_value=log_path), \
+                    patch.object(db_notifier, "pooled_connection", return_value=conn):
+                result = db_notifier.notify_report_ready(
+                    UUID, prefix="", exit_code=0, execution_token=TOKEN
+                )
+
+        sql, params = statement_matching(cur, "SELECT id FROM reports")
+        self.assertIn("execution_token = %s", sql)
+        self.assertIn(TOKEN, params)
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/script/tests/test_db_notifier_pid_guard.py
+++ b/script/tests/test_db_notifier_pid_guard.py
@@ -43,6 +43,9 @@ if "db_notifier" in sys.modules:
 
 import db_notifier  # noqa: E402
 
+# Rails mints this when it claims the attempt; every scanner write is fenced on it.
+TOKEN = "11111111-2222-3333-4444-555555555555"
+
 
 class TestNotifyReportStoppedPidGuard(unittest.TestCase):
     """notify_report_stopped only clears PID when stored PID matches caller."""
@@ -68,7 +71,7 @@ class TestNotifyReportStoppedPidGuard(unittest.TestCase):
         mock_pooled.return_value = mock_conn
 
         my_pid = os.getpid()
-        result = db_notifier.notify_report_stopped("test-uuid-owner")
+        result = db_notifier.notify_report_stopped("test-uuid-owner", execution_token=TOKEN)
 
         self.assertTrue(result)
 
@@ -77,7 +80,7 @@ class TestNotifyReportStoppedPidGuard(unittest.TestCase):
         executed_params = mock_cur.execute.call_args[0][1]
 
         self.assertIn("AND pid = %s", executed_sql)
-        self.assertEqual(executed_params, ("test-uuid-owner", my_pid))
+        self.assertEqual(executed_params, ("test-uuid-owner", my_pid, TOKEN))
 
     @patch("db_notifier.pooled_connection")
     def test_mismatched_pid_does_not_clear(self, mock_pooled):
@@ -86,14 +89,14 @@ class TestNotifyReportStoppedPidGuard(unittest.TestCase):
         mock_pooled.return_value = mock_conn
 
         # Pass a PID that would be different from stored PID
-        result = db_notifier.notify_report_stopped("test-uuid-child", expected_pid=99999)
+        result = db_notifier.notify_report_stopped("test-uuid-child", expected_pid=99999, execution_token=TOKEN)
 
         self.assertFalse(result)
 
         executed_sql = mock_cur.execute.call_args[0][0]
         executed_params = mock_cur.execute.call_args[0][1]
         self.assertIn("AND pid = %s", executed_sql)
-        self.assertEqual(executed_params, ("test-uuid-child", 99999))
+        self.assertEqual(executed_params, ("test-uuid-child", 99999, TOKEN))
 
     @patch("db_notifier.pooled_connection")
     def test_explicit_expected_pid_overrides_getpid(self, mock_pooled):
@@ -102,12 +105,12 @@ class TestNotifyReportStoppedPidGuard(unittest.TestCase):
         mock_pooled.return_value = mock_conn
 
         explicit_pid = 12345
-        result = db_notifier.notify_report_stopped("test-uuid-explicit", expected_pid=explicit_pid)
+        result = db_notifier.notify_report_stopped("test-uuid-explicit", expected_pid=explicit_pid, execution_token=TOKEN)
 
         self.assertTrue(result)
 
         executed_params = mock_cur.execute.call_args[0][1]
-        self.assertEqual(executed_params, ("test-uuid-explicit", explicit_pid))
+        self.assertEqual(executed_params, ("test-uuid-explicit", explicit_pid, TOKEN))
 
     @patch("db_notifier.pooled_connection")
     def test_defaults_to_current_pid(self, mock_pooled):
@@ -115,7 +118,7 @@ class TestNotifyReportStoppedPidGuard(unittest.TestCase):
         mock_conn, mock_cur = self._make_mock_conn(rowcount=1)
         mock_pooled.return_value = mock_conn
 
-        result = db_notifier.notify_report_stopped("test-uuid-default")
+        result = db_notifier.notify_report_stopped("test-uuid-default", execution_token=TOKEN)
 
         executed_params = mock_cur.execute.call_args[0][1]
         self.assertEqual(executed_params[1], os.getpid())
@@ -125,7 +128,7 @@ class TestNotifyReportStoppedPidGuard(unittest.TestCase):
         """Database errors are caught and return False."""
         mock_pooled.side_effect = Exception("connection failed")
 
-        result = db_notifier.notify_report_stopped("test-uuid-err")
+        result = db_notifier.notify_report_stopped("test-uuid-err", execution_token=TOKEN)
         self.assertFalse(result)
 
     @patch("db_notifier.pooled_connection")
@@ -138,13 +141,13 @@ class TestNotifyReportStoppedPidGuard(unittest.TestCase):
         parent_pid = os.getpid()
         child_pid = parent_pid + 1  # Would be different after fork
 
-        result = db_notifier.notify_report_stopped("test-uuid-fork", expected_pid=child_pid)
+        result = db_notifier.notify_report_stopped("test-uuid-fork", expected_pid=child_pid, execution_token=TOKEN)
 
         self.assertFalse(result)
         executed_sql = mock_cur.execute.call_args[0][0]
         executed_params = mock_cur.execute.call_args[0][1]
         self.assertIn("AND pid = %s", executed_sql)
-        self.assertEqual(executed_params, ("test-uuid-fork", child_pid))
+        self.assertEqual(executed_params, ("test-uuid-fork", child_pid, TOKEN))
 
 
 if __name__ == "__main__":

--- a/script/tests/test_remove_web_config_file.py
+++ b/script/tests/test_remove_web_config_file.py
@@ -51,19 +51,23 @@ class TestRemoveWebConfigFile(unittest.TestCase):
                 run_garak.remove_web_config_file("nope")  # must not raise
 
 
+TOKEN = "11111111-2222-3333-4444-555555555555"
+
+
 class TestSignalHandlerCleanup(unittest.TestCase):
     def test_main_process_removes_web_config_on_signal(self):
         # An early SIGTERM (before the main try/finally) must still delete the
         # credential file from the parent signal handler.
         with patch.object(run_garak, "_main_pid", os.getpid()), \
              patch.object(run_garak, "current_report_uuid", "uuid-xyz"), \
+             patch.object(run_garak, "current_execution_token", TOKEN), \
              patch.object(run_garak, "current_journal_sync", None), \
              patch.object(run_garak, "current_heartbeat", None), \
              patch.object(run_garak, "notify_report_stopped") as m_stop, \
              patch.object(run_garak, "remove_web_config_file") as m_rm:
             with self.assertRaises(SystemExit):
                 run_garak.signal_handler(15, None)
-        m_stop.assert_called_once_with("uuid-xyz")
+        m_stop.assert_called_once_with("uuid-xyz", TOKEN)
         m_rm.assert_called_once_with("uuid-xyz")
 
 

--- a/script/tests/test_run_garak_log_path.py
+++ b/script/tests/test_run_garak_log_path.py
@@ -52,6 +52,9 @@ finally:
 run_garak = _run_garak
 
 
+TOKEN = "11111111-2222-3333-4444-555555555555"
+
+
 class TestRunGarakJournalSyncLogPath(unittest.TestCase):
     def setUp(self):
         self._saved_uuid = run_garak.current_report_uuid
@@ -86,7 +89,8 @@ class TestRunGarakJournalSyncLogPath(unittest.TestCase):
              patch.object(run_garak, "run_garak_scan", return_value=0), \
              patch.object(run_garak, "notify_report_ready_from_synced", return_value=True), \
              patch.object(run_garak, "notify_report_stopped", return_value=True), \
-             patch("sys.exit") as mock_exit:
+             patch("sys.exit") as mock_exit, \
+             patch.dict(os.environ, {"SCAN_EXECUTION_TOKEN": TOKEN}):
             run_garak.main()
 
         mock_journal_sync.assert_called_once_with(
@@ -94,6 +98,7 @@ class TestRunGarakJournalSyncLogPath(unittest.TestCase):
             run_garak.REPORTS_PATH / "report-uuid.report.jsonl",
             prefix="prefix-data",
             log_path=log_path,
+            execution_token=TOKEN,
         )
         journal_sync.start.assert_called_once()
         journal_sync.stop.assert_called_once()

--- a/script/tests/test_run_garak_running_notification.py
+++ b/script/tests/test_run_garak_running_notification.py
@@ -57,9 +57,13 @@ finally:
     else:
         sys.modules["db_notifier"] = _original_db_notifier
 
+# Rails mints this when it claims the attempt and passes it in the process env.
+TOKEN = "11111111-2222-3333-4444-555555555555"
+
 
 class TestRunningNotificationFailureIsFatal(unittest.TestCase):
-    def _run_main(self, running_result, uuid="report-uuid-123", config_dir=None):
+    def _run_main(self, running_result, uuid="report-uuid-123", config_dir=None, token=TOKEN,
+                  stopped_result=True):
         # run_garak is imported once per process, so whichever test module imports it
         # first supplies these module-level constants. Pin them here (as Path, since
         # run_garak builds paths with `/`) so this test does not depend on that order.
@@ -74,10 +78,15 @@ class TestRunningNotificationFailureIsFatal(unittest.TestCase):
              patch.object(run_garak, "JournalSyncThread"), \
              patch.object(run_garak, "notify_report_ready", return_value=True), \
              patch.object(run_garak, "notify_report_ready_from_synced", return_value=True), \
-             patch.object(run_garak, "notify_report_stopped", return_value=True) as mock_stopped, \
+             patch.object(run_garak, "notify_report_stopped", return_value=stopped_result) as mock_stopped, \
              patch.object(run_garak, "load_existing_jsonl_prefix", return_value=""), \
              patch.object(run_garak, "get_log_file_path", return_value=tmp / "report.log"), \
-             patch.object(sys, "argv", ["run_garak.py", uuid]):
+             patch.object(sys, "argv", ["run_garak.py", uuid]), \
+             patch.dict(os.environ, {}):
+            if token:
+                os.environ["SCAN_EXECUTION_TOKEN"] = token
+            else:
+                os.environ.pop("SCAN_EXECUTION_TOKEN", None)
             with self.assertRaises(SystemExit) as ctx:
                 run_garak.main()
         return ctx.exception.code, mock_scan, mock_heartbeat, mock_stopped
@@ -113,10 +122,60 @@ class TestRunningNotificationFailureIsFatal(unittest.TestCase):
         code, _scan, _hb, mock_stopped = self._run_main(running_result=False)
 
         self.assertEqual(code, 1)
-        mock_stopped.assert_called_once_with("report-uuid-123")
+        mock_stopped.assert_called_once_with("report-uuid-123", TOKEN)
 
     def test_still_runs_the_scan_when_the_running_write_succeeds(self):
         code, mock_scan, _mock_heartbeat, _stopped = self._run_main(running_result=True)
+
+        self.assertEqual(code, 0)
+        mock_scan.assert_called_once()
+
+    def test_keeps_the_credential_config_when_another_attempt_owns_the_report(self):
+        # <uuid>_web.json is keyed on the report UUID alone, so it is the same file a
+        # replacement attempt is already using. notify_report_stopped declining is how
+        # this process learns it is no longer the owner.
+        config_dir = Path(tempfile.mkdtemp()) / "config"
+        config_dir.mkdir(parents=True)
+        web_config = config_dir / "report-uuid-123_web.json"
+        web_config.write_text("{}")
+
+        self._run_main(running_result=False, config_dir=config_dir, stopped_result=False)
+
+        self.assertTrue(
+            web_config.exists(),
+            "a superseded process deleted the live attempt's credential file",
+        )
+
+    def test_removes_the_credential_config_when_ownership_cleanup_errors(self):
+        # A None result means the release could not be determined -- a database outage,
+        # say -- not that another attempt owns the report. Only a definitive mismatch
+        # may keep credentials on disk; nothing else runs after this exit.
+        config_dir = Path(tempfile.mkdtemp()) / "config"
+        config_dir.mkdir(parents=True)
+        web_config = config_dir / "report-uuid-123_web.json"
+        web_config.write_text('{"cookies": [{"name": "session", "value": "secret"}]}')
+
+        self._run_main(running_result=False, config_dir=config_dir, stopped_result=None)
+
+        self.assertFalse(web_config.exists(), "credential web config left on disk")
+
+    def test_refuses_to_start_without_an_execution_token(self):
+        # Rails could only omit the token if the attempt was already revoked. Every
+        # write this process makes would be rejected, so running the scan would burn
+        # a full scan's work to produce nothing. Fail immediately, with a reason.
+        code, mock_scan, mock_heartbeat, _stopped = self._run_main(
+            running_result=True, token=None
+        )
+
+        self.assertEqual(code, 1)
+        mock_scan.assert_not_called()
+        mock_heartbeat.assert_not_called()
+
+    def test_validation_runs_do_not_need_an_execution_token(self):
+        # Validation runs have no report row to own, so there is nothing to fence.
+        code, mock_scan, _hb, _stopped = self._run_main(
+            running_result=True, uuid="validation_abc", token=None
+        )
 
         self.assertEqual(code, 0)
         mock_scan.assert_called_once()

--- a/script/tests/test_run_garak_signal_handler.py
+++ b/script/tests/test_run_garak_signal_handler.py
@@ -60,12 +60,14 @@ _orig_sigterm = signal.getsignal(signal.SIGTERM)
 _orig_sigint = signal.getsignal(signal.SIGINT)
 
 try:
-    import run_garak  # noqa: E402  (registers global SIGTERM/SIGINT handlers)
+    import run_garak  # noqa: E402 (registers global SIGTERM/SIGINT handlers)
 finally:
     if _original_db_notifier is None:
         sys.modules.pop("db_notifier", None)
     else:
         sys.modules["db_notifier"] = _original_db_notifier
+
+TOKEN = "11111111-2222-3333-4444-555555555555"
 
 
 class TestParentSignalHandler(unittest.TestCase):
@@ -73,24 +75,27 @@ class TestParentSignalHandler(unittest.TestCase):
 
     def setUp(self):
         self._saved_uuid = run_garak.current_report_uuid
+        self._saved_token = run_garak.current_execution_token
         self._saved_hb = run_garak.current_heartbeat
         self._saved_js = run_garak.current_journal_sync
 
     def tearDown(self):
         run_garak.current_report_uuid = self._saved_uuid
+        run_garak.current_execution_token = self._saved_token
         run_garak.current_heartbeat = self._saved_hb
         run_garak.current_journal_sync = self._saved_js
 
     def test_parent_calls_notify_report_stopped(self):
         """Parent process performs cleanup when signal_handler fires."""
         run_garak.current_report_uuid = "parent-test-uuid"
+        run_garak.current_execution_token = TOKEN
         run_garak.current_heartbeat = None
         run_garak.current_journal_sync = None
 
         with patch.object(run_garak, "notify_report_stopped", return_value=True) as mock_stopped:
             with self.assertRaises(SystemExit):
                 run_garak.signal_handler(signal.SIGTERM, None)
-            mock_stopped.assert_called_once_with("parent-test-uuid")
+            mock_stopped.assert_called_once_with("parent-test-uuid", TOKEN)
 
     def test_parent_stops_heartbeat_and_journal_sync(self):
         """Parent process stops heartbeat and journal sync threads."""
@@ -117,11 +122,13 @@ class TestChildSignalHandlerSafety(unittest.TestCase):
 
     def setUp(self):
         self._saved_uuid = run_garak.current_report_uuid
+        self._saved_token = run_garak.current_execution_token
         self._saved_hb = run_garak.current_heartbeat
         self._saved_js = run_garak.current_journal_sync
 
     def tearDown(self):
         run_garak.current_report_uuid = self._saved_uuid
+        run_garak.current_execution_token = self._saved_token
         run_garak.current_heartbeat = self._saved_hb
         run_garak.current_journal_sync = self._saved_js
 
@@ -138,13 +145,16 @@ class TestChildSignalHandlerSafety(unittest.TestCase):
         # Replace notify_report_stopped with a version that writes a marker
         original_fn = run_garak.notify_report_stopped
 
-        def tracking_stopped(uuid):
+        def tracking_stopped(uuid, execution_token=None):
             with open(marker_file, "w") as f:
                 f.write(f"cleanup_called_by_pid_{os.getpid()}")
             return True
 
         run_garak.notify_report_stopped = tracking_stopped
         run_garak.current_report_uuid = "child-test-uuid"
+        # Without this the parent-cleanup branch skips notify_report_stopped on its
+        # own, and the test would pass even with the fork guard removed.
+        run_garak.current_execution_token = TOKEN
         run_garak.current_heartbeat = None
         run_garak.current_journal_sync = None
 

--- a/spec/jobs/check_stale_reports_job_spec.rb
+++ b/spec/jobs/check_stale_reports_job_spec.rb
@@ -16,6 +16,43 @@ RSpec.describe CheckStaleReportsJob, type: :job do
   end
 
   describe "#perform" do
+    describe "execution ownership" do
+      # Whatever the old process does after this point must not land on the
+      # replacement attempt, so every transition out of a live scan revokes.
+      it "revokes the token when a stale report is interrupted" do
+        report = create(:report, target: target, scan: scan, status: :running, pid: 12345,
+                        heartbeat_at: 3.minutes.ago, retry_count: 0,
+                        execution_token: SecureRandom.uuid)
+
+        described_class.new.perform
+
+        expect(report.reload.status).to eq("interrupted")
+        expect(report.execution_token).to be_nil
+      end
+
+      it "revokes the token when a stale report is failed" do
+        report = create(:report, target: target, scan: scan, status: :running, pid: 12345,
+                        heartbeat_at: 3.minutes.ago, retry_count: 3,
+                        execution_token: SecureRandom.uuid)
+
+        described_class.new.perform
+
+        expect(report.reload.status).to eq("failed")
+        expect(report.execution_token).to be_nil
+      end
+
+      it "revokes the token when a report stuck in starting is retried" do
+        report = create(:report, target: target, scan: scan, status: :starting,
+                        retry_count: 0, execution_token: SecureRandom.uuid)
+        report.update_column(:updated_at, 10.minutes.ago)
+
+        described_class.new.perform
+
+        expect(report.reload.status).to eq("pending")
+        expect(report.execution_token).to be_nil
+      end
+    end
+
     describe "stale running reports" do
       it "marks report as interrupted when heartbeat is stale (first occurrence)" do
         stale_time = 3.minutes.ago

--- a/spec/jobs/retry_interrupted_reports_job_spec.rb
+++ b/spec/jobs/retry_interrupted_reports_job_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe RetryInterruptedReportsJob, type: :job do
   end
 
   describe "#perform" do
+    it "revokes the execution token of the interrupted attempt" do
+      report = create(:report, target: target, scan: scan, status: :interrupted,
+                      retry_count: 0, updated_at: 1.minute.ago,
+                      execution_token: SecureRandom.uuid)
+
+      described_class.new.perform
+
+      expect(report.reload.status).to eq("pending")
+      expect(report.execution_token).to be_nil
+    end
+
     describe "basic retry behavior" do
       it "moves interrupted reports back to pending after stabilization delay" do
         report = create(:report, target: target, scan: scan, status: :interrupted, retry_count: 0, updated_at: 1.minute.ago)

--- a/spec/jobs/start_pending_scans_job_spec.rb
+++ b/spec/jobs/start_pending_scans_job_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe StartPendingScansJob, type: :job do
   end
 
   describe "#perform" do
+    it "mints an execution token when it claims a report" do
+      # The token is what lets the scanner process prove that the attempt it is
+      # writing for is still the attempt this pod claimed.
+      report = create(:report, target: target, scan: scan, status: :pending)
+
+      described_class.new.perform
+
+      expect(report.reload.execution_token).to be_present
+    end
+
     describe "available slots calculation" do
       before do
         allow(SettingsService).to receive(:parallel_scans_limit).and_return(5)

--- a/spec/services/reports/stop_spec.rb
+++ b/spec/services/reports/stop_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe Reports::Stop do
   let(:report) { create(:report, scan: scan, target: target, status: :running, heartbeat_at: Time.current) }
 
   describe "#call" do
+    it "revokes the execution token so the scanner process cannot keep writing" do
+      report.update!(execution_token: SecureRandom.uuid)
+
+      described_class.new(report).call
+
+      expect(report.reload.execution_token).to be_nil
+    end
+
     it "changes report status to stopped" do
       described_class.new(report).call
       expect(report.reload.status).to eq("stopped")

--- a/spec/services/run_command_spec.rb
+++ b/spec/services/run_command_spec.rb
@@ -63,6 +63,36 @@ RSpec.describe RunCommand do
   end
 
   describe '#call_async' do
+    it 'prepares the log file before spawning, so a setup failure orphans nothing' do
+      # Anything fallible between popen3 and the pipe-drain threads can leave a live
+      # child whose stdout nobody reads: garak fills the 64K pipe buffer and blocks
+      # forever while its heartbeat thread keeps reporting the scan healthy.
+      allow(FileUtils).to receive(:mkdir_p).and_raise(Errno::EACCES)
+      expect(Open3).not_to receive(:popen3)
+
+      expect {
+        described_class.new([ 'echo', 'hi' ]).call_async(log_file: '/nope/async.log')
+      }.to raise_error(Errno::EACCES)
+    end
+
+    it 'reports the spawn before anything that can fail with a live child' do
+      # Callers use on_spawn to decide whether a failure left a process running, so it
+      # must fire the moment popen3 returns: closing stdin can itself raise with the
+      # child already alive, and that is not a launch failure.
+      spawned = false
+      stdin = instance_double(IO)
+      allow(stdin).to receive(:close).and_raise(Errno::EPIPE)
+      stdout = instance_double(IO, each_line: nil)
+      stderr = instance_double(IO, each_line: nil)
+      wait_thr = double("wait_thr", status: "sleep", pid: 4242)
+      allow(Open3).to receive(:popen3).and_return([ stdin, stdout, stderr, wait_thr ])
+
+      described_class.new([ 'echo', 'spawn boundary' ])
+        .call_async(on_spawn: -> { spawned = true })
+
+      expect(spawned).to be true
+    end
+
     it 'returns a process object' do
       command_service = RunCommand.new([ "echo", "async test" ])
       result = command_service.call_async

--- a/spec/services/run_garak_scan_spec.rb
+++ b/spec/services/run_garak_scan_spec.rb
@@ -18,14 +18,109 @@ RSpec.describe RunGarakScan, type: :service do
       allow(FileUtils).to receive(:mkdir_p)
     end
 
+    it 'mints an execution token when it is the one moving the report into starting' do
+      # The normal path claims the token in StartPendingScansJob and arrives already
+      # starting. A caller arriving in any other status would otherwise launch a
+      # process that cannot prove ownership, and the process refuses to run.
+      report.update!(status: :pending, execution_token: nil)
+      service = described_class.new(report)
+      allow(service).to receive(:call).and_call_original
+      allow(service).to receive(:execute_scan)
+
+      service.call
+
+      report.reload
+      expect(report.status).to eq("starting")
+      expect(report.execution_token).to be_present
+    end
+
+    it 'does not launch a second process when another pod claimed the report first' do
+      # GenerateVariantReportsJob and MockTargetSetupService create a pending report
+      # and call this service directly, so StartPendingScansJob can claim the very
+      # same row in between. A read-then-write mint would overwrite that attempt's
+      # token and start a second garak process for one report.
+      report.update!(status: :pending, execution_token: nil)
+      service = described_class.new(report)
+      allow(service).to receive(:call).and_call_original
+
+      other_pod_token = SecureRandom.uuid
+      Report.where(id: report.id).update_all(status: :starting, execution_token: other_pod_token)
+
+      expect(service).not_to receive(:execute_scan)
+
+      service.call
+
+      expect(report.reload.execution_token).to eq(other_pod_token)
+    end
+
+    it 'keeps the execution token when the failure happens after the process is spawned' do
+      # call_async reports the spawn through on_spawn; an error after that can arrive
+      # with garak already running, and revoking then would make the live process fail
+      # its own running-claim and exit.
+      report.update!(status: :starting, execution_token: SecureRandom.uuid)
+      token = report.execution_token
+      service = described_class.new(report)
+      allow(service).to receive(:call).and_call_original
+      # Stubbed so the spec does not depend on storage/config existing: build_argv
+      # writes a probes YAML there, and this block stubs FileUtils.mkdir_p away.
+      allow(service).to receive(:build_argv).and_return([ "python3", "script/run_garak.py", report.uuid ])
+      run_command = double("RunCommand")
+      allow(run_command).to receive(:call_async) do |on_spawn:, **|
+        on_spawn.call
+        raise Errno::ENOSPC, "log file"
+      end
+      allow(RunCommand).to receive(:new).and_return(run_command)
+
+      expect { service.call }.to raise_error(Errno::ENOSPC)
+
+      expect(report.reload.execution_token).to eq(token)
+    end
+
+    it 'releases the execution token when the failure happens before anything is spawned' do
+      # Nothing is running, so releasing lets a retry claim it immediately instead of
+      # waiting out the stuck-starting reaper.
+      report.update!(status: :starting, execution_token: SecureRandom.uuid)
+      service = described_class.new(report)
+      allow(service).to receive(:call).and_call_original
+      # Stubbed so the spec does not depend on storage/config existing: build_argv
+      # writes a probes YAML there, and this block stubs FileUtils.mkdir_p away.
+      allow(service).to receive(:build_argv).and_return([ "python3", "script/run_garak.py", report.uuid ])
+      allow(service).to receive(:build_env).and_raise(StandardError, "decryption failed")
+
+      expect { service.call }.to raise_error(StandardError, "decryption failed")
+
+      expect(report.reload.execution_token).to be_nil
+    end
+
+    it 'revokes the execution token when the process fails to start' do
+      report.update!(execution_token: SecureRandom.uuid)
+      service = described_class.new(report)
+      allow(service).to receive(:call).and_call_original
+      # Stubbed so the spec does not depend on storage/config existing: build_argv
+      # writes a probes YAML there, and this block stubs FileUtils.mkdir_p away.
+      allow(service).to receive(:build_argv).and_return([ "python3", "script/run_garak.py", report.uuid ])
+      run_command = double("RunCommand")
+      allow(run_command).to receive(:call_async).and_raise(
+        RunCommand::ImmediateExitError.new(127, "/opt/venv/bin/python3 script/run_garak.py")
+      )
+      allow(RunCommand).to receive(:new).and_return(run_command)
+
+      service.call
+
+      report.reload
+      expect(report.status).to eq("failed")
+      expect(report.execution_token).to be_nil
+    end
+
     it 'updates the report status to starting' do
       service = described_class.new(report)
       allow(service).to receive(:call).and_call_original
       allow(service).to receive(:execute_scan)
 
-      expect(report).to receive(:update).with(status: :starting)
-
       service.call
+
+      expect(report.reload.status).to eq("starting")
+      expect(report.execution_token).to be_present
     end
 
     it 'calls execute_scan for valid targets' do
@@ -33,9 +128,10 @@ RSpec.describe RunGarakScan, type: :service do
       allow(service).to receive(:call).and_call_original
 
       expect(service).to receive(:execute_scan)
-      expect(report).to receive(:update).with(status: :starting)
-
       service.call
+
+      expect(report.reload.status).to eq("starting")
+      expect(report.execution_token).to be_present
     end
 
     it 'aborts and marks the report failed when the target URL fails the SSRF recheck' do
@@ -68,6 +164,7 @@ RSpec.describe RunGarakScan, type: :service do
       expect(Rails.logger).to receive(:error).with("Cannot run scan for report #{bad_report.id} - target #{bad_target.id} (#{bad_target.name}) has 'bad' status. Validation text: #{bad_target.validation_text}")
       expect(bad_report).to receive(:update).with(
         status: :failed,
+        execution_token: nil,
         logs: "Scan failed: Target '#{bad_target.name}' validation failed. #{bad_target.validation_text}",
         failure_code: "target_validation_failed",
         failure_message: "Target '#{bad_target.name}' validation failed. #{bad_target.validation_text}",
@@ -91,6 +188,7 @@ RSpec.describe RunGarakScan, type: :service do
       expect(Rails.logger).to receive(:error).with("Cannot run scan for report #{bad_report.id} - target #{bad_target.id} (#{bad_target.name}) has 'bad' status. Validation text: ")
       expect(bad_report).to receive(:update).with(
         status: :failed,
+        execution_token: nil,
         logs: "Scan failed: Target '#{bad_target.name}' validation failed.",
         failure_code: "target_validation_failed",
         failure_message: "Target '#{bad_target.name}' validation failed.",
@@ -109,9 +207,10 @@ RSpec.describe RunGarakScan, type: :service do
       allow(service).to receive(:call).and_call_original
       allow(service).to receive(:execute_scan)
 
-      expect(good_report).to receive(:update).with(status: :starting)
-
       service.call
+
+      expect(good_report.reload.status).to eq("starting")
+      expect(good_report.execution_token).to be_present
     end
 
     it 'uses the same generated log path for the runner env and command output' do
@@ -126,7 +225,7 @@ RSpec.describe RunGarakScan, type: :service do
         .and_return(Pathname.new("/tmp/first.log"), Pathname.new("/tmp/second.log"))
 
       run_command = double("RunCommand")
-      expect(run_command).to receive(:call_async).with(log_file: "/tmp/first.log")
+      expect(run_command).to receive(:call_async).with(hash_including(log_file: "/tmp/first.log"))
       expect(RunCommand).to receive(:new) do |received_argv, env:|
         expect(received_argv).to eq(argv)
         captured_env = env
@@ -150,7 +249,7 @@ RSpec.describe RunGarakScan, type: :service do
         .and_return(Pathname.new("/tmp/first.log"), Pathname.new("/tmp/second.log"))
 
       run_command = double("RunCommand")
-      expect(run_command).to receive(:call_async).with(log_file: "/tmp/first.log").and_raise(
+      expect(run_command).to receive(:call_async).with(hash_including(log_file: "/tmp/first.log")).and_raise(
         RunCommand::ImmediateExitError.new(127, "/opt/venv/bin/python3 script/run_garak.py")
       )
       expect(RunCommand).to receive(:new).and_return(run_command)
@@ -180,6 +279,7 @@ RSpec.describe RunGarakScan, type: :service do
       expect(Rails.logger).to receive(:warn).with("Cannot run scan for report #{validating_report.id} - target #{validating_target.id} (#{validating_target.name}) is in 'validating' status")
       expect(validating_report).to receive(:update).with(
         status: :failed,
+        execution_token: nil,
         logs: "Scan failed: Target '#{validating_target.name}' is still being validated. Please wait for validation to complete before running scans.",
         failure_code: "target_validation_failed",
         failure_message: "Target '#{validating_target.name}' is still being validated. Please wait for validation to complete before running scans.",
@@ -205,6 +305,7 @@ RSpec.describe RunGarakScan, type: :service do
       expect(Rails.logger).to receive(:error).with("Cannot run scan for report #{unexpected_report.id} - target #{unexpected_target.id} (#{unexpected_target.name}) has unexpected status: unknown_status")
       expect(unexpected_report).to receive(:update).with(
         status: :failed,
+        execution_token: nil,
         logs: "Scan failed: Target '#{unexpected_target.name}' is not ready for scanning (status: unknown_status). Target must be validated successfully before running scans.",
         failure_code: "target_validation_failed",
         failure_message: "Target '#{unexpected_target.name}' is not ready for scanning (status: unknown_status). Target must be validated successfully before running scans.",
@@ -260,6 +361,34 @@ RSpec.describe RunGarakScan, type: :service do
     end
 
     describe '#build_env' do
+      it 'passes the execution token to the scan process' do
+        # The Python side refuses to run without it, and every DB write it makes
+        # is fenced on it.
+        report.update!(execution_token: SecureRandom.uuid)
+        service = described_class.new(report)
+
+        ActsAsTenant.with_tenant(report.company) do
+          env = service.send(:build_env)
+
+          expect(env["SCAN_EXECUTION_TOKEN"]).to eq(report.execution_token)
+        end
+      end
+
+      it 'sets the execution token unconditionally so tenant env vars cannot supply one' do
+        # merged_env_vars comes from tenant-controlled EnvironmentVariable rows and
+        # there is no reserved-name blocklist. Setting the key only when present would
+        # let a row named SCAN_EXECUTION_TOKEN survive and defeat the Python guard.
+        report.update!(execution_token: nil)
+        service = described_class.new(report)
+
+        ActsAsTenant.with_tenant(report.company) do
+          env = service.send(:build_env)
+
+          expect(env).to have_key("SCAN_EXECUTION_TOKEN")
+          expect(env["SCAN_EXECUTION_TOKEN"]).to eq("")
+        end
+      end
+
       it 'returns a hash of environment variables' do
         service = described_class.new(report)
 
@@ -362,6 +491,53 @@ RSpec.describe RunGarakScan, type: :service do
       # Cleanup any created config files
       Dir.glob(described_class::CONFIG_PATH.join("#{webchat_report.uuid}*")).each do |f|
         File.delete(f) if File.exist?(f)
+      end
+    end
+
+    describe '#call launch-failure credential cleanup' do
+      before do
+        allow(service).to receive(:call).and_call_original
+        allow(service).to receive(:all_probes_completed?).and_return(false)
+        allow(MonitoringService).to receive(:active?).and_return(false)
+        allow(webchat_target).to receive(:scan_launch_url_safe?).and_return(true)
+        webchat_target.update_column(:status, Target.statuses[:good])
+      end
+
+      it 'removes the web config when the failure happens before anything is spawned' do
+        allow(service).to receive(:build_argv).and_return([ 'echo' ])
+        allow(service).to receive(:build_env).and_raise(StandardError, 'decryption failed')
+
+        path = described_class::CONFIG_PATH.join("#{webchat_report.uuid}_web.json")
+        File.write(path, '{}')
+        webchat_report.update!(status: :starting, execution_token: SecureRandom.uuid)
+
+        expect { service.call }.to raise_error(StandardError, 'decryption failed')
+
+        # Nothing was spawned, so nothing will ever read or delete this file.
+        expect(File.exist?(path)).to be false
+        expect(webchat_report.reload.execution_token).to be_nil
+      end
+
+      it 'keeps the web config when the failure happens after the process is spawned' do
+        allow(service).to receive(:build_argv).and_return([ 'echo' ])
+        run_command = double("RunCommand")
+        allow(run_command).to receive(:call_async) do |on_spawn:, **|
+          on_spawn.call
+          raise StandardError, 'log file'
+        end
+        allow(RunCommand).to receive(:new).and_return(run_command)
+
+        path = described_class::CONFIG_PATH.join("#{webchat_report.uuid}_web.json")
+        File.write(path, '{}')
+        webchat_report.update!(status: :starting, execution_token: SecureRandom.uuid)
+        token = webchat_report.execution_token
+
+        expect { service.call }.to raise_error(StandardError, 'log file')
+
+        # call_async spawns before it opens the log file, so garak may be running and
+        # may not have read its --generator_option_file yet.
+        expect(File.exist?(path)).to be true
+        expect(webchat_report.reload.execution_token).to eq(token)
       end
     end
 
@@ -486,6 +662,8 @@ RSpec.describe RunGarakScan, type: :service do
         File.write(path, '{}')
 
         expect { service.call }.to raise_error(StandardError, 'launch failed')
+        # The stub raises without ever signalling a spawn through on_spawn, so no child
+        # exists: nothing will consume or delete the credential file, and cleanup runs.
         expect(File.exist?(path)).to be false
       end
 


### PR DESCRIPTION
## Context

A PID is local to a container. When a worker pod is drained and replaced, the replacement can be handed the same PID, so a PID match cannot prove that the process writing is the one started for the current attempt — stale cleanup from the old pod could clear ownership belonging to the replacement and trigger an extra retry.

## Changes

Rails mints a nullable UUID `execution_token` when it claims a scan, passes it to the scanner process, and revokes it on every transition out of a live attempt. Every write the scanner makes is fenced on that token.

Revoked is not the same as superseded, and the two fences differ accordingly. Rails revokes whenever an attempt ends — including while the process is still running (a stop, or the stale reaper firing on a lapsed heartbeat):

- Writes that **claim** the report (the running-status claim, heartbeats) require an exact match, so a revoked process fails its claim and terminates itself.
- Writes that **release or flush** (clearing this process's own PID, the journal sync, the completion handoff) accept a matching *or absent* token, and are refused only by a different one. Otherwise a stopped report keeps a PID pointing at a dead process, the final journal flush on SIGTERM is dropped, and a scan that finishes after a false stale-report positive cannot hand off at all.
- A revoked token is honoured only while the report is still in flight or queued for retry. A stopped or failed report has had its `raw_report_data` deliberately deleted, and writing again would resurrect exactly what the user cancelled.

Launch failures release the attempt only when nothing was spawned. `RunCommand#call_async` now reports the spawn through an `on_spawn:` callback fired the moment `popen3` returns, so a failure that leaves a live child neither revokes its token nor deletes the credential config it may not have read yet. The log file is opened before the spawn so that nothing fallible sits between the spawn and the pipe-drain threads, where a failure would leave a child blocked on a full pipe buffer.

A non-validation run refuses to start without a token rather than producing results that would be rejected.

## Verification

- RSpec: 2731 examples, 0 failures
- Python: 86 tests, 0 failures (17 skipped — the playwright-guarded ones)
- RuboCop: 484 files, clean
- Brakeman: 0 warnings, 0 errors
- Migration: primary down/up, plus a nullable UUID type assertion

## Known gap

Two attempts for one report still share `<uuid>.report.jsonl` and the scan log, so a superseded process's file writes are not fenced. That path predates this change; per-attempt paths would have to move through garak's report prefix, the resume logic that reads it back, and cleanup.