### PR TITLE
feat(reports): separate result completeness from execution lifecycle

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     coderay (1.1.3)

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -3,6 +3,35 @@
 module AdminHelper
   # Status tag helper for admin views
   # Usage: status_tag("Active", :ok) or status_tag("Pending")
+  # Whether there is anything to open: a finished scan, or a run that stopped early
+  # but retained usable evidence. Gating the Details and PDF links on completed?
+  # alone hides exactly the partial reports the new notice exists to explain.
+  def report_has_viewable_results?(report)
+    return true if report.completed?
+
+    # Read once: each predicate re-derives completeness for an unclassified row, and
+    # every derivation queries probe_results. This runs on every row of the index.
+    completeness = report.result_completeness
+    return true if completeness == "partial" || completeness == "complete"
+
+    # Completeness is left unresolved when there is no plan to compare the results
+    # against. They are real either way, so they stay reachable.
+    completeness.nil? && report.probe_results.exists?
+  end
+
+  # Renders the report's lifecycle and, when it applies, its result completeness.
+  # They are shown as two tags because they answer different questions: how the run
+  # ended, and whether what it left behind is usable evidence.
+  def report_lifecycle_tags(report)
+    tags = [ status_tag(report.status) ]
+
+    if report.partial_results?
+      tags << status_tag("partial results", :warning)
+    end
+
+    safe_join(tags, " ")
+  end
+
   def status_tag(text, status = nil)
     # Map status to CSS classes
     status_classes = case status

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -62,6 +62,40 @@ class Report < ApplicationRecord
     interrupted: 7
   }
 
+  # Result completeness is independent of the execution lifecycle above. A scan can
+  # fail or be stopped and still leave usable partial evidence; presenting that the
+  # same way as a finished scan is what this separation exists to prevent.
+  #
+  # Prefixed so the predicates read as completeness rather than status
+  # (`complete_results?`, not `complete?`).
+  enum :result_completeness, {
+    complete: "complete",
+    partial: "partial",
+    none: "none"
+  }, suffix: :results
+
+  # The stored value is authoritative, but it is not always present: a report can reach
+  # a terminal state without passing through Reports::Process (an unsafe target, a
+  # launch failure, a stop, the stale reaper), and during a rolling deploy an
+  # old-version worker finishes in-flight reports without writing the column. Reading
+  # those as "not partial" would silently present partial evidence as final, so the
+  # predicates fall back to deriving it. Same rule as the backfill, one definition.
+  def result_completeness
+    super.presence || derived_result_completeness
+  end
+
+  def complete_results?
+    result_completeness == "complete"
+  end
+
+  def partial_results?
+    result_completeness == "partial"
+  end
+
+  def none_results?
+    result_completeness == "none"
+  end
+
   # Status constants
   # - processing/starting are internal transition states, not shown to users
   # - interrupted is visible so users can monitor auto-retry behavior
@@ -71,6 +105,81 @@ class Report < ApplicationRecord
   DEBUG_STREAM_LIVE_TAIL_STATUSES = %w[running processing].freeze
   DEBUG_STREAM_POLLING_STATUSES = (DEBUG_BROADCAST_ACTIVE_STATUSES + %w[pending]).freeze
   UNKNOWN_TARGET_NAME = "Unknown target".freeze
+
+  # Failure codes the classifier assigns from log evidence. It can apply them to a run
+  # that produced every attempt, eval and completion row, so such a report has complete
+  # results despite a failed status. Nothing recorded afterwards distinguishes that from
+  # a genuine mid-run stop, so the backfill declines to guess and leaves them unset.
+  PROVIDER_CLASSIFIED_FAILURE_CODES = %w[
+    provider_model_unavailable
+    provider_payment_required
+    provider_auth_failed
+    provider_rejected_request
+    provider_rate_limited
+    provider_service_unavailable
+  ].freeze
+
+  # Codes that assert incompleteness in their own right: the classifier saw a run end
+  # without finishing. What went missing there may be a completion row or usable
+  # timing rather than a probe result, so a full probe count cannot overturn it.
+  # legacy_stale_processing is no longer written, but historical rows carry it.
+  INCOMPLETE_ASSERTING_FAILURE_CODES = %w[
+    scan_incomplete_results
+    legacy_stale_processing
+  ].freeze
+
+  # Statuses a report can no longer move on from. Anything else is still being worked
+  # on, and gets its completeness from the worker that finishes it -- classifying it
+  # here would stamp a value that worker never revisits, and during an upgrade that
+  # worker is still running the previous version.
+  TERMINAL_STATUSES_FOR_BACKFILL = %i[completed failed stopped].freeze
+
+  # Terminal states are reached from several places besides Reports::Process -- a stop,
+  # the stale reaper, a launch failure, a failed variant child -- and each of those would
+  # otherwise leave completeness unset forever. Recording it as the status changes means a
+  # terminal report always carries the value, so every reader can simply check the column.
+  # The ASR aggregate depends on that: it is one SQL round trip over many rows and cannot
+  # call this model per row, so an unset column there would mean restating this whole rule
+  # in SQL and keeping the two in step.
+  #
+  # Results are always persisted before the terminal transition (Reports::Process writes
+  # them in the same transaction; a stop or reaper acts on a run that already produced
+  # whatever it produced), so the evidence is complete by the time this reads it.
+  before_save :record_result_completeness_on_terminal_status
+
+  def record_result_completeness_on_terminal_status
+    return unless will_save_change_to_status?
+    # Reports::Process assigns the value from what it saw in the JSONL, which is richer
+    # evidence than anything derivable afterwards -- never overwrite it.
+    return if self[:result_completeness].present?
+    return unless TERMINAL_STATUSES_FOR_BACKFILL.any? { |terminal| status == terminal.to_s }
+
+    derived = compute_derived_result_completeness
+    self[:result_completeness] = derived if derived.present?
+  end
+
+  def self.backfill_result_completeness!(batch_size: 1000)
+    terminal = statuses.values_at(*TERMINAL_STATUSES_FOR_BACKFILL.map(&:to_s))
+
+    where(result_completeness: nil, status: terminal).in_batches(of: batch_size) do |batch|
+      batch.where(status: statuses[:completed]).update_all(result_completeness: "complete")
+
+      unfinished = batch.where.not(status: statuses[:completed])
+      counts = ProbeResult.where(report_id: unfinished.select(:id)).group(:report_id).count
+
+      # Rows holding nothing are settled in one statement; only those holding results
+      # need the plan compared against, and they are a small minority of terminal runs.
+      unfinished.where.not(id: counts.keys).update_all(result_completeness: "none") if counts.any?
+      next unfinished.update_all(result_completeness: "none") if counts.empty?
+
+      unfinished.where(id: counts.keys).includes(scan: :probes).find_each do |report|
+        completeness = report.completeness_from_evidence(counts[report.id].to_i)
+        # nil means the evidence does not settle it; left NULL so a later run with a
+        # recorded plan can classify it rather than freezing a guess.
+        report.update_columns(result_completeness: completeness) if completeness
+      end
+    end
+  end
 
   def self.ransackable_attributes(auth_object = nil)
     [ "company_id", "failure_code", "name", "created_at", "id", "status", "target_id", "updated_at", "uuid", "asr" ]
@@ -86,6 +195,117 @@ class Report < ApplicationRecord
 
   def historical_target_name
     historical_target&.name || UNKNOWN_TARGET_NAME
+  end
+
+  # Number of probes this run actually produced results for.
+  def processed_scope
+    probe_results.count
+  end
+
+  # Number of probes this run set out to execute, or nil when that is unknown.
+  # Returned separately from processed_scope so callers can show the processed count
+  # alone rather than assert a ratio they cannot support.
+  #
+  # Read from the plan recorded when the run was prepared, never from the scan's
+  # current probe list: that list is mutable (an edit, or AutoUpdateScanProbesJob
+  # adding probes afterwards), and a variant child executes mapped variants rather
+  # than the scan's own probes. Reports created before the column have no recorded
+  # plan, and no ratio is claimed for them.
+  def planned_scope
+    planned = planned_probe_count
+    return nil if planned.nil? || planned.zero?
+
+    planned
+  end
+
+  # The probe count this run will actually execute: mapped variants for a variant
+  # child, the scan's selected probes otherwise.
+  def planned_probe_count_for_run
+    return variant_count if is_variant_report?
+
+    scan&.probes&.count
+  end
+
+  # Best available evidence of the plan, used to judge completeness rather than to
+  # display a ratio. Falls back to the scan's current probe list for rows predating
+  # planned_probe_count: that list can have changed since the run, so it informs a
+  # classification we would otherwise have to guess at, but never a figure shown to
+  # the user -- planned_scope stays strict for that.
+  def evidenced_planned_scope
+    recorded = planned_probe_count
+    return recorded unless recorded.nil? || recorded.zero?
+
+    planned_probe_count_for_run
+  end
+
+  # The one rule both the live derivation and the backfill apply, so a report
+  # classified as it finishes and one classified afterwards cannot disagree.
+  #
+  # Counting results against the plan is what makes a failure code unnecessary here:
+  # a short result set is positive proof the run stopped early, and a full one proves
+  # it produced everything asked of it -- including the provider-classified failures
+  # that apply_terminal_provider_failure_metadata marks :failed on the strength of the
+  # logs after every row was written. Only when there is no plan to compare against
+  # does that ambiguity survive, and then nothing is claimed.
+  def completeness_from_evidence(processed)
+    return "none" if processed.zero?
+    return "partial" if INCOMPLETE_ASSERTING_FAILURE_CODES.include?(failure_code)
+
+    planned = evidenced_planned_scope
+    return processed < planned ? "partial" : "complete" if planned.present? && planned.positive?
+    return nil if PROVIDER_CLASSIFIED_FAILURE_CODES.include?(failure_code)
+
+    "partial"
+  end
+
+  # Completeness inferred from what the run left behind, for rows with no stored value.
+  # Memoized: the admin index calls several predicates per row, and each derivation
+  # queries probe_results.
+  def derived_result_completeness
+    return @derived_result_completeness if defined?(@derived_result_completeness)
+
+    @derived_result_completeness = compute_derived_result_completeness
+  end
+
+  def reload(*)
+    remove_instance_variable(:@derived_result_completeness) if defined?(@derived_result_completeness)
+    super
+  end
+
+  def compute_derived_result_completeness
+    # Only terminal reports have a completeness to infer. A run still in flight may
+    # yet produce results, and calling it "none" would be a claim we cannot make.
+    return nil unless TERMINAL_STATUSES_FOR_BACKFILL.any? { |terminal| status == terminal.to_s }
+
+    # A completed run is complete unless the plan recorded at launch says otherwise --
+    # the same judgement Reports::Process makes, so a row an old processor left unset
+    # cannot read differently from one written by the current code. Only the recorded
+    # plan counts here, never the scan's current list: historical completed rows have
+    # no recorded plan and must not be judged against a list that has grown since.
+    if completed?
+      planned = planned_probe_count.to_i
+      return "complete" unless planned.positive?
+
+      return processed_scope < planned ? "partial" : "complete"
+    end
+
+    completeness_from_evidence(processed_scope)
+  end
+
+  # Human-readable completed scope. Falls back to the processed count alone when the
+  # planned scope is unknown, rather than asserting a ratio we cannot support.
+  def processed_scope_summary
+    processed = processed_scope
+    planned = planned_scope
+    # A variant child executes mapped threat variants and records one result per
+    # variant, so calling those probes would misstate what was measured.
+    unit = is_variant_report? ? "variant" : "probe"
+    # A scan edited between attempts of a resumed run can leave the recorded plan below
+    # what was processed, and "7 of 5 probes" states something that cannot be true. The
+    # processed count is the fact we hold either way, so the ratio is simply dropped.
+    return "#{processed} of #{planned} #{unit.pluralize}" if planned && processed <= planned
+
+    "#{processed} #{unit.pluralize(processed)}"
   end
 
   def failed_with_reason?
@@ -232,6 +452,12 @@ class Report < ApplicationRecord
     scan.reports
         .parent_reports
         .completed
+        # A finished run that dropped eval rows is completed but partial. Comparing
+        # against it reports a movement that is an artefact of the missing work -- the
+        # very comparison the partial notice tells the reader not to make. Rows written
+        # before the column are complete by virtue of being completed, so NULL stays
+        # eligible; <> alone would discard them, being unknown for NULL.
+        .where("reports.result_completeness IS NULL OR reports.result_completeness <> 'partial'")
         .where(target_id: target_id)
         .where.not(id: id)
         .where("reports.created_at < ?", created_at)

--- a/app/services/reports/process.rb
+++ b/app/services/reports/process.rb
@@ -108,6 +108,27 @@ module Reports
       report.failure_details = {}
     end
 
+    # A finished run is complete unless something it measured is missing. Two ways that
+    # happens: an eval row garak produced that we could not record, or a probe from the
+    # plan that produced no eval at all -- we pass --skip_unknown, so a probe garak does
+    # not recognise is skipped silently and no row arrives to be dropped. ProbeResult is
+    # unique per probe, so a short count means a planned probe left nothing behind.
+    #
+    # The recorded plan judges the final state, which is what a resumed scan needs: its
+    # segments are concatenated, so an eval invalid in one segment is re-run and recorded
+    # in a later one. The dropped-row flag cannot see that recovery and would call a whole
+    # run partial, so it only speaks for runs launched without a plan.
+    #
+    # Judged against the plan recorded at launch and never the scan's current probe list:
+    # that list keeps growing afterwards, so a completed run would look short and be
+    # flagged wrongly.
+    def completed_run_completeness(evals_dropped)
+      planned = report.planned_probe_count.to_i
+      return ProbeResult.where(report_id: report.id).count < planned ? :partial : :complete if planned.positive?
+
+      evals_dropped ? :partial : :complete
+    end
+
     def process_jsonl_data(jsonl_string, mark_processing: true)
       report.update!(status: :processing) if mark_processing
 
@@ -116,6 +137,7 @@ module Reports
       valid_lines = 0
       attempts_processed = false
       evals_processed = false
+      evals_dropped = false
       completion_processed = false
 
       jsonl_string.each_line do |line|
@@ -147,7 +169,14 @@ module Reports
             process_attempt(data)
             attempts_processed = true
           when "eval"
-            evals_processed = true if process_eval(data)
+            # An eval garak evaluated but we could not record -- an invalid row, or a
+            # probe that no longer resolves. Either way that probe's numbers are gone
+            # for good, so the run finished without leaving the whole picture.
+            if process_eval(data)
+              evals_processed = true
+            else
+              evals_dropped = true
+            end
           when "completion"
             completion_processed = true if process_completion(data) == :processed
           else
@@ -172,23 +201,38 @@ module Reports
       # Having attempts/evals without completion means garak exited early after
       # producing partial data; keep those probe results for diagnosis, but do
       # not present the report as completed with an unknown duration.
+      #
+      # Each branch records result completeness alongside the status. The two are
+      # separate facts: the status says how the run ended, completeness says whether
+      # what it left behind is usable evidence. Only eval rows persist probe results,
+      # so a run that never reached them has nothing to show (`none`), while one that
+      # produced evals but never finished has real, partial evidence.
       if !attempts_processed
         Rails.logger.warn "Report #{report.id}: No attempts found in report, marking as failed"
         report.status = :failed
+        # process_eval persists a probe result on its own, so an eval row that arrived
+        # without its attempt still left usable evidence behind. Completeness follows
+        # what was actually recorded, not which row type was missing.
+        report.result_completeness = evals_processed ? :partial : :none
       elsif !evals_processed
         Rails.logger.warn "Report #{report.id}: Attempts found but no eval results - scan may have been interrupted, marking as failed"
         report.status = :failed
+        report.result_completeness = :none
       elsif !completion_processed
         Rails.logger.warn "Report #{report.id}: Attempts and eval results found but no completion row - scan exited before completion, marking as failed"
         report.status = :failed
+        report.result_completeness = :partial
       elsif report.start_time.blank? || report.end_time.blank?
         Rails.logger.warn "Report #{report.id}: Completion found but scan timing is incomplete, marking as failed"
         report.status = :failed
+        report.result_completeness = :partial
       elsif processed && valid_lines > 0
         report.status = :completed
+        report.result_completeness = completed_run_completeness(evals_dropped)
       else
         Rails.logger.warn "Report #{report.id}: No probe results created despite processing lines, marking as failed"
         report.status = :failed
+        report.result_completeness = :none
       end
 
       finalize_failed_report_timing

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -103,6 +103,7 @@ class RunGarakScan
       report.assign_attributes(status: :starting, execution_token: token)
       report.changes_applied
       @execution_token = token
+      record_planned_probe_count!
     else
       Rails.logger.info(
         "[RunGarakScan] report #{report.id} was claimed by another process; " \
@@ -124,6 +125,28 @@ class RunGarakScan
   # Returns false when a DIFFERENT attempt owns the report -- this process must then
   # touch neither the row nor the credential file -- true when the attempt was ours
   # (or the row is gone), and nil when ownership could not be determined.
+  # Capture what this run set out to execute, while it is still true. The scan's
+  # probe list can change afterwards (an edit, AutoUpdateScanProbesJob), so a count
+  # read later describes a plan this run never had.
+  #
+  # Raised but never lowered. AutoUpdateScanProbesJob can add probes between attempts
+  # and a resumed run executes them, while processed_scope counts results from every
+  # attempt -- a plan frozen at the first launch would render as "7 of 5 probes". A
+  # scan edited down must equally not shrink a plan this report already exceeded.
+  def record_planned_probe_count!
+    planned = report.planned_probe_count_for_run
+    return if planned.nil? || planned.zero?
+
+    recorded = report.planned_probe_count
+    return if recorded.present? && recorded >= planned
+
+    report.update_columns(planned_probe_count: planned)
+  rescue StandardError => e
+    Rails.logger.warn(
+      "[RunGarakScan] failed to record planned probe count for #{report.uuid}: #{e.class}: #{e.message}"
+    )
+  end
+
   def revoke_execution_token_after_launch_failure
     Report.unscoped.transaction do
       current_report = Report.unscoped.lock.find_by(id: report.id, company_id: report.company_id)

--- a/app/services/stats/average_asr_score.rb
+++ b/app/services/stats/average_asr_score.rb
@@ -3,6 +3,14 @@ module Stats
     DEFAULT_WINDOW = 30.days.freeze
 
     SQL_SUCCESS_RATE = "(SUM(probe_results.passed)::float / SUM(probe_results.total)::float * 100)".freeze
+
+    # Reports are classified as they reach a terminal state -- Reports::Process from the
+    # JSONL it read, and a Report before_save hook for every other terminal path -- so the
+    # aggregate only has to read the column. NULL means a run still in flight, which was
+    # always counted, or a row a previous version wrote mid-upgrade; the backfill
+    # migration classifies historical rows.
+    NOT_PARTIAL_SQL = "(reports.result_completeness IS NULL OR reports.result_completeness <> 'partial')".freeze
+
     TIME_GROUP_FORMATS = {
       "week" => "TO_CHAR(reports.created_at, 'IYYY-IW')",
       "month" => "TO_CHAR(reports.created_at, 'YYYY-MM')",
@@ -36,6 +44,7 @@ module Stats
           FROM reports
           INNER JOIN probe_results ON probe_results.report_id = reports.id
           WHERE probe_results.total > 0 AND reports.company_id = :company_id #{date_condition}
+            AND #{NOT_PARTIAL_SQL}
           GROUP BY reports.id
         ) subquery
       SQL
@@ -95,6 +104,7 @@ module Stats
       # by company_id explicitly (nil => no rows), mirroring the scalar average.
       query = Report.where(company_id: ActsAsTenant.current_tenant&.id)
                     .joins(:probe_results).where("probe_results.total > 0")
+                    .where(NOT_PARTIAL_SQL)
       since_date.present? ? query.where("reports.created_at >= ?", since_date) : query
     end
 

--- a/app/views/admin/reports/_report_header.html.erb
+++ b/app/views/admin/reports/_report_header.html.erb
@@ -2,7 +2,10 @@
   action_buttons = []
 
   # View Full Report (only for completed reports)
-  if report.completed?
+  # Offered whenever the run left usable evidence -- a finished scan, or one that
+  # stopped early but retained results. Gating on completed? alone made the partial
+  # report and its explanation unreachable.
+  if report_has_viewable_results?(report)
     action_buttons << {
       label: "View Report",
       path: report_detail_path(report),

--- a/app/views/admin/reports/_show_v2.html.erb
+++ b/app/views/admin/reports/_show_v2.html.erb
@@ -35,6 +35,13 @@
         <%= render partial: 'reports/failure_summary', locals: { report: report, admin: true } %>
       <% end %>
 
+      <% if report.partial_results? %>
+        <%#- Admin opens reports through this view, so it needs the same explanation:
+            otherwise a partial report with no failure metadata reads as an ordinary
+            failed one. -%>
+        <%= render partial: 'reports/partial_results_notice', locals: { report: report } %>
+      <% end %>
+
       <%= render partial: 'admin/reports/statistics_section', locals: { report: report } %>
 
       <% if show_activity_stream_for_report?(report, params: params, user: current_user) %>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -98,7 +98,7 @@
       label: "Status",
       type: :custom,
       sortable: true,
-      render: ->(report) { status_tag(report.status) }
+      render: ->(report) { report_lifecycle_tags(report) }
     },
     {
       key: :asr,
@@ -159,7 +159,9 @@
           end
         end
 
-        if report.completed?
+        # Usable evidence, not just a finished scan: a partial report's notice and
+        # metrics are only reachable if this link is offered.
+        if report_has_viewable_results?(report)
           links << link_to(report_detail_path(report), target: "_blank", class: "inline-flex items-center gap-1 text-xs text-actionButton hover:text-textMuted transition-colors cursor-pointer") do
             safe_join([content_tag(:span, "", class: "icon icon-sm icon-external-link"), "Details"])
           end

--- a/app/views/report_details/_narrative_band.html.erb
+++ b/app/views/report_details/_narrative_band.html.erb
@@ -5,7 +5,10 @@
 <% asr = report.attack_success_rate %>
 <% has_scores = report.detector_results.exists? %>
 <% grade = report_risk_grade_label(asr) %>
-<% delta = report.asr_delta_vs_previous %>
+<%# No delta for a partial report: its rate covers only the work that was recorded,
+    so comparing it with a completed scan reports a movement that is an artefact of
+    the scan stopping early. %>
+<% delta = report.partial_results? ? nil : report.asr_delta_vs_previous %>
 <% findings = report.top_findings %>
 <% if has_scores %>
   <div data-narrative-band class="<%= pdf_mode ? 'px-6 py-5 bg-white border-b border-gray-200' : 'px-8 py-6 bg-gradient-to-r from-indigo-50 via-white to-white border-b border-gray-200' %>">
@@ -21,6 +24,15 @@
         <span class="<%= pdf_mode ? 'text-xl font-bold text-gray-900' : 'text-2xl font-bold text-gray-900' %>"><%= asr.round %>%</span>
         <span class="text-xs text-gray-500">attack success rate</span>
       </span>
+      <% if report.partial_results? %>
+        <%# The rate is computed from recorded work only; say so next to the number itself.
+            A completed run can be partial too (results it measured but could not record),
+            so the reason is phrased to fit both rather than asserting it stopped early. %>
+        <span class="inline-flex items-center px-2.5 py-1 rounded-lg text-xs font-semibold bg-amber-100 text-amber-900"
+              title="Calculated from <%= report.processed_scope_summary %> — this scan's results are incomplete">
+          partial — <%= report.processed_scope_summary %>
+        </span>
+      <% end %>
       <% unless delta.nil? %>
         <% pts = delta.round %>
         <% worse = pts.positive? %>

--- a/app/views/report_details/show.html.erb
+++ b/app/views/report_details/show.html.erb
@@ -76,6 +76,10 @@
     <%= render partial: 'reports/failure_summary', locals: { report: @report, pdf_mode: pdf_mode } %>
   <% end %>
 
+  <% if @report.partial_results? %>
+    <%= render partial: "reports/partial_results_notice", locals: { report: @report, pdf_mode: pdf_mode } %>
+  <% end %>
+
   <%= render partial: 'report_details/narrative_band', locals: { report: @report, pdf_mode: pdf_mode } %>
 
   <% if @report.detector_results.exists? %>

--- a/app/views/reports/_partial_results_notice.html.erb
+++ b/app/views/reports/_partial_results_notice.html.erb
@@ -1,0 +1,38 @@
+<%#
+  Shown when a scan ended early but left usable evidence.
+
+  Deliberately NOT gated on failure_code: most partial reports never recorded one,
+  so gating on `failed_with_reason?` would leave them silently indistinguishable
+  from a finished scan. locals: report, pdf_mode (boolean)
+%>
+<%
+  pdf_mode = local_assigns.fetch(:pdf_mode, false)
+  container_class = pdf_mode ? "px-6 py-5 bg-amber-50 border-b border-amber-200" : "px-8 py-6 bg-amber-50 border-b border-amber-200"
+
+  # Worded to hold for every way a report becomes partial, rather than asserting when
+  # the run ended: it may have stopped early, finished but lost eval rows, finished
+  # without usable timing, or had a probe skipped. Status alone cannot tell those apart,
+  # and the specific cause is already shown in the Reason line below when one is known.
+  heading = "Partial results — some of this scan's work was not recorded"
+  lead = "This report covers only part of what the scan set out to measure."
+%>
+
+<div class="<%= container_class %>" role="status" data-partial-results-notice>
+  <div class="flex gap-3">
+    <span class="icon icon-md icon-warning shrink-0 text-amber-600"></span>
+    <div class="min-w-0">
+      <h2 class="text-base font-semibold text-amber-900"><%= heading %></h2>
+      <p class="mt-1 text-sm leading-6 text-amber-800">
+        <%= lead %> The findings below are real, but they cover only what was recorded:
+        <strong><%= report.processed_scope_summary %></strong>.
+        Every metric on this page is calculated from that recorded work alone, so it is not
+        comparable with a scan whose results are complete.
+      </p>
+      <% if report.failure_code.present? || report.failure_message.present? %>
+        <p class="mt-2 text-sm text-amber-900">
+          <span class="font-medium">Reason:</span> <%= report.user_failure_message %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/db/migrate/20260813210000_add_result_completeness_to_reports.rb
+++ b/db/migrate/20260813210000_add_result_completeness_to_reports.rb
@@ -1,0 +1,9 @@
+class AddResultCompletenessToReports < ActiveRecord::Migration[8.1]
+  def change
+    # Result completeness is deliberately separate from `status`: a failed or stopped
+    # scan can still carry usable partial evidence, and the two facts are read
+    # independently by the UI and by aggregate metrics.
+    add_column :reports, :result_completeness, :string
+    add_index :reports, [ :company_id, :result_completeness ]
+  end
+end

--- a/db/migrate/20260813223000_add_planned_probe_count_to_reports.rb
+++ b/db/migrate/20260813223000_add_planned_probe_count_to_reports.rb
@@ -1,0 +1,11 @@
+class AddPlannedProbeCountToReports < ActiveRecord::Migration[8.1]
+  def change
+    # Recorded when the run is prepared, because the scan's probe list is mutable:
+    # an edit or AutoUpdateScanProbesJob can add or remove probes afterwards, and a
+    # variant child executes mapped variants rather than the scan's own probes.
+    # Reading either at render time yields a ratio against a plan that was never run.
+    # NULL means the plan is unknown (every report created before this column), and
+    # callers show the processed count alone rather than a ratio.
+    add_column :reports, :planned_probe_count, :integer
+  end
+end

--- a/db/migrate/20260813231500_backfill_result_completeness_on_reports.rb
+++ b/db/migrate/20260813231500_backfill_result_completeness_on_reports.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class BackfillResultCompletenessOnReports < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  # Classifies reports processed before result_completeness existed. Runs here rather
+  # than as a deploy step so it happens automatically wherever migrations do, and only
+  # touches terminal reports -- an in-flight one is classified by the worker that
+  # finishes it, so this is safe to run while the previous version is still serving.
+  #
+  # Idempotent: only fills rows with no value. Reports whose failure the classifier
+  # attributed to the provider are deliberately left unset when they hold results,
+  # because such a run may have completed in full; see Report#backfill_result_completeness!.
+  def up
+    Report.reset_column_information
+    Report.backfill_result_completeness!
+  end
+
+  def down
+    # No-op: the column itself is removed by the companion migration on rollback.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_11_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_231500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -297,6 +297,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_120000) do
     t.string "name", null: false
     t.integer "parent_report_id"
     t.integer "pid"
+    t.integer "planned_probe_count"
+    t.string "result_completeness"
     t.integer "retry_count", default: 0, null: false
     t.integer "scan_id", null: false
     t.datetime "start_time"
@@ -305,6 +307,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_120000) do
     t.datetime "updated_at", null: false
     t.string "uuid", null: false
     t.string "variant_probe_name"
+    t.index ["company_id", "result_completeness"], name: "index_reports_on_company_id_and_result_completeness"
     t.index ["company_id"], name: "index_reports_on_company_id"
     t.index ["failure_code"], name: "index_reports_on_failure_code"
     t.index ["heartbeat_at"], name: "index_reports_on_heartbeat_running_only", where: "(status = 1)"

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -3,6 +3,95 @@
 require "rails_helper"
 
 RSpec.describe AdminHelper, type: :helper do
+  describe "#report_has_viewable_results?" do
+    # The partial notice, metrics and PDF are only reachable if the list and header
+    # offer the links. Gating them on completed? hides exactly the reports this
+    # change exists to explain.
+    let(:vr_scan) { create(:complete_scan) }
+    let(:vr_target) { create(:target) }
+
+    it "is true for a completed report" do
+      report = create(:report, scan: vr_scan, target: vr_target, status: :completed, result_completeness: :complete)
+
+      expect(helper.report_has_viewable_results?(report)).to be true
+    end
+
+    it "is true for a failed report holding partial results" do
+      report = create(:report, scan: vr_scan, target: vr_target, status: :failed, result_completeness: :partial)
+
+      expect(helper.report_has_viewable_results?(report)).to be true
+    end
+
+    it "is true when completeness is unknown but results exist" do
+      # A failure with no plan to compare against stays unclassified. Its results are
+      # real either way, and hiding the links would make them unreachable.
+      parent = create(:report, scan: vr_scan, target: vr_target, status: :completed)
+      report = create(:report, scan: vr_scan, target: vr_target, status: :failed,
+                               result_completeness: nil, failure_code: "provider_rate_limited",
+                               parent_report_id: parent.id)
+      create(:probe_result, report: report, probe: create(:probe))
+      # Completeness is recorded as a report turns terminal, so an unresolved row has to
+      # be made deliberately: this one has results but no denominator to judge them by.
+      report.update_columns(result_completeness: nil)
+
+      expect(helper.report_has_viewable_results?(report.reload)).to be true
+    end
+
+    it "is false for a failed report with nothing recorded" do
+      report = create(:report, scan: vr_scan, target: vr_target, status: :failed, result_completeness: :none)
+
+      expect(helper.report_has_viewable_results?(report)).to be false
+    end
+
+    it "resolves an unclassified row without re-deriving for every predicate" do
+      # The admin index renders this helper and the lifecycle tags on every row. A row
+      # that stays unclassified falls through each predicate in turn, and re-deriving
+      # per call means a fresh probe_results query each time -- ~5 a row, so a 20-row
+      # page pays ~100 extra queries.
+      parent = create(:report, scan: vr_scan, target: vr_target, status: :completed)
+      report = create(:report, scan: vr_scan, target: vr_target, status: :failed,
+                               result_completeness: nil, failure_code: "provider_rate_limited",
+                               parent_report_id: parent.id)
+      create(:probe_result, report: report, probe: create(:probe))
+      report.reload
+
+      queries = 0
+      counter = ->(_n, _s, _f, _i, payload) { queries += 1 if payload[:sql].to_s.include?("probe_results") }
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        helper.report_has_viewable_results?(report)
+        helper.report_lifecycle_tags(report)
+      end
+
+      expect(queries).to be <= 2
+    end
+  end
+
+  describe "#report_lifecycle_tags" do
+    # Lifecycle and completeness are separate facts, so the list shows both: a failed
+    # report holding partial evidence must not read the same as one holding nothing.
+    let(:scan) { create(:complete_scan) }
+    let(:target) { create(:target) }
+
+    it "shows only the lifecycle for a completed report" do
+      report = create(:report, scan: scan, target: target, status: :completed, result_completeness: :complete)
+
+      expect(helper.report_lifecycle_tags(report)).to match(/completed/i)
+      expect(helper.report_lifecycle_tags(report)).not_to match(/partial/i)
+    end
+
+    it "marks a failed report holding results as partial" do
+      report = create(:report, scan: scan, target: target, status: :failed, result_completeness: :partial)
+
+      expect(helper.report_lifecycle_tags(report)).to match(/partial/i)
+    end
+
+    it "does not mark a failed report with no results as partial" do
+      report = create(:report, scan: scan, target: target, status: :failed, result_completeness: :none)
+
+      expect(helper.report_lifecycle_tags(report)).not_to match(/partial/i)
+    end
+  end
+
   describe "#status_tag" do
     describe "explicit status" do
       it "renders ok status with green styling" do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1058,6 +1058,27 @@ RSpec.describe Report, type: :model do
       expect(current.previous_completed_report).to eq(newer)
     end
 
+    it 'skips a completed run that only holds partial results' do
+      # A finished run that dropped eval rows is completed but partial. Using it as the
+      # baseline reports a movement that is an artefact of the missing work -- the very
+      # comparison the partial notice tells the reader not to make.
+      whole = create(:report, :completed, company: company, target: target, scan: scan,
+                     created_at: 3.days.ago, result_completeness: :complete)
+      create(:report, :completed, company: company, target: target, scan: scan,
+             created_at: 1.day.ago, result_completeness: :partial)
+      current = create(:report, :completed, company: company, target: target, scan: scan)
+
+      expect(current.previous_completed_report).to eq(whole)
+    end
+
+    it 'still uses a completed run that predates the completeness column' do
+      legacy = create(:report, :completed, company: company, target: target, scan: scan,
+                      created_at: 2.days.ago, result_completeness: nil)
+      current = create(:report, :completed, company: company, target: target, scan: scan)
+
+      expect(current.previous_completed_report).to eq(legacy)
+    end
+
     it 'ignores reports for a different target' do
       other_target = create(:target, company: company)
       other_scan = build(:scan, company: company).tap do |s|
@@ -1147,6 +1168,355 @@ RSpec.describe Report, type: :model do
       create(:detector_result, report: current, passed: 2, total: 10) # 20%
 
       expect(current.asr_delta_vs_previous).to eq(-30.0)
+    end
+  end
+
+  describe "result completeness" do
+    # Completeness is now recorded as a report reaches a terminal state, so a row that
+    # predates the column -- the case this whole describe is about -- has to be made
+    # deliberately rather than by omitting the attribute.
+    def legacy(report)
+      report.update_columns(result_completeness: nil)
+      report.reload
+    end
+
+    describe "when the column was never written" do
+      # Reports can reach a terminal state without going through Reports::Process --
+      # an unsafe target, a launch failure, a stop, the stale reaper -- and a rolling
+      # deploy leaves in-flight reports to be finished by old workers. Those rows have
+      # no stored completeness, and must still read correctly rather than silently
+      # counting as complete.
+      let(:nc_scan) { create(:complete_scan) }
+      let(:nc_target) { create(:target) }
+
+      it "reads a failed report holding results as partial" do
+        report = create(:report, scan: nc_scan, target: nc_target, status: :failed, result_completeness: nil)
+        create(:probe_result, report: report, probe: create(:probe))
+
+        legacy(report)
+
+        expect(report).to be_partial_results
+      end
+
+      it "reads a failed report with nothing recorded as none" do
+        report = create(:report, scan: nc_scan, target: nc_target, status: :failed, result_completeness: nil)
+
+        legacy(report)
+
+        expect(report).not_to be_partial_results
+        expect(report).to be_none_results
+      end
+
+      it "reads a completed report short of its recorded plan as partial" do
+        # A new launcher records the plan, then an old processor finishes the run during
+        # a rollout and leaves the column unset. Reading that as complete would contradict
+        # what the live path stores for the very same evidence.
+        report = create(:report, scan: nc_scan, target: nc_target, status: :completed,
+                                 result_completeness: nil, planned_probe_count: 3)
+        create(:probe_result, report: report, probe: create(:probe))
+
+        legacy(report)
+
+        expect(report).to be_partial_results
+      end
+
+      it "reads a completed report that covered its recorded plan as complete" do
+        report = create(:report, scan: nc_scan, target: nc_target, status: :completed,
+                                 result_completeness: nil, planned_probe_count: 1)
+        create(:probe_result, report: report, probe: create(:probe))
+
+        legacy(report)
+
+        expect(report).to be_complete_results
+      end
+
+      it "reads a completed report as complete" do
+        report = create(:report, scan: nc_scan, target: nc_target, status: :completed, result_completeness: nil)
+
+        legacy(report)
+
+        expect(report).to be_complete_results
+        expect(report).not_to be_partial_results
+      end
+
+      it "reads a provider-classified failure that fell short of its plan as partial" do
+        # nc_scan plans two probes, so one result is positive proof the run stopped
+        # early -- whichever failure the classifier attributed it to.
+        report = create(:report, scan: nc_scan, target: nc_target, status: :failed,
+                                 result_completeness: nil, failure_code: "provider_rate_limited")
+        create(:probe_result, report: report, probe: create(:probe))
+
+        legacy(report)
+
+        expect(report).to be_partial_results
+      end
+
+      it "reads a provider-classified failure that produced its whole plan as complete" do
+        # apply_terminal_provider_failure_metadata can mark a run :failed on the
+        # strength of the logs after it produced every row. Counting its results
+        # against the plan settles that without guessing.
+        report = create(:report, scan: nc_scan, target: nc_target, status: :failed,
+                                 result_completeness: nil, failure_code: "provider_rate_limited")
+        2.times { create(:probe_result, report: report, probe: create(:probe)) }
+
+        legacy(report)
+
+        expect(report).to be_complete_results
+        expect(report).not_to be_partial_results
+      end
+
+      it "keeps a run the classifier called incomplete as partial despite a full count" do
+        # scan_incomplete_results asserts incompleteness directly: the run ended without
+        # its completion row or usable timing. A full probe count does not overturn that,
+        # since what went missing was never a probe result.
+        report = create(:report, scan: nc_scan, target: nc_target, status: :failed,
+                                 result_completeness: nil, failure_code: "scan_incomplete_results")
+        2.times { create(:probe_result, report: report, probe: create(:probe)) }
+
+        legacy(report)
+
+        expect(report).to be_partial_results
+      end
+
+      it "declines to classify a provider-classified failure with no plan to compare against" do
+        # A variant report that never recorded its variant_count has no denominator,
+        # so the ambiguity the failure code carries is genuine and left unresolved.
+        parent = create(:report, scan: nc_scan, target: nc_target, status: :completed)
+        report = create(:report, scan: nc_scan, target: nc_target, status: :failed,
+                                 result_completeness: nil, failure_code: "provider_rate_limited",
+                                 parent_report_id: parent.id)
+        create(:probe_result, report: report, probe: create(:probe))
+
+        legacy(report)
+
+        expect(report.result_completeness).to be_nil
+      end
+
+      it "prefers the stored value when there is one" do
+        report = create(:report, scan: nc_scan, target: nc_target, status: :failed, result_completeness: :none)
+        create(:probe_result, report: report, probe: create(:probe))
+
+        expect(report).not_to be_partial_results
+      end
+    end
+
+    describe ".backfill_result_completeness!" do
+      it "leaves an in-flight report alone" do
+        # A report still being worked on gets its completeness from the worker that
+        # finishes it. Classifying it here would stamp a value that worker never
+        # revisits -- and during an upgrade that worker is still the old version.
+        %i[pending starting running processing].each do |status|
+          report = create(:report, scan: bf_scan, target: bf_target, status: status, result_completeness: nil)
+
+          legacy(report)
+
+          Report.backfill_result_completeness!
+
+          expect(report.reload.result_completeness).to be_nil
+        end
+      end
+
+      # 200 production reports predate this column. They carry no completeness signal
+      # of their own, so it is reconstructed from whether any results were recorded.
+      let(:bf_scan) { create(:complete_scan) }
+      let(:bf_target) { create(:target) }
+
+      it "marks completed reports complete" do
+        report = create(:report, scan: bf_scan, target: bf_target, status: :completed, result_completeness: nil)
+
+        legacy(report)
+
+        Report.backfill_result_completeness!
+
+        expect(report.reload.result_completeness).to eq("complete")
+      end
+
+      it "marks a failed report holding results partial" do
+        report = create(:report, scan: bf_scan, target: bf_target, status: :failed, result_completeness: nil)
+        create(:probe_result, report: report, probe: create(:probe))
+
+        legacy(report)
+
+        Report.backfill_result_completeness!
+
+        expect(report.reload.result_completeness).to eq("partial")
+      end
+
+      it "marks a failed report with nothing recorded as none" do
+        report = create(:report, scan: bf_scan, target: bf_target, status: :failed, result_completeness: nil)
+
+        legacy(report)
+
+        Report.backfill_result_completeness!
+
+        expect(report.reload.result_completeness).to eq("none")
+      end
+
+      it "classifies a provider failure that recorded nothing as none" do
+        # The ambiguity is only about whether retained results are complete. With no
+        # results at all there is nothing to be ambiguous about, and leaving it NULL
+        # would mean this row is never classified on any run.
+        report = create(:report, scan: bf_scan, target: bf_target, status: :failed,
+                                 result_completeness: nil, failure_code: "provider_rate_limited")
+
+        legacy(report)
+
+        Report.backfill_result_completeness!
+
+        expect(report.reload.result_completeness).to eq("none")
+      end
+
+      it "records a failure that produced its whole plan as complete" do
+        # apply_terminal_provider_failure_metadata can turn a run that produced every
+        # attempt, eval and completion row into :failed on the strength of the logs.
+        # Inferring "partial" from not-completed-with-results would put a false "scan
+        # did not finish" banner on valid data and drop it from Average ASR, so the
+        # result count is compared against the plan instead of guessing from status.
+        report = create(:report, scan: bf_scan, target: bf_target, status: :failed,
+                                 result_completeness: nil, failure_code: "provider_rate_limited")
+        2.times { create(:probe_result, report: report, probe: create(:probe)) }
+
+        legacy(report)
+
+        Report.backfill_result_completeness!
+
+        expect(report.reload.result_completeness).to eq("complete")
+      end
+
+      it "records a failure that fell short of its plan as partial" do
+        report = create(:report, scan: bf_scan, target: bf_target, status: :failed,
+                                 result_completeness: nil, failure_code: "provider_rate_limited")
+        create(:probe_result, report: report, probe: create(:probe))
+
+        legacy(report)
+
+        Report.backfill_result_completeness!
+
+        expect(report.reload.result_completeness).to eq("partial")
+      end
+
+      it "leaves a failure with no plan to compare against unclassified" do
+        parent = create(:report, scan: bf_scan, target: bf_target, status: :completed)
+        report = create(:report, scan: bf_scan, target: bf_target, status: :failed,
+                                 result_completeness: nil, failure_code: "provider_rate_limited",
+                                 parent_report_id: parent.id)
+        create(:probe_result, report: report, probe: create(:probe))
+
+        legacy(report)
+
+        Report.backfill_result_completeness!
+
+        expect(report.reload.result_completeness).to be_nil
+      end
+
+      it "leaves an already-classified report untouched" do
+        report = create(:report, scan: bf_scan, target: bf_target, status: :failed, result_completeness: :partial)
+
+        Report.backfill_result_completeness!
+
+        expect(report.reload.result_completeness).to eq("partial")
+      end
+    end
+
+    # Execution lifecycle (status) and result completeness are separate concepts.
+    # A failed scan can still carry usable partial evidence, and the UI must be able
+    # to tell that apart from a failure with nothing to show and from a finished scan.
+    let(:target) { create(:target) }
+    let(:scan) { create(:complete_scan) }
+
+    it "treats a completed scan as complete" do
+      report = create(:report, scan: scan, target: target, status: :completed, result_completeness: :complete)
+
+      expect(report).to be_complete_results
+      expect(report).not_to be_partial_results
+    end
+
+    it "treats a failed scan that produced results as partial" do
+      report = create(:report, scan: scan, target: target, status: :failed, result_completeness: :partial)
+
+      expect(report).to be_partial_results
+      expect(report).to be_failed
+    end
+
+    it "treats a failed scan with nothing recorded as having no results" do
+      report = create(:report, scan: scan, target: target, status: :failed, result_completeness: :none)
+
+      expect(report).not_to be_partial_results
+      expect(report.result_completeness).to eq("none")
+    end
+
+    it "treats a stopped scan that produced results as partial" do
+      # Stopped scans retain no results today, but the same grid must cover them.
+      report = create(:report, scan: scan, target: target, status: :stopped, result_completeness: :partial)
+
+      expect(report).to be_partial_results
+      expect(report).to be_stopped
+    end
+
+    describe "#processed_scope and #planned_scope" do
+      it "reports processed work against the plan recorded for the run" do
+        report = create(:report, scan: scan, target: target, status: :failed,
+                                 result_completeness: :partial, planned_probe_count: 3)
+        create_list(:probe, 2).each { |probe| create(:probe_result, report: report, probe: probe) }
+
+        expect(report.processed_scope).to eq(2)
+        expect(report.planned_scope).to eq(3)
+        expect(report.processed_scope_summary).to eq("2 of 3 probes")
+      end
+
+      it "never renders a ratio the processed count exceeds" do
+        # A scan edited between attempts of a resumed run can leave the recorded plan
+        # below what was actually processed. "7 of 5 probes" is not a fact about
+        # anything, so the ratio is dropped rather than shown impossible.
+        report = create(:report, scan: scan, target: target, status: :failed,
+                                 result_completeness: :partial, planned_probe_count: 2)
+        create_list(:probe, 3).each { |probe| create(:probe_result, report: report, probe: probe) }
+
+        expect(report.processed_scope_summary).to eq("3 probes")
+      end
+
+      it "uses the plan recorded when the run was prepared" do
+        report = create(:report, scan: scan, target: target, status: :failed,
+                                 result_completeness: :partial, planned_probe_count: 10)
+        # The scan's list has since changed; the recorded plan is what this run had.
+        scan.probes = create_list(:probe, 3)
+
+        expect(report.planned_scope).to eq(10)
+      end
+
+      it "counts variants, not probes, for a variant report" do
+        # A variant child executes mapped threat variants and records one result per
+        # variant, so calling them probes misstates what was measured.
+        parent = create(:report, scan: scan, target: target, status: :completed)
+        report = create(:report, scan: scan, target: target, status: :failed,
+                                 result_completeness: :partial, parent_report_id: parent.id,
+                                 planned_probe_count: 8)
+        create_list(:probe, 5).each { |probe| create(:probe_result, report: report, probe: probe) }
+
+        expect(report.processed_scope_summary).to eq("5 of 8 variants")
+      end
+
+      it "withholds the ratio when no plan was recorded for the run" do
+        # Every report created before the column has no plan. Reading the scan's
+        # current list instead would claim a ratio against probes it never ran --
+        # AutoUpdateScanProbesJob adds probes, and a variant child runs mapped
+        # variants rather than the scan's own probes.
+        report = create(:report, scan: scan, target: target, status: :failed,
+                                 result_completeness: :partial, planned_probe_count: nil)
+        scan.probes = create_list(:probe, 4)
+        create_list(:probe, 3).each { |probe| create(:probe_result, report: report, probe: probe) }
+
+        expect(report.planned_scope).to be_nil
+        expect(report.processed_scope_summary).to eq("3 probes")
+      end
+
+      it "reports processed work with no planned scope when the scan has no probes" do
+        report = create(:report, scan: scan, target: target, status: :failed, result_completeness: :partial)
+        scan.probes = []
+
+        expect(report.processed_scope).to eq(0)
+        expect(report.planned_scope).to be_nil
+      end
     end
   end
 end

--- a/spec/requests/report_details_spec.rb
+++ b/spec/requests/report_details_spec.rb
@@ -4,6 +4,127 @@ RSpec.describe "ReportDetails", type: :request do
   let(:company) { create(:company) }
   let(:report) { create(:report, :completed, company: company) }
 
+  describe "partial result presentation" do
+    let(:company) { create(:company) }
+    let(:user) { ActsAsTenant.with_tenant(company) { create(:user, :super_admin, company: company) } }
+    let(:probe) { ActsAsTenant.with_tenant(company) { create(:probe) } }
+    let(:detector) { ActsAsTenant.with_tenant(company) { create(:detector) } }
+
+    def build_report(status:, completeness:, with_results: true, failure_code: nil)
+      ActsAsTenant.with_tenant(company) do
+        report = create(:report, company: company, status: status,
+                                 result_completeness: completeness, failure_code: failure_code)
+        if with_results
+          create(:probe_result, report: report, probe: probe, detector: detector, passed: 5, total: 10)
+          # The narrative band (ASR headline, delta) only renders when detector
+          # results exist, so a fixture without one never exercises it.
+          create(:detector_result, report: report, detector: detector, passed: 5, total: 10)
+        end
+        report
+      end
+    end
+
+    before do
+      user.update!(current_company: company)
+      sign_in user
+      ActsAsTenant.current_tenant = company
+    end
+
+    it "labels a failed report that retained results as partial" do
+      report = build_report(status: :failed, completeness: :partial)
+
+      get report_detail_path(report)
+
+      expect(response.body).to match(/partial/i)
+    end
+
+    it "labels a partial report even when no failure_code was recorded" do
+      # 142 of 200 such reports in production have no failure_code, so gating the
+      # explanation on failed_with_reason? leaves most of them silently unlabelled.
+      report = build_report(status: :failed, completeness: :partial, failure_code: nil)
+
+      get report_detail_path(report)
+
+      expect(response.body).to match(/partial/i)
+    end
+
+    it "does not tell a completed run that it failed to finish" do
+      # A run that emitted its completion row and timing but lost eval rows is
+      # completed and partial. Telling the customer it "did not finish" reports the
+      # wrong execution outcome on the report page and in the PDF.
+      report = build_report(status: :completed, completeness: :partial)
+
+      get report_detail_path(report)
+
+      expect(response.body).to match(/partial/i)
+      expect(response.body).not_to match(/did not finish/i)
+      expect(response.body).not_to match(/ended before completing/i)
+    end
+
+    it "does not tell a run that finished but lost its timing that it stopped early" do
+      # attempts, evals and a completion row, but unusable timing: Reports::Process
+      # marks that failed and partial though the scan ran to completion. The notice is
+      # worded to hold for every partial case rather than asserting when it ended.
+      report = build_report(status: :failed, completeness: :partial,
+                            failure_code: "scan_incomplete_results")
+
+      get report_detail_path(report)
+
+      expect(response.body).to match(/partial/i)
+      expect(response.body).not_to match(/did not finish/i)
+      expect(response.body).not_to match(/ended before completing/i)
+    end
+
+    it "shows how much of the planned work was processed" do
+      report = build_report(status: :failed, completeness: :partial)
+      # The plan is the one recorded when the run was prepared, not the scan's
+      # current probe list, which may have changed since.
+      report.update!(planned_probe_count: 2)
+
+      get report_detail_path(report)
+
+      expect(response.body).to include("1 of 2")
+    end
+
+    it "does not compare a partial report against a previous completed scan" do
+      # The notice says partial metrics are not comparable with a completed scan, so
+      # rendering a "vs last scan" delta beside them contradicts it and can report a
+      # movement that is an artefact of the scan stopping early.
+      report = build_report(status: :failed, completeness: :partial)
+      allow_any_instance_of(Report).to receive(:asr_delta_vs_previous).and_return(12.0)
+
+      get report_detail_path(report)
+
+      expect(response.body).not_to match(/vs last scan/i)
+    end
+
+    it "labels a partial report on the admin detail page too" do
+      # Admin opens reports through a different view; a partial report with no failure
+      # metadata otherwise reads there as an ordinary failed report.
+      report = build_report(status: :failed, completeness: :partial)
+
+      get report_path(report)
+
+      expect(response.body).to match(/partial/i)
+    end
+
+    it "does not label a completed report as partial" do
+      report = build_report(status: :completed, completeness: :complete)
+
+      get report_detail_path(report)
+
+      expect(response.body).not_to match(/partial/i)
+    end
+
+    it "labels a stopped report that retained results as partial" do
+      report = build_report(status: :stopped, completeness: :partial)
+
+      get report_detail_path(report)
+
+      expect(response.body).to match(/partial/i)
+    end
+  end
+
   describe "GET /report_details/:id (cross-tenant isolation)" do
     let(:company_a) { create(:company) }
     let(:company_b) { create(:company) }

--- a/spec/services/reports/process_spec.rb
+++ b/spec/services/reports/process_spec.rb
@@ -32,6 +32,155 @@ RSpec.describe Reports::Process, type: :service do
       allow(ToastNotifier).to receive(:call)
     end
 
+    describe 'result completeness' do
+      # process_jsonl_data already distinguishes these cases in order to pick a
+      # status; the completeness they imply must survive rather than being folded
+      # into `failed`, because a failure that produced usable evidence has to be
+      # presented differently from one that produced nothing.
+      # The probe must exist for an eval row to persist a probe result, and the logs
+      # decide whether garak exited cleanly -- both are what the branches key on.
+      let!(:completeness_probe) { create(:probe, name: 'TestProbe') }
+
+      def run_with(lines, logs: 'Garak scan completed - Exit code: 0')
+        RawReportData.where(report_id: report.id).delete_all
+        RawReportData.create!(report_id: report.id, jsonl_data: lines.join("\n"), logs_data: logs, status: 'pending')
+        service.call
+        report.reload
+      end
+
+      let(:init_line) { { entry_type: 'init', start_time: '2023-06-01T10:00:00Z' }.to_json }
+      let(:attempt_line) do
+        { entry_type: 'attempt', probe_classname: '0din.TestProbe', uuid: 'a1', prompt: 'p',
+          outputs: [ 'o' ], notes: { score_percentage: 70 } }.to_json
+      end
+      let(:eval_line) do
+        { entry_type: 'eval', detector: 'detector.test_detector', probe: '0din.TestProbe',
+          passed: 3, total_evaluated: 10 }.to_json
+      end
+      let(:completion_line) { { entry_type: 'completion', end_time: '2023-06-01T11:00:00Z' }.to_json }
+
+      it 'marks a clean run complete' do
+        run_with([ init_line, attempt_line, eval_line, completion_line ])
+
+        expect(report.status).to eq('completed')
+        expect(report.result_completeness).to eq('complete')
+      end
+
+      it 'marks eval rows without their attempt as partial' do
+        # process_eval persists a ProbeResult on its own, so a malformed or missing
+        # attempt row still leaves usable evidence. Storing "none" there would
+        # contradict the results sitting in the database.
+        run_with([ init_line, eval_line ], logs: 'Garak scan completed - Exit code: 1')
+
+        expect(report.status).to eq('failed')
+        expect(report.result_completeness).to eq('partial')
+      end
+
+      it 'marks a run with no attempts as having no results' do
+        run_with([ init_line ])
+
+        expect(report.status).to eq('failed')
+        expect(report.result_completeness).to eq('none')
+      end
+
+      it 'marks attempts without evals as having no results' do
+        # Evals are what persist probe results, so there is nothing to show yet.
+        run_with([ init_line, attempt_line ])
+
+        expect(report.status).to eq('failed')
+        expect(report.result_completeness).to eq('none')
+      end
+
+      it 'marks evals without a completion row as partial' do
+        # This is report 4599: garak died mid-run after recording real results.
+        run_with([ init_line, attempt_line, eval_line ], logs: 'Garak scan completed - Exit code: 1')
+
+        expect(report.status).to eq('failed')
+        expect(report.result_completeness).to eq('partial')
+      end
+
+      it 'marks a completed run with unusable timing as partial' do
+        run_with([ attempt_line, eval_line, completion_line ], logs: 'Garak scan completed - Exit code: 1')
+
+        expect(report.status).to eq('failed')
+        expect(report.result_completeness).to eq('partial')
+      end
+
+      it 'marks a finished run that lost an eval row to malformed counts as partial' do
+        # evals_processed is set by the first eval that persists, so a run whose other
+        # eval rows were rejected still reaches the success branch. That probe's data
+        # is gone for good, so the results on offer are not the whole picture.
+        malformed = { entry_type: 'eval', detector: 'detector.test_detector',
+                      probe: '0din.TestProbe', passed: nil, total_evaluated: nil }.to_json
+
+        run_with([ init_line, attempt_line, eval_line, malformed, completion_line ])
+
+        expect(report.status).to eq('completed')
+        expect(report.result_completeness).to eq('partial')
+      end
+
+      it 'marks a finished run short of its recorded plan as partial' do
+        # We pass --skip_unknown to garak, so a probe it does not recognise is skipped
+        # silently: no eval row arrives to be dropped, and another probe still sets the
+        # flags. One ProbeResult exists per planned probe, so a short count is the only
+        # evidence that a selected probe produced nothing.
+        report.update!(planned_probe_count: 3)
+
+        run_with([ init_line, attempt_line, eval_line, completion_line ])
+
+        expect(report.status).to eq('completed')
+        expect(report.result_completeness).to eq('partial')
+      end
+
+      it 'marks a finished run that covered its recorded plan as complete' do
+        report.update!(planned_probe_count: 1)
+
+        run_with([ init_line, attempt_line, eval_line, completion_line ])
+
+        expect(report.status).to eq('completed')
+        expect(report.result_completeness).to eq('complete')
+      end
+
+      it 'does not call a resumed run partial when a retry recorded the lost eval' do
+        # Resumed scans concatenate segments. A malformed eval is not treated as
+        # completed work, so the retry runs that probe again and records it. The final
+        # state holds every planned result, and that is what the report is judged on.
+        malformed = { entry_type: 'eval', detector: 'detector.test_detector',
+                      probe: '0din.TestProbe', passed: nil, total_evaluated: nil }.to_json
+        report.update!(planned_probe_count: 1)
+
+        run_with([ init_line, attempt_line, malformed, eval_line, completion_line ])
+
+        expect(report.status).to eq('completed')
+        expect(report.result_completeness).to eq('complete')
+      end
+
+      it 'does not treat a rejected non-eval row as lost results' do
+        # process_completion rejects malformed rows with the same symbol. Concatenated
+        # retry data can carry a bad completion row ahead of a good one, and no eval
+        # was lost there -- calling that partial would drop a whole scan from ASR.
+        bad_completion = { entry_type: 'completion' }.to_json
+
+        run_with([ init_line, attempt_line, eval_line, bad_completion, completion_line ])
+
+        expect(report.status).to eq('completed')
+        expect(report.result_completeness).to eq('complete')
+      end
+
+      it 'marks a finished run whose eval names an unresolvable probe as partial' do
+        # The probe or detector no longer resolves, so garak evaluated work this report
+        # cannot show. In production a completed run records exactly one result per
+        # planned probe, so a dropped row is a real gap rather than routine noise.
+        unresolvable = { entry_type: 'eval', detector: 'detector.test_detector',
+                         probe: '0din.NoSuchProbe', passed: 3, total_evaluated: 10 }.to_json
+
+        run_with([ init_line, attempt_line, eval_line, unresolvable, completion_line ])
+
+        expect(report.status).to eq('completed')
+        expect(report.result_completeness).to eq('partial')
+      end
+    end
+
     context 'when raw_report_data does not exist' do
       before do
         # Ensure no raw_report_data exists

--- a/spec/services/run_garak_scan_spec.rb
+++ b/spec/services/run_garak_scan_spec.rb
@@ -152,6 +152,52 @@ RSpec.describe RunGarakScan, type: :service do
       expect(report.execution_token).to be_nil
     end
 
+    it 'records the probe plan for this run before launching' do
+      # The scan's probe list is mutable, so the plan has to be captured at launch;
+      # reading it later can only describe a plan the run never had.
+      report.update!(status: :pending, execution_token: nil, planned_probe_count: nil)
+      scan.probes = create_list(:probe, 4)
+      service = described_class.new(report)
+      allow(service).to receive(:call).and_call_original
+      allow(service).to receive(:build_argv).and_return([ "python3", "script/run_garak.py", report.uuid ])
+      allow(RunCommand).to receive(:new).and_return(double("RunCommand", call_async: nil))
+
+      service.call
+
+      expect(report.reload.planned_probe_count).to eq(4)
+    end
+
+    it 'raises the recorded plan when a retry executes probes added since the first attempt' do
+      # AutoUpdateScanProbesJob can add probes to a scan between attempts, and a
+      # resumed run executes them. processed_scope counts results from every attempt,
+      # so a plan frozen at the first launch would render as "7 of 5 probes".
+      report.update!(status: :pending, execution_token: nil, planned_probe_count: 5)
+      scan.probes = create_list(:probe, 7)
+      service = described_class.new(report)
+      allow(service).to receive(:call).and_call_original
+      allow(service).to receive(:build_argv).and_return([ "python3", "script/run_garak.py", report.uuid ])
+      allow(RunCommand).to receive(:new).and_return(double("RunCommand", call_async: nil))
+
+      service.call
+
+      expect(report.reload.planned_probe_count).to eq(7)
+    end
+
+    it 'never lowers a recorded plan the run has already exceeded' do
+      # A scan edited down after the fact must not retroactively shrink the plan a
+      # completed run was measured against.
+      report.update!(status: :pending, execution_token: nil, planned_probe_count: 9)
+      scan.probes = create_list(:probe, 2)
+      service = described_class.new(report)
+      allow(service).to receive(:call).and_call_original
+      allow(service).to receive(:build_argv).and_return([ "python3", "script/run_garak.py", report.uuid ])
+      allow(RunCommand).to receive(:new).and_return(double("RunCommand", call_async: nil))
+
+      service.call
+
+      expect(report.reload.planned_probe_count).to eq(9)
+    end
+
     it 'updates the report status to starting' do
       service = described_class.new(report)
       allow(service).to receive(:call).and_call_original

--- a/spec/services/stats/average_asr_score_spec.rb
+++ b/spec/services/stats/average_asr_score_spec.rb
@@ -16,6 +16,69 @@ RSpec.describe Stats::AverageAsrScore do
     # tenant explicitly at call time (the aggregate is tenant-scoped).
     subject { ActsAsTenant.with_tenant(company) { described_class.new(days: 30).call } }
 
+    context 'when a report holds only partial results' do
+      # A scan that died mid-run leaves real but incomplete evidence. Averaging it
+      # with finished scans silently mixes partial data into a headline number, so
+      # partial reports are excluded from the aggregate entirely.
+      let!(:complete_report) do
+        create(:report, scan: scan, target: target, company: company,
+                        status: :completed, result_completeness: :complete).tap do |report|
+          create(:probe_result, report: report, probe: probe, detector: detector, passed: 4, total: 10)
+        end
+      end
+
+      let!(:partial_report) do
+        create(:report, scan: scan, target: target, company: company,
+                        status: :failed, result_completeness: :partial).tap do |report|
+          create(:probe_result, report: report, probe: probe, detector: detector, passed: 10, total: 10)
+        end
+      end
+
+      it 'excludes the partial report from the average' do
+        # Both included would average (40 + 100) / 2 = 70.0
+        expect(subject[:score]).to eq(40.0)
+      end
+
+      it 'excludes the partial report from the time series' do
+        rates = subject[:data][:rates].reject(&:zero?)
+
+        expect(rates).to all eq(40.0)
+      end
+    end
+
+    context 'when a report reaches a terminal state outside Reports::Process' do
+      # A stop records completeness through the Report hook, so the aggregate only has to
+      # read the column -- it does not restate the rule in SQL. This is the end-to-end
+      # proof of that: stop a run holding partial results and it leaves the average.
+      let!(:complete_report) do
+        create(:report, scan: scan, target: target, company: company,
+                        status: :completed, result_completeness: :complete).tap do |report|
+          create(:probe_result, report: report, probe: probe, detector: detector, passed: 4, total: 10)
+        end
+      end
+
+      it 'excludes a stopped run that kept only some of its results' do
+        stopped = create(:report, scan: scan, target: target, company: company, status: :running,
+                                  planned_probe_count: 5)
+        create(:probe_result, report: stopped, probe: probe, detector: detector, passed: 10, total: 10)
+        stopped.update!(status: :stopped)
+
+        expect(stopped.reload.result_completeness).to eq('partial')
+        # Counted it would average (40 + 100) / 2 = 70.0
+        expect(subject[:score]).to eq(40.0)
+      end
+
+      it 'still counts a stopped run that produced everything it planned' do
+        stopped = create(:report, scan: scan, target: target, company: company, status: :running,
+                                  planned_probe_count: 1)
+        create(:probe_result, report: stopped, probe: probe, detector: detector, passed: 10, total: 10)
+        stopped.update!(status: :stopped)
+
+        expect(stopped.reload.result_completeness).to eq('complete')
+        expect(subject[:score]).to eq(70.0)
+      end
+    end
+
     context 'when no reports exist' do
       it 'returns zero score with empty data' do
         result = subject


### PR DESCRIPTION
A failed or stopped scan can still leave usable results, but nothing distinguished execution failure from result completeness — a partial report rendered its ASR and statistics through the same path as a finished one.

Reports now record completeness (`complete` / `partial` / `none`) alongside the status. Partial reports explain themselves in the UI without depending on a failure code, state how much of the plan was processed, and are excluded from Average ASR and its time series.