### PR TITLE
fix(stats): exclude unclassified terminal reports from Average ASR

### DIFF
--- a/app/services/stats/average_asr_score.rb
+++ b/app/services/stats/average_asr_score.rb
@@ -6,10 +6,22 @@ module Stats
 
     # Reports are classified as they reach a terminal state -- Reports::Process from the
     # JSONL it read, and a Report before_save hook for every other terminal path -- so the
-    # aggregate only has to read the column. NULL means a run still in flight, which was
-    # always counted, or a row a previous version wrote mid-upgrade; the backfill
-    # migration classifies historical rows.
-    NOT_PARTIAL_SQL = "(reports.result_completeness IS NULL OR reports.result_completeness <> 'partial')".freeze
+    # aggregate reads the column instead of restating the rule in SQL.
+    #
+    # A failed or stopped run that is still unset was written by neither (an old worker
+    # finishing mid-rollout, before the new code took over) and may hold partial evidence,
+    # so it is left out rather than counted on the assumption that unset means whole. An
+    # unset completed run is counted, which is what the model derives for it as well. Both
+    # cases are transient: the migration classifies history and re-running
+    # scanner:backfill_result_completeness settles any stragglers.
+    NOT_PARTIAL_SQL = <<~SQL.squish.freeze
+      (
+        reports.result_completeness IS NOT NULL
+          AND reports.result_completeness <> 'partial'
+        OR reports.result_completeness IS NULL
+          AND reports.status NOT IN (#{Report.statuses.values_at('failed', 'stopped').join(', ')})
+      )
+    SQL
 
     TIME_GROUP_FORMATS = {
       "week" => "TO_CHAR(reports.created_at, 'IYYY-IW')",

--- a/spec/services/stats/average_asr_score_spec.rb
+++ b/spec/services/stats/average_asr_score_spec.rb
@@ -46,6 +46,38 @@ RSpec.describe Stats::AverageAsrScore do
       end
     end
 
+    context 'when a terminal report was never classified' do
+      # The hook classifies every terminal transition and the migration classifies
+      # history, but an old worker finishing mid-rollout writes neither. Such a row may
+      # hold partial evidence, so it is left out rather than counted on the assumption
+      # that unset means whole.
+      let!(:complete_report) do
+        create(:report, scan: scan, target: target, company: company,
+                        status: :completed, result_completeness: :complete).tap do |report|
+          create(:probe_result, report: report, probe: probe, detector: detector, passed: 4, total: 10)
+        end
+      end
+
+      it 'excludes an unclassified failed report' do
+        unclassified = create(:report, scan: scan, target: target, company: company, status: :failed)
+        create(:probe_result, report: unclassified, probe: probe, detector: detector, passed: 10, total: 10)
+        unclassified.update_columns(result_completeness: nil)
+
+        # Counted it would average (40 + 100) / 2 = 70.0
+        expect(subject[:score]).to eq(40.0)
+      end
+
+      it 'still counts an unclassified completed report' do
+        # A finished run is complete unless a recorded plan says otherwise, which is what
+        # the model derives for it too -- so dropping it would discard good data.
+        unclassified = create(:report, scan: scan, target: target, company: company, status: :completed)
+        create(:probe_result, report: unclassified, probe: probe, detector: detector, passed: 10, total: 10)
+        unclassified.update_columns(result_completeness: nil)
+
+        expect(subject[:score]).to eq(70.0)
+      end
+    end
+
     context 'when a report reaches a terminal state outside Reports::Process' do
       # A stop records completeness through the Report hook, so the aggregate only has to
       # read the column -- it does not restate the rule in SQL. This is the end-to-end


### PR DESCRIPTION
A failed or stopped report whose result completeness was never recorded may still hold partial evidence, so it is now left out of Average ASR and its time series rather than counted on the assumption that unset means whole. An unset completed report is still counted, matching what the model derives for it.