### PR TITLE
fix(scanner): fence stale attempt cleanup against concurrent stops

### DIFF
--- a/app/jobs/generate_variant_reports_job.rb
+++ b/app/jobs/generate_variant_reports_job.rb
@@ -59,9 +59,24 @@ class GenerateVariantReportsJob < ApplicationJob
   rescue ActiveRecord::RecordNotUnique
     Rails.logger.info("Variant report already exists for parent #{parent_report.id}, skipping")
   rescue StandardError => e
-    child_report&.update(status: :failed, execution_token: nil) if child_report&.persisted?
+    record_variant_generation_failure(child_report) if child_report&.persisted?
     Rails.logger.error("Failed to create combined variant report: #{e.message}")
     Rails.logger.error(e.backtrace.join("\n"))
     raise
+  end
+
+  # A user's stop, or a replacement attempt, can land between the launch failing and
+  # this write. An unconditional update would turn a stopped report into a failed one,
+  # losing the fact that it was cancelled.
+  def record_variant_generation_failure(child_report)
+    child_report.with_lock do
+      next if child_report.completed? || child_report.failed? || child_report.stopped?
+
+      child_report.update(status: :failed, execution_token: nil)
+    end
+  rescue StandardError => e
+    Rails.logger.warn(
+      "[GenerateVariantReports] could not record failure for report #{child_report.id}: #{e.message}"
+    )
   end
 end

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -14,6 +14,9 @@ class RunGarakScan
 
   def initialize(report)
     @report = report
+    # Remember which attempt this instance is, independently of the row, which any
+    # other pod may change under us.
+    @execution_token = report.execution_token
   end
 
   def call
@@ -61,7 +64,11 @@ class RunGarakScan
     # and the file would be orphaned. Once call_async has been entered the process may
     # be alive and may not have read its --generator_option_file yet, so deleting it
     # would race a live scan; that process removes the file on its own exit paths.
-    remove_web_config_file unless @scan_process_may_be_running
+    unless @scan_process_may_be_running
+      # A replacement attempt owns the UUID-keyed credential file in that case.
+      @execution_attempt_replaced = execution_attempt_replaced? if @execution_attempt_replaced.nil?
+      remove_web_config_file unless @execution_attempt_replaced
+    end
     raise
   end
 
@@ -95,6 +102,7 @@ class RunGarakScan
       # to be current here, which is outside the with_tenant block below.
       report.assign_attributes(status: :starting, execution_token: token)
       report.changes_applied
+      @execution_token = token
     else
       Rails.logger.info(
         "[RunGarakScan] report #{report.id} was claimed by another process; " \
@@ -113,12 +121,61 @@ class RunGarakScan
   # update_columns: the report may be mid-failure elsewhere, and this must not fire
   # callbacks or fail on validation. Losing the revoke is not fatal -- the stale
   # reaper clears it -- so failure is logged rather than raised over the original error.
+  # Returns false when a DIFFERENT attempt owns the report -- this process must then
+  # touch neither the row nor the credential file -- true when the attempt was ours
+  # (or the row is gone), and nil when ownership could not be determined.
   def revoke_execution_token_after_launch_failure
-    report.update_columns(execution_token: nil)
+    Report.unscoped.transaction do
+      current_report = Report.unscoped.lock.find_by(id: report.id, company_id: report.company_id)
+      next true unless current_report
+      next false if current_report.execution_token.present? && current_report.execution_token != @execution_token
+
+      current_report.update_columns(execution_token: nil) if current_report.execution_token == @execution_token
+      true
+    end
   rescue StandardError => e
     Rails.logger.warn(
       "[RunGarakScan] failed to revoke execution token for #{report.uuid}: #{e.class}: #{e.message}"
     )
+    nil
+  end
+
+  def execution_attempt_replaced?
+    current_token = Report.unscoped.where(id: report.id, company_id: report.company_id).pick(:execution_token)
+    current_token.present? && current_token != @execution_token
+  rescue StandardError => e
+    Rails.logger.warn(
+      "[RunGarakScan] failed to check execution ownership for #{report.uuid}: #{e.class}: #{e.message}"
+    )
+    nil
+  end
+
+  # Records a launch failure only while this attempt still owns the report. A user's
+  # stop, or a replacement attempt, can land between the process exiting and this
+  # write; an unconditional update would turn a stopped report into a failed one.
+  # Returns false when a different attempt has taken over.
+  def record_launch_failure(message)
+    Report.unscoped.transaction do
+      current_report = Report.unscoped.lock.find_by(id: report.id, company_id: report.company_id)
+      next true unless current_report
+      next false if current_report.execution_token.present? && current_report.execution_token != @execution_token
+      next true unless current_report.starting?
+
+      # Write through the instance we already hold, whose associations are loaded, and
+      # skip validation: this records a terminal failure state, touches nothing a
+      # validation guards, and must not be silently dropped -- `update` returning false
+      # would leave the report stuck in `starting` until the reaper timed it out.
+      report.assign_attributes(status: :failed, execution_token: nil, logs: message)
+      unless report.save(validate: false)
+        Rails.logger.warn("[RunGarakScan] could not record launch failure for #{report.uuid}")
+      end
+      true
+    end
+  rescue StandardError => e
+    Rails.logger.warn(
+      "[RunGarakScan] failed to record launch failure for #{report.uuid}: #{e.class}: #{e.message}"
+    )
+    true
   end
 
   # Deletes the per-scan web config file written by temp_web_config_file_path.
@@ -144,16 +201,20 @@ class RunGarakScan
         on_spawn: -> { @scan_process_may_be_running = true }
       )
     rescue RunCommand::ImmediateExitError => e
-      # The process exited immediately, so it is definitively dead: releasing the
-      # attempt and deleting its credential file are both safe.
-      remove_web_config_file
+      # RunCommand raises this only after wait_thr confirms the process terminated, so
+      # nothing is racing us for the process itself. The report row is another matter:
+      # a stop or a replacement attempt can land between the exit and this write.
+      @scan_process_may_be_running = false
       Rails.logger.error("Scan process failed to start for report #{report.uuid}: #{e.message}")
       stderr_tail = read_log_tail
       message = "Scan process failed to start (exit status #{e.exit_status})."
       message += " Output: #{stderr_tail}" if stderr_tail.present?
-      report.update(status: :failed, execution_token: nil, logs: message)
+      @execution_attempt_replaced = record_launch_failure(message) == false
+      remove_web_config_file unless @execution_attempt_replaced
     rescue StandardError
-      revoke_execution_token_after_launch_failure unless @scan_process_may_be_running
+      unless @scan_process_may_be_running
+        @execution_attempt_replaced = revoke_execution_token_after_launch_failure == false
+      end
       raise
     end
   end

--- a/script/db_notifier.py
+++ b/script/db_notifier.py
@@ -1285,6 +1285,38 @@ def notify_report_stopped(
         return None
 
 
+def execution_attempt_replaced(report_uuid: str, execution_token: str):
+    """Has a DIFFERENT attempt taken ownership of this report?
+
+    notify_report_stopped returning False is not evidence of this on its own: it also
+    returns False when the stored PID no longer matches, which happens routinely when
+    the recovery path clears the PID before the old process reaches its cleanup. Only
+    a different, non-null token means someone else owns the report -- and therefore
+    owns the UUID-keyed files that belong to it.
+
+    Returns True when another attempt owns it, False when this attempt does or nobody
+    does, and None when ownership could not be determined.
+    """
+    try:
+        with pooled_connection("primary") as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT execution_token FROM reports WHERE uuid = %s",
+                    (report_uuid,),
+                )
+                row = cur.fetchone()
+
+        if row is None:
+            return False
+
+        current_token = row[0]
+        return current_token is not None and str(current_token) != str(execution_token)
+
+    except Exception as e:
+        logger.error(f"Error checking execution ownership for {report_uuid}: {e}")
+        return None
+
+
 def _enqueue_process_report_job(report_id: int, queue_conn) -> int:
     """
     Enqueue ProcessReportJob in Solid Queue.

--- a/script/run_garak.py
+++ b/script/run_garak.py
@@ -101,9 +101,11 @@ def signal_handler(signum, frame):
     if current_heartbeat:
         current_heartbeat.stop()
     if current_report_uuid:
-        if current_execution_token:
-            notify_report_stopped(current_report_uuid, current_execution_token)
-        remove_web_config_file(current_report_uuid)
+        # An early SIGTERM (before the main try/finally is entered) would otherwise
+        # skip the finally cleanup, orphaning the credential-bearing <uuid>_web.json.
+        release_attempt_and_cleanup_web_config(
+            current_report_uuid, current_execution_token
+        )
     sys.exit(1)
 
 signal.signal(signal.SIGTERM, signal_handler)
@@ -204,6 +206,29 @@ def notify_report_stopped(report_uuid, execution_token):
         print(f"Error notifying report stopped: {e}", file=sys.stderr)
         return None
 
+def release_attempt_and_cleanup_web_config(report_uuid, execution_token):
+    """Release this attempt and remove its credential file unless superseded.
+
+    A definitive ownership mismatch means the UUID-keyed file belongs to a newer
+    attempt and must be left alone. Unknown ownership still deletes it, so
+    credentials are not left behind when the database is unavailable.
+    """
+    if not execution_token:
+        remove_web_config_file(report_uuid)
+        return None
+
+    released = notify_report_stopped(report_uuid, execution_token)
+    if released is False:
+        logger.warning(
+            f"Leaving credential config for {report_uuid} in place: another "
+            f"execution attempt owns this report and may be using it"
+        )
+        return False
+
+    remove_web_config_file(report_uuid)
+    return released
+
+
 def main():
     """Main function to parse arguments and run the Garak scan."""
     if len(sys.argv) < 2:
@@ -276,19 +301,7 @@ def main():
             # releases a PID that was recorded before the failing statement. It only
             # declines when a *different* attempt owns the report -- which is exactly
             # when <uuid>_web.json belongs to that attempt, so it is left in place.
-            released = notify_report_stopped(report_uuid, execution_token)
-            if released is False:
-                # Definitive mismatch: a different attempt owns the report, and
-                # <uuid>_web.json is keyed on the report uuid alone, so that file is
-                # the live attempt's. Anything else -- cleared, or undetermined
-                # because the database did not answer -- must delete it, since no
-                # other cleanup path runs after this exit.
-                logger.warning(
-                    f"Leaving credential config for {report_uuid} in place: another "
-                    f"execution attempt owns this report and may be using it"
-                )
-            else:
-                remove_web_config_file(report_uuid)
+            release_attempt_and_cleanup_web_config(report_uuid, execution_token)
             sys.exit(1)
 
         heartbeat = HeartbeatThread(report_uuid, execution_token=execution_token)

--- a/script/run_garak.py
+++ b/script/run_garak.py
@@ -40,6 +40,7 @@ from pathlib import Path
 
 from garak_plugin_cache_guard import install_plugin_cache_guard
 from db_notifier import (
+    execution_attempt_replaced as db_execution_attempt_replaced,
     notify_report_running as db_notify_running,
     notify_report_ready as db_notify_ready,
     notify_report_ready_from_synced as db_notify_ready_from_synced,
@@ -206,6 +207,16 @@ def notify_report_stopped(report_uuid, execution_token):
         print(f"Error notifying report stopped: {e}", file=sys.stderr)
         return None
 
+def execution_attempt_replaced(report_uuid, execution_token):
+    """True when a different attempt owns the report, False when it does not, None
+    when that could not be determined."""
+    try:
+        return db_execution_attempt_replaced(report_uuid, execution_token)
+    except Exception as e:
+        print(f"Error checking execution ownership: {e}", file=sys.stderr)
+        return None
+
+
 def release_attempt_and_cleanup_web_config(report_uuid, execution_token):
     """Release this attempt and remove its credential file unless superseded.
 
@@ -218,7 +229,11 @@ def release_attempt_and_cleanup_web_config(report_uuid, execution_token):
         return None
 
     released = notify_report_stopped(report_uuid, execution_token)
-    if released is False:
+
+    # Ask who owns the report rather than inferring it from the release result: that
+    # is also False on an ordinary PID mismatch, which the recovery path produces
+    # routinely, and nothing else would ever remove the file in that case.
+    if execution_attempt_replaced(report_uuid, execution_token) is True:
         logger.warning(
             f"Leaving credential config for {report_uuid} in place: another "
             f"execution attempt owns this report and may be using it"

--- a/script/tests/test_remove_web_config_file.py
+++ b/script/tests/test_remove_web_config_file.py
@@ -55,6 +55,21 @@ TOKEN = "11111111-2222-3333-4444-555555555555"
 
 
 class TestSignalHandlerCleanup(unittest.TestCase):
+    def test_keeps_the_web_config_when_another_attempt_owns_the_report(self):
+        # On SIGTERM a superseded process must not delete <uuid>_web.json: it is keyed
+        # on the report uuid alone, so it belongs to the attempt that replaced us.
+        with patch.object(run_garak, "_main_pid", os.getpid()), \
+             patch.object(run_garak, "current_report_uuid", "uuid-xyz"), \
+             patch.object(run_garak, "current_execution_token", TOKEN), \
+             patch.object(run_garak, "current_journal_sync", None), \
+             patch.object(run_garak, "current_heartbeat", None), \
+             patch.object(run_garak, "notify_report_stopped", return_value=False), \
+             patch.object(run_garak, "remove_web_config_file") as m_rm:
+            with self.assertRaises(SystemExit):
+                run_garak.signal_handler(15, None)
+
+        m_rm.assert_not_called()
+
     def test_main_process_removes_web_config_on_signal(self):
         # An early SIGTERM (before the main try/finally) must still delete the
         # credential file from the parent signal handler.

--- a/script/tests/test_remove_web_config_file.py
+++ b/script/tests/test_remove_web_config_file.py
@@ -64,6 +64,7 @@ class TestSignalHandlerCleanup(unittest.TestCase):
              patch.object(run_garak, "current_journal_sync", None), \
              patch.object(run_garak, "current_heartbeat", None), \
              patch.object(run_garak, "notify_report_stopped", return_value=False), \
+             patch.object(run_garak, "execution_attempt_replaced", return_value=True), \
              patch.object(run_garak, "remove_web_config_file") as m_rm:
             with self.assertRaises(SystemExit):
                 run_garak.signal_handler(15, None)

--- a/script/tests/test_run_garak_log_path.py
+++ b/script/tests/test_run_garak_log_path.py
@@ -16,6 +16,7 @@ _mock_db.notify_report_running = MagicMock(return_value=True)
 _mock_db.notify_report_ready = MagicMock(return_value=True)
 _mock_db.notify_report_ready_from_synced = MagicMock(return_value=True)
 _mock_db.notify_report_stopped = MagicMock(return_value=True)
+_mock_db.execution_attempt_replaced = MagicMock(return_value=False)
 _mock_db.load_existing_jsonl_prefix = MagicMock(return_value="")
 _mock_db.get_log_file_path = MagicMock(return_value=Path("/tmp/fake_reports/report.log"))
 _mock_db.HeartbeatThread = MagicMock

--- a/script/tests/test_run_garak_plugin_cache_guard.py
+++ b/script/tests/test_run_garak_plugin_cache_guard.py
@@ -14,6 +14,7 @@ _mock_db.notify_report_running = MagicMock(return_value=True)
 _mock_db.notify_report_ready = MagicMock(return_value=True)
 _mock_db.notify_report_ready_from_synced = MagicMock(return_value=True)
 _mock_db.notify_report_stopped = MagicMock(return_value=True)
+_mock_db.execution_attempt_replaced = MagicMock(return_value=False)
 _mock_db.load_existing_jsonl_prefix = MagicMock(return_value="")
 _mock_db.get_log_file_path = MagicMock(return_value=Path("/tmp/fake_reports/report.log"))
 _mock_db.HeartbeatThread = MagicMock

--- a/script/tests/test_run_garak_running_notification.py
+++ b/script/tests/test_run_garak_running_notification.py
@@ -63,7 +63,7 @@ TOKEN = "11111111-2222-3333-4444-555555555555"
 
 class TestRunningNotificationFailureIsFatal(unittest.TestCase):
     def _run_main(self, running_result, uuid="report-uuid-123", config_dir=None, token=TOKEN,
-                  stopped_result=True):
+                  stopped_result=True, replaced_result=False):
         # run_garak is imported once per process, so whichever test module imports it
         # first supplies these module-level constants. Pin them here (as Path, since
         # run_garak builds paths with `/`) so this test does not depend on that order.
@@ -79,6 +79,7 @@ class TestRunningNotificationFailureIsFatal(unittest.TestCase):
              patch.object(run_garak, "notify_report_ready", return_value=True), \
              patch.object(run_garak, "notify_report_ready_from_synced", return_value=True), \
              patch.object(run_garak, "notify_report_stopped", return_value=stopped_result) as mock_stopped, \
+             patch.object(run_garak, "execution_attempt_replaced", return_value=replaced_result), \
              patch.object(run_garak, "load_existing_jsonl_prefix", return_value=""), \
              patch.object(run_garak, "get_log_file_path", return_value=tmp / "report.log"), \
              patch.object(sys, "argv", ["run_garak.py", uuid]), \
@@ -139,7 +140,12 @@ class TestRunningNotificationFailureIsFatal(unittest.TestCase):
         web_config = config_dir / "report-uuid-123_web.json"
         web_config.write_text("{}")
 
-        self._run_main(running_result=False, config_dir=config_dir, stopped_result=False)
+        self._run_main(
+            running_result=False,
+            config_dir=config_dir,
+            stopped_result=False,
+            replaced_result=True,
+        )
 
         self.assertTrue(
             web_config.exists(),
@@ -156,6 +162,25 @@ class TestRunningNotificationFailureIsFatal(unittest.TestCase):
         web_config.write_text('{"cookies": [{"name": "session", "value": "secret"}]}')
 
         self._run_main(running_result=False, config_dir=config_dir, stopped_result=None)
+
+        self.assertFalse(web_config.exists(), "credential web config left on disk")
+
+    def test_removes_the_credential_config_when_only_the_pid_no_longer_matches(self):
+        # notify_report_stopped also returns False when the stored PID no longer
+        # matches -- RetryInterruptedReportsJob clears both the PID and the token
+        # before the old process reaches this cleanup. Nobody else owns the file then,
+        # and nothing else will ever remove it.
+        config_dir = Path(tempfile.mkdtemp()) / "config"
+        config_dir.mkdir(parents=True)
+        web_config = config_dir / "report-uuid-123_web.json"
+        web_config.write_text('{"cookies": [{"name": "session", "value": "secret"}]}')
+
+        self._run_main(
+            running_result=False,
+            config_dir=config_dir,
+            stopped_result=False,
+            replaced_result=False,
+        )
 
         self.assertFalse(web_config.exists(), "credential web config left on disk")
 

--- a/script/tests/test_run_garak_traceback.py
+++ b/script/tests/test_run_garak_traceback.py
@@ -21,6 +21,7 @@ _mock_db.notify_report_running = MagicMock(return_value=True)
 _mock_db.notify_report_ready = MagicMock(return_value=True)
 _mock_db.notify_report_ready_from_synced = MagicMock(return_value=True)
 _mock_db.notify_report_stopped = MagicMock(return_value=True)
+_mock_db.execution_attempt_replaced = MagicMock(return_value=False)
 _mock_db.load_existing_jsonl_prefix = MagicMock(return_value="")
 _mock_db.get_log_file_path = MagicMock(return_value=Path("/tmp/fake_reports/report.log"))
 _mock_db.HeartbeatThread = MagicMock

--- a/spec/jobs/generate_variant_reports_job_spec.rb
+++ b/spec/jobs/generate_variant_reports_job_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe GenerateVariantReportsJob, type: :job do
         expect(child.variant_probes).to include(probe)
       end
 
+      it "does not overwrite a concurrent stop when variant generation fails" do
+        # The child is stopped between the launch and the failure being recorded; an
+        # unconditional write would turn the user's cancellation into a failure.
+        allow_any_instance_of(RunGarakScan).to receive(:call) do |instance|
+          Report.where(id: instance.report.id)
+                .update_all(status: Report.statuses[:stopped], execution_token: nil)
+          raise StandardError, "launch blew up"
+        end
+
+        expect { described_class.new.perform(report.id) }.to raise_error(StandardError, "launch blew up")
+
+        child = Report.find_by(parent_report_id: report.id)
+        expect(child.reload.status).to eq("stopped")
+      end
+
       it "calls RunGarakScan on the child report" do
         expect_any_instance_of(RunGarakScan).to receive(:call)
 

--- a/spec/services/run_garak_scan_spec.rb
+++ b/spec/services/run_garak_scan_spec.rb
@@ -18,6 +18,46 @@ RSpec.describe RunGarakScan, type: :service do
       allow(FileUtils).to receive(:mkdir_p)
     end
 
+    it 'does not overwrite a concurrent stop when the process exits immediately' do
+      # The user can stop the scan between the launch failing and this handler
+      # running. An unconditional write would turn that stopped report into a failed
+      # one, losing the fact that the user cancelled it.
+      report.update!(status: :starting, execution_token: SecureRandom.uuid)
+      service = described_class.new(report)
+      allow(service).to receive(:call).and_call_original
+      allow(service).to receive(:build_argv).and_return([ "python3", "script/run_garak.py", report.uuid ])
+      run_command = double("RunCommand")
+      allow(run_command).to receive(:call_async) do |**|
+        Report.where(id: report.id).update_all(status: Report.statuses[:stopped], execution_token: nil)
+        raise RunCommand::ImmediateExitError.new(127, "python3")
+      end
+      allow(RunCommand).to receive(:new).and_return(run_command)
+
+      service.call
+
+      expect(report.reload.status).to eq("stopped")
+    end
+
+    it 'does not fail a report a replacement attempt has already claimed' do
+      report.update!(status: :starting, execution_token: SecureRandom.uuid)
+      service = described_class.new(report)
+      allow(service).to receive(:call).and_call_original
+      allow(service).to receive(:build_argv).and_return([ "python3", "script/run_garak.py", report.uuid ])
+      replacement_token = SecureRandom.uuid
+      run_command = double("RunCommand")
+      allow(run_command).to receive(:call_async) do |**|
+        Report.where(id: report.id).update_all(execution_token: replacement_token)
+        raise RunCommand::ImmediateExitError.new(127, "python3")
+      end
+      allow(RunCommand).to receive(:new).and_return(run_command)
+
+      service.call
+
+      report.reload
+      expect(report.status).to eq("starting")
+      expect(report.execution_token).to eq(replacement_token)
+    end
+
     it 'mints an execution token when it is the one moving the report into starting' do
       # The normal path claims the token in StartPendingScansJob and arrives already
       # starting. A caller arriving in any other status would otherwise launch a
@@ -496,6 +536,10 @@ RSpec.describe RunGarakScan, type: :service do
 
     describe '#call launch-failure credential cleanup' do
       before do
+        # Before the first `service` reference: RunGarakScan memoizes the report's
+        # execution token at construction, and a token appearing afterwards is
+        # correctly read as a replacement attempt having claimed the report.
+        webchat_report.update!(status: :starting, execution_token: SecureRandom.uuid)
         allow(service).to receive(:call).and_call_original
         allow(service).to receive(:all_probes_completed?).and_return(false)
         allow(MonitoringService).to receive(:active?).and_return(false)
@@ -509,7 +553,6 @@ RSpec.describe RunGarakScan, type: :service do
 
         path = described_class::CONFIG_PATH.join("#{webchat_report.uuid}_web.json")
         File.write(path, '{}')
-        webchat_report.update!(status: :starting, execution_token: SecureRandom.uuid)
 
         expect { service.call }.to raise_error(StandardError, 'decryption failed')
 
@@ -529,7 +572,6 @@ RSpec.describe RunGarakScan, type: :service do
 
         path = described_class::CONFIG_PATH.join("#{webchat_report.uuid}_web.json")
         File.write(path, '{}')
-        webchat_report.update!(status: :starting, execution_token: SecureRandom.uuid)
         token = webchat_report.execution_token
 
         expect { service.call }.to raise_error(StandardError, 'log file')


### PR DESCRIPTION
## Context

Follow-up to #138. Every path that recorded a launch failure wrote unconditionally, so a user's stop — or a replacement attempt claiming the report — landing between the failure and the write was clobbered: a stopped report silently became a failed one.

## Changes

- `RunGarakScan` remembers which attempt it is at construction (and when it claims one), independently of a row any other pod may change underneath it.
- The immediate-exit handler and the variant job's failure recorder take a row lock and apply the failure only while this attempt still owns the report. Revoking the token does the same, and reports whether a different attempt has taken over.
- Credential-file removal is gated on that ownership check. `<uuid>_web.json` is keyed on the report uuid alone, so once a replacement has claimed the report the file belongs to the replacement.
- The terminal failure write skips validation: it touches nothing a validation guards, and a silently dropped update would leave the report stuck in `starting` until the reaper timed it out.
- Releasing the attempt and cleaning up the credential file is one helper shared by the abort path and the signal handler. The signal handler previously deleted the file unconditionally, so a superseded process being terminated removed the credentials of the attempt that replaced it.

## Verification

- RSpec: 2734 examples, 0 failures
- Python: 87 tests, 0 failures (17 skipped — the playwright-guarded ones)
- RuboCop: 484 files, clean
- Brakeman: 0 warnings, 0 errors