### PR TITLE
ci(release): pass the dry-run flag through the environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,16 @@ jobs:
         id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release${{ inputs.dry_run && ' --dry-run' || '' }}
+          # Passed through the environment rather than interpolated into the script:
+          # `${{ }}` inside a `run:` is the shape of a shell-injection bug even when,
+          # as here, the expression can only ever yield a constant.
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            npx semantic-release --dry-run
+          else
+            npx semantic-release
+          fi
 
   build-amd64:
     needs: release


### PR DESCRIPTION
Interpolating `${{ }}` into a `run:` script is the shape of a shell-injection bug, so the dry-run flag now travels in an env var and the script branches on it, quoted.

The previous form was not exploitable — `inputs.dry_run` is declared `type: boolean` and the ternary yielded one of two constant literals, so no user-controlled text could reach the shell — but scanners flag the pattern rather than its reachability, and the pattern is worth not having.

Behaviour is unchanged for both triggers: a `push` run has no `inputs`, so `DRY_RUN` is empty and the normal release path runs, exactly as the old empty-string branch did.

Verified the workflow still parses, the step's env is `[DRY_RUN, GITHUB_TOKEN]`, and no `run:` step in the release job interpolates `${{ }}` any more.