### PR TITLE
fix(reports): one ASR definition across every report surface

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -127,7 +127,11 @@ module Admin
 
       reports.each do |report|
         dates << report.created_at.strftime("%m/%d")
-        asr_values << report.attack_success_rate.round(1)
+        # From the canonical figure, not attack_success_rate: that is already rounded to
+        # 2dp, so rounding again moved the value (12/961 plotted 1.3 while the page said
+        # 1.2). nil leaves a gap for a report with nothing to measure -- a plotted 0
+        # would read as a perfect result where the page says N/A.
+        asr_values << report.asr.percent&.round(1)
         successful_attacks << report.total_successful_attacks
       end
 

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,4 +1,21 @@
 module ReportsHelper
+  # The single place ASR becomes text. Every surface -- the reports list, the overview
+  # statistics, the customer narrative band and its PDF -- renders through this, so the
+  # same report cannot read 83.24% in one place and 83% in another.
+  #
+  # Precision policy: one decimal place everywhere. The only sanctioned exception is the
+  # customer narrative headline, which passes precision: 0 because it is a hero number;
+  # a spec asserts that exception so a third precision cannot appear quietly.
+  #
+  # "N/A" is reserved for a figure that cannot be calculated at all. A measured zero is
+  # rendered as 0.0% -- it means every attack was blocked, which is a result, not an
+  # absence of one.
+  def asr_display(figure, precision: 1)
+    return "N/A" unless figure&.calculable?
+
+    number_to_percentage(figure.percent, precision: precision)
+  end
+
   # Risk grade label boundaries, aligned to the ASR color bands (0...25, 25...50,
   # 50...75, 75+) so the grade word always matches the ASR number.
   RISK_GRADE_THRESHOLDS = [ [ 25, "Low" ], [ 50, "Medium" ], [ 75, "High" ] ].freeze

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -428,6 +428,11 @@ class Report < ApplicationRecord
     detector_results.sum(:total)
   end
 
+  # Numeric ASR for charts, sorting and aggregates, which need a comparable number.
+  #
+  # Returns 0 when nothing was measurable, so it CANNOT distinguish "no attack
+  # succeeded" from "no attacks were evaluated" -- never render it directly. Display
+  # goes through #asr and ReportsHelper#asr_display, which keep those apart.
   def attack_success_rate
     total = cached_total
     passed = cached_passed
@@ -435,9 +440,16 @@ class Report < ApplicationRecord
     (passed.to_f / total * 100).round(2)
   end
 
-  def formatted_asr
-    asr = attack_success_rate
-    asr == 0 ? "N/A" : "#{asr}%"
+  # The canonical reading every surface renders, and the only place the numerator and
+  # denominator are chosen: detector_results, which is what ASR has always meant here
+  # and what the aggregates use. Returning a figure rather than a Float keeps "nothing
+  # succeeded" and "nothing was measurable" apart -- see Reports::AsrFigure.
+  def asr
+    Reports::AsrFigure.new(
+      numerator: cached_passed,
+      denominator: cached_total,
+      partial: partial_results?
+    )
   end
 
   # The most recent prior completed parent (non-variant) report of the same
@@ -470,10 +482,20 @@ class Report < ApplicationRecord
   # NOTE: calls attack_success_rate on self and on the prior report; each
   # falls back to two detector_results queries when not preloaded.
   # Multi-report callers should preload.
+  # Movement against the previous run, or nil when there is nothing to compare.
+  #
+  # Computed from the figures rather than attack_success_rate, which collapses an
+  # unmeasurable report to 0: subtracting that reported "50 pts vs last scan" beside an
+  # ASR of "N/A" -- a movement away from a number that was never stated.
   def asr_delta_vs_previous
     prev = previous_completed_report
     return nil unless prev
-    (attack_success_rate - prev.attack_success_rate).round(2)
+
+    current_figure = asr
+    previous_figure = prev.asr
+    return nil unless current_figure.calculable? && previous_figure.calculable?
+
+    (current_figure.percent - previous_figure.percent).round(2)
   end
 
   def total_successful_attacks

--- a/app/models/reports/asr_figure.rb
+++ b/app/models/reports/asr_figure.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Reports
+  # One attack-success-rate reading, and the only thing a surface may render.
+  #
+  # It exists to keep two facts apart that the previous Float could not:
+  #
+  #   0.0  -- attacks were evaluated and none succeeded (a real, good result)
+  #   nil  -- nothing was measurable, so no rate can be stated
+  #
+  # Report#attack_success_rate collapsed both to 0, and #formatted_asr then rendered
+  # every zero as "N/A". A completed scan that blocked all three attacks reported
+  # "unavailable" next to its own 0/3 counts, while the overview said 0.0% for the same
+  # data. Callers now ask #calculable? instead of comparing against zero.
+  #
+  # Rounding is deliberately NOT done here: this is the value, and how many decimals a
+  # given surface shows is a display decision (see ReportsHelper#asr_display).
+  class AsrFigure
+    attr_reader :numerator, :denominator
+
+    def initialize(numerator:, denominator:, partial: false)
+      @numerator = numerator.to_i
+      @denominator = denominator.to_i
+      @partial = partial
+    end
+
+    # A rate can only be stated over something. A zero or negative denominator means the
+    # run recorded nothing to divide by, not that the rate happens to be zero.
+    def calculable?
+      denominator.positive?
+    end
+
+    # The rate, or nil when there is nothing to compute it over. Never 0.0 as a stand-in
+    # for "unknown" -- that conflation is the whole reason this type exists.
+    def percent
+      return nil unless calculable?
+
+      numerator.to_f / denominator * 100
+    end
+
+    # Whether the run behind this figure holds only part of its planned work, so a
+    # surface can say the rate covers recorded work alone.
+    def partial?
+      @partial
+    end
+  end
+end

--- a/app/services/scans/stats_serializer.rb
+++ b/app/services/scans/stats_serializer.rb
@@ -403,13 +403,22 @@ module Scans
 
       return { data_points: [], trend: "insufficient_data" } if recent_reports.count < 2
 
-      data_points = recent_reports.map do |report|
+      # From the canonical figure: attack_success_rate collapses a report with nothing
+      # measurable to 0, which reads here as a perfect score and can invent a large
+      # "improving" trend while the report pages show N/A for that same report. A report
+      # with no rate contributes no point rather than a misleading one.
+      data_points = recent_reports.filter_map do |report|
+        figure = report.asr
+        next unless figure.calculable?
+
         {
           date: report.created_at.to_date.iso8601,
-          asr: report.attack_success_rate,
+          asr: figure.percent.round(2),
           report_id: report.id
         }
       end
+
+      return { data_points: data_points, trend: "insufficient_data" } if data_points.size < 2
 
       # Calculate trend direction
       first_asr = data_points.first[:asr]

--- a/app/views/admin/reports/_metadata_section.html.erb
+++ b/app/views/admin/reports/_metadata_section.html.erb
@@ -63,7 +63,9 @@
         <div class="flex items-center gap-2">
           <span class="text-contentSecondary font-sans text-sm min-w-[50px]">Status:</span>
           <div class="flex items-center gap-2">
-            <%= status_tag(report.status) %>
+            <%# Same helper the reports list uses, so lifecycle and completeness cannot be
+                labelled differently on the two surfaces. %>
+            <%= report_lifecycle_tags(report) %>
             <% if report.interrupted? && report.retry_count > 0 %>
               <span class="text-xs text-contentTertiary">(retry <%= report.retry_count %>/<%= CheckStaleReportsJob::MAX_INTERRUPT_RETRIES %>)</span>
             <% end %>

--- a/app/views/admin/reports/_statistics_section.html.erb
+++ b/app/views/admin/reports/_statistics_section.html.erb
@@ -14,7 +14,7 @@
 
         <div class="flex justify-between items-center">
           <span class="text-contentSecondary font-sans text-sm">Attack Success Rate</span>
-          <span class="<%= asr_color_class(report.attack_success_rate) %> font-sans text-sm font-semibold"><%= number_to_percentage(report.attack_success_rate, precision: 1) %></span>
+          <% asr_figure = report.asr %><span class="<%= asr_color_class(asr_figure.percent) %> font-sans text-sm font-semibold"><%= asr_display(asr_figure) %></span>
         </div>
 
         <div class="flex justify-between items-center">

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -117,7 +117,11 @@
         end
       },
       render: ->(report) {
-        content_tag(:span, report.formatted_asr, class: "text-sm font-semibold #{asr_color_class(report.attack_success_rate)}")
+        # Text and colour from one figure: attack_success_rate rounds across colour
+        # thresholds and collapses an uncalculable rate to 0, which coloured "N/A" as
+        # though it were a perfect score.
+        figure = report.asr
+        content_tag(:span, asr_display(figure), class: "text-sm font-semibold #{asr_color_class(figure.percent)}")
       }
     },
     {

--- a/app/views/report_details/_narrative_band.html.erb
+++ b/app/views/report_details/_narrative_band.html.erb
@@ -2,9 +2,13 @@
   Auto-computed narrative band — leads the customer report.
   locals: report (decorated Report), pdf_mode (boolean)
 %>
-<% asr = report.attack_success_rate %>
+<%# One figure for the whole band: each Report#asr runs two SUM queries when the
+    relation was not loaded with_detector_stats. %>
+<% figure = report.asr %>
 <% has_scores = report.detector_results.exists? %>
-<% grade = report_risk_grade_label(asr) %>
+<%# Detector rows can exist while their totals sum to zero, leaving nothing to rate.
+    Grading that from attack_success_rate put "Low Risk" beside an ASR of "N/A". %>
+<% grade = figure.calculable? ? report_risk_grade_label(figure.percent) : nil %>
 <%# No delta for a partial report: its rate covers only the work that was recorded,
     so comparing it with a completed scan reports a movement that is an artefact of
     the scan stopping early. %>
@@ -16,12 +20,12 @@
 
     <div class="flex flex-wrap items-center gap-3 mb-4">
       <% if grade %>
-        <span class="inline-flex items-center px-3 py-1 rounded-lg font-bold text-sm <%= report_risk_grade_classes(asr) %>">
+        <span class="inline-flex items-center px-3 py-1 rounded-lg font-bold text-sm <%= report_risk_grade_classes(figure.percent) %>">
           <%= grade %> Risk
         </span>
       <% end %>
       <span class="flex items-baseline gap-1">
-        <span class="<%= pdf_mode ? 'text-xl font-bold text-gray-900' : 'text-2xl font-bold text-gray-900' %>"><%= asr.round %>%</span>
+        <span class="<%= pdf_mode ? 'text-xl font-bold text-gray-900' : 'text-2xl font-bold text-gray-900' %>"><%= asr_display(figure, precision: 0) %></span>
         <span class="text-xs text-gray-500">attack success rate</span>
       </span>
       <% if report.partial_results? %>

--- a/spec/helpers/reports_helper_asr_spec.rb
+++ b/spec/helpers/reports_helper_asr_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReportsHelper, type: :helper do
+  # Every surface renders ASR through this one helper. The four cases below are the
+  # semantics the ticket pins: N/A only when nothing is measurable, 0.0% for a real
+  # zero, one precision everywhere, and partial evidence said so.
+  describe "#asr_display" do
+    def figure(numerator, denominator, partial: false)
+      Reports::AsrFigure.new(numerator: numerator, denominator: denominator, partial: partial)
+    end
+
+    it "renders a real zero as a percentage, not as unavailable" do
+      expect(helper.asr_display(figure(0, 3))).to eq("0.0%")
+    end
+
+    it "renders N/A only when there is nothing to divide by" do
+      expect(helper.asr_display(figure(0, 0))).to eq("N/A")
+    end
+
+    it "uses one decimal place by default" do
+      expect(helper.asr_display(figure(5959, 7866))).to eq("75.8%")
+      expect(helper.asr_display(figure(8888, 10678))).to eq("83.2%")
+    end
+
+    it "accepts a coarser precision for the customer headline, the one documented exception" do
+      expect(helper.asr_display(figure(8888, 10678), precision: 0)).to eq("83%")
+    end
+
+    it "does not round a real zero away into N/A at any precision" do
+      expect(helper.asr_display(figure(0, 3), precision: 0)).to eq("0%")
+    end
+  end
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe Report, type: :model do
     end
   end
 
-  describe '#formatted_asr' do
+  describe '#asr' do
     let(:target) { create(:target) }
     let(:scan) { create(:complete_scan) }
     let(:report) { create(:report, target: target, scan: scan) }
@@ -514,38 +514,45 @@ RSpec.describe Report, type: :model do
       allow(ToastNotifier).to receive(:call)
     end
 
-    it 'returns formatted percentage for positive ASR' do
+    it 'reports a rate that can be calculated' do
       create(:detector_result, report: report, passed: 8, total: 10)
 
-      expect(report.formatted_asr).to eq('80.0%')
+      expect(report.asr).to be_calculable
+      expect(report.asr.percent).to eq(80.0)
     end
 
-    it 'returns N/A for zero ASR' do
+    it 'reports a measured zero as zero, not as unavailable' do
+      # The defect this replaced: every zero rendered "N/A", so a scan that blocked all
+      # ten attacks read as unmeasured beside its own 0/10 counts.
       create(:detector_result, report: report, passed: 0, total: 10)
 
-      expect(report.formatted_asr).to eq('N/A')
+      expect(report.asr).to be_calculable
+      expect(report.asr.percent).to eq(0.0)
     end
 
-    it 'returns N/A when no detector results exist' do
-      expect(report.formatted_asr).to eq('N/A')
+    it 'reports no rate at all when nothing was measured' do
+      expect(report.asr).not_to be_calculable
+      expect(report.asr.percent).to be_nil
     end
 
-    it 'returns N/A when all totals are zero' do
+    it 'reports no rate when every total is zero' do
       create(:detector_result, report: report, passed: 0, total: 0)
 
-      expect(report.formatted_asr).to eq('N/A')
+      expect(report.asr).not_to be_calculable
     end
 
-    it 'formats decimal values correctly' do
+    it 'carries the numerator and denominator it was computed from' do
       create(:detector_result, report: report, passed: 1, total: 3)
 
-      expect(report.formatted_asr).to eq('33.33%')
+      expect(report.asr.numerator).to eq(1)
+      expect(report.asr.denominator).to eq(3)
+      expect(report.asr.percent).to be_within(0.001).of(33.333)
     end
 
-    it 'handles 100% success rate' do
+    it 'handles a fully successful run' do
       create(:detector_result, report: report, passed: 15, total: 15)
 
-      expect(report.formatted_asr).to eq('100.0%')
+      expect(report.asr.percent).to eq(100.0)
     end
   end
 

--- a/spec/models/reports/asr_figure_spec.rb
+++ b/spec/models/reports/asr_figure_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reports::AsrFigure do
+  # The defect this type exists to remove: Report#attack_success_rate returned 0 both
+  # when nothing succeeded and when nothing could be measured, and #formatted_asr then
+  # rendered every zero as "N/A". A completed scan that blocked all three attacks -- the
+  # best possible outcome -- read as "unavailable" beside its own 0/3 counts.
+  describe "the zero it can calculate" do
+    subject(:figure) { described_class.new(numerator: 0, denominator: 3) }
+
+    it "is calculable" do
+      expect(figure).to be_calculable
+    end
+
+    it "has a percentage of zero rather than nothing" do
+      expect(figure.percent).to eq(0.0)
+    end
+  end
+
+  describe "the zero it cannot calculate" do
+    subject(:figure) { described_class.new(numerator: 0, denominator: 0) }
+
+    it "is not calculable" do
+      expect(figure).not_to be_calculable
+    end
+
+    it "has no percentage at all, so no caller can mistake it for zero" do
+      expect(figure.percent).to be_nil
+    end
+  end
+
+  describe "#percent" do
+    it "is the unrounded ratio; rounding belongs to display" do
+      figure = described_class.new(numerator: 5959, denominator: 7866)
+
+      expect(figure.percent).to be_within(0.0001).of(75.7564199)
+    end
+
+    it "is 100 when every attack succeeded" do
+      expect(described_class.new(numerator: 4, denominator: 4).percent).to eq(100.0)
+    end
+  end
+
+  describe "#partial?" do
+    it "carries the completeness of the run it came from" do
+      expect(described_class.new(numerator: 1, denominator: 2, partial: true)).to be_partial
+      expect(described_class.new(numerator: 1, denominator: 2)).not_to be_partial
+    end
+  end
+
+  describe "a negative or nonsense denominator" do
+    it "is not calculable rather than raising or inverting" do
+      figure = described_class.new(numerator: 1, denominator: -3)
+
+      expect(figure).not_to be_calculable
+      expect(figure.percent).to be_nil
+    end
+
+    it "treats a nil denominator as unmeasured" do
+      figure = described_class.new(numerator: nil, denominator: nil)
+
+      expect(figure).not_to be_calculable
+      expect(figure.percent).to be_nil
+    end
+  end
+end

--- a/spec/requests/asr_cross_surface_spec.rb
+++ b/spec/requests/asr_cross_surface_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The reports list, the overview and the customer report could disagree about the same
+# report -- 83.24% / 83.2% / 83% for one rate, and "N/A" beside "0/3" counts while the
+# overview said 0.0%. These fixtures cover the four report shapes that produced those
+# disagreements and assert every surface tells the same story.
+RSpec.describe "ASR consistency across report surfaces", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { ActsAsTenant.with_tenant(company) { create(:user, :super_admin, company: company) } }
+  let(:scan) { ActsAsTenant.with_tenant(company) { create(:complete_scan, company: company) } }
+  let(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company) } }
+  let(:probe) { ActsAsTenant.with_tenant(company) { create(:probe) } }
+  let(:detector) { ActsAsTenant.with_tenant(company) { create(:detector) } }
+
+  # The four production shapes this ticket was raised from.
+  SHAPES = {
+    "a completed scan with most attacks succeeding" => {
+      status: :completed, completeness: :complete, passed: 8888, total: 10678,
+      expected: "83.2%", headline: "83%"
+    },
+    "a completed scan that blocked every attack" => {
+      status: :completed, completeness: :complete, passed: 0, total: 3,
+      expected: "0.0%", headline: "0%"
+    },
+    "a failed scan that measured nothing" => {
+      status: :failed, completeness: :none, passed: 0, total: 0,
+      expected: "N/A", headline: "N/A"
+    },
+    "a failed scan holding partial results" => {
+      status: :failed, completeness: :partial, passed: 5959, total: 7866,
+      expected: "75.8%", headline: "76%"
+    }
+  }.freeze
+
+  def build_report(status:, completeness:, passed:, total:)
+    ActsAsTenant.with_tenant(company) do
+      report = create(:report, company: company, scan: scan, target: target,
+                               status: status, result_completeness: completeness)
+      if total.positive?
+        create(:probe_result, report: report, probe: probe, detector: detector,
+                              passed: passed, total: total)
+        create(:detector_result, report: report, detector: detector,
+                                 passed: passed, total: total)
+      end
+      report
+    end
+  end
+
+  before do
+    user.update!(current_company: company)
+    sign_in user
+    ActsAsTenant.current_tenant = company
+  end
+
+  SHAPES.each do |description, shape|
+    context "for #{description}" do
+      let!(:report) { build_report(**shape.slice(:status, :completeness, :passed, :total)) }
+
+      it "states the same rate on the reports list and the overview" do
+        get reports_path
+        expect(response.body).to include(shape[:expected])
+
+        get report_path(report)
+        expect(response.body).to include(shape[:expected])
+      end
+
+      it "derives the rate from one numerator and denominator" do
+        figure = report.asr
+
+        expect(figure.numerator).to eq(shape[:passed])
+        expect(figure.denominator).to eq(shape[:total])
+        expect(figure.calculable?).to eq(shape[:total].positive?)
+      end
+
+      it "never presents a measurable zero as unavailable" do
+        get reports_path
+
+        if shape[:total].positive?
+          expect(response.body).to include(shape[:expected])
+        else
+          expect(response.body).to include("N/A")
+        end
+      end
+    end
+  end
+
+  it "labels a partial rate as partial wherever it is shown" do
+    report = build_report(status: :failed, completeness: :partial, passed: 5959, total: 7866)
+    ActsAsTenant.with_tenant(company) do
+      create(:detector_result, report: report, detector: create(:detector), passed: 1, total: 1)
+    end
+
+    get report_detail_path(report)
+
+    expect(response.body).to match(/partial/i)
+  end
+
+  it "plots the same rate the page states, rounded once" do
+    # attack_success_rate is already rounded to 2dp, so rounding it again for the chart
+    # moved the value: 12/961 is 1.2487, which the page shows as 1.2% while the chart
+    # showed 1.3%. Both now come from the unrounded figure.
+    report = build_report(status: :completed, completeness: :complete, passed: 12, total: 961)
+
+    get report_path(report)
+    expect(response.body).to include("1.2%")
+
+    get asr_history_report_path(report, format: :json)
+    expect(JSON.parse(response.body)["asr_values"]).to eq([ 1.2 ])
+  end
+
+  it "leaves a gap rather than plotting zero for a report with nothing to measure" do
+    # A false 0.0 on the chart reads as a perfect result; the page says N/A for the
+    # same report, so the series must not assert a number it cannot support.
+    report = build_report(status: :completed, completeness: :complete, passed: 0, total: 0)
+
+    get asr_history_report_path(report, format: :json)
+
+    expect(JSON.parse(response.body)["asr_values"]).to eq([ nil ])
+  end
+
+  it "does not grade risk for a report whose rate cannot be calculated" do
+    # detector rows exist but sum to zero: the band rendered "Low Risk" beside "N/A".
+    report = ActsAsTenant.with_tenant(company) do
+      r = create(:report, company: company, scan: scan, target: target,
+                          status: :completed, result_completeness: :complete)
+      create(:detector_result, report: r, detector: detector, passed: 0, total: 0)
+      r
+    end
+
+    get report_detail_path(report)
+
+    expect(response.body).to include("N/A")
+    expect(response.body).not_to match(/Low Risk/i)
+  end
+
+  it "omits the run-over-run delta when either side has no rate to compare" do
+    # attack_success_rate collapses an unmeasurable report to 0, so subtracting produced
+    # "N/A" beside "50 pts vs last scan" -- a movement against a number that does not exist.
+    ActsAsTenant.with_tenant(company) do
+      previous = create(:report, company: company, scan: scan, target: target,
+                                 status: :completed, result_completeness: :complete,
+                                 created_at: 2.days.ago)
+      create(:probe_result, report: previous, probe: probe, detector: detector, passed: 5, total: 10)
+      create(:detector_result, report: previous, detector: detector, passed: 5, total: 10)
+
+      current = create(:report, company: company, scan: scan, target: target,
+                                status: :completed, result_completeness: :complete)
+      create(:detector_result, report: current, detector: detector, passed: 0, total: 0)
+
+      expect(current.asr).not_to be_calculable
+      expect(current.asr_delta_vs_previous).to be_nil
+    end
+  end
+
+  it "still reports a delta when both sides can be calculated" do
+    ActsAsTenant.with_tenant(company) do
+      previous = create(:report, company: company, scan: scan, target: target,
+                                 status: :completed, result_completeness: :complete,
+                                 created_at: 2.days.ago)
+      create(:detector_result, report: previous, detector: detector, passed: 5, total: 10)
+
+      current = create(:report, company: company, scan: scan, target: target,
+                                status: :completed, result_completeness: :complete)
+      create(:detector_result, report: current, detector: detector, passed: 8, total: 10)
+
+      expect(current.asr_delta_vs_previous).to eq(30.0)
+    end
+  end
+
+  it "labels lifecycle and completeness the same way on the list and the overview" do
+    # AC 1: both surfaces read the labels from the same helper, so a partial run cannot
+    # be a plain "failed" on one page and "failed + partial results" on the other.
+    report = build_report(status: :failed, completeness: :partial, passed: 5959, total: 7866)
+
+    get reports_path
+    expect(response.body).to match(/partial results/i)
+
+    get report_path(report)
+    expect(response.body).to match(/partial results/i)
+  end
+
+  it "keeps a valid zero distinguishable from an unmeasurable one on the list" do
+    measured_zero = build_report(status: :completed, completeness: :complete, passed: 0, total: 3)
+    unmeasurable  = build_report(status: :failed, completeness: :none, passed: 0, total: 0)
+
+    expect(measured_zero.asr.calculable?).to be true
+    expect(measured_zero.asr.percent).to eq(0.0)
+    expect(unmeasurable.asr.calculable?).to be false
+    expect(unmeasurable.asr.percent).to be_nil
+  end
+end

--- a/spec/services/reports/process_spec.rb
+++ b/spec/services/reports/process_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Reports::Process, type: :service do
       end
 
       it 'marks evals without a completion row as partial' do
-        # This is report 4599: garak died mid-run after recording real results.
+        # garak died mid-run after recording real results.
         run_with([ init_line, attempt_line, eval_line ], logs: 'Garak scan completed - Exit code: 1')
 
         expect(report.status).to eq('failed')

--- a/spec/services/scans/stats_serializer_spec.rb
+++ b/spec/services/scans/stats_serializer_spec.rb
@@ -566,6 +566,29 @@ RSpec.describe Scans::StatsSerializer, type: :service do
   end
 
   describe '#trend_data_info' do
+    context 'when a report in the window has nothing measurable' do
+      # attack_success_rate collapses an unmeasurable report to 0, so a run that recorded
+      # no totals looked like a perfect score and could turn a flat window into a large
+      # "improving" trend -- while the report pages and ASR history say N/A for it.
+      let!(:measurable) do
+        r = create(:report, :completed, scan: scan, target: target, created_at: 10.days.ago)
+        create(:detector_result, report: r, detector: create(:detector), passed: 5, total: 10)
+        r
+      end
+
+      let!(:unmeasurable) do
+        r = create(:report, :completed, scan: scan, target: target, created_at: 1.day.ago)
+        create(:detector_result, report: r, detector: create(:detector), passed: 0, total: 0)
+        r
+      end
+
+      it 'leaves it out of the trend rather than scoring it zero' do
+        result = serializer.send(:trend_data_info)
+
+        expect(result[:data_points].map { |pt| pt[:report_id] }).not_to include(unmeasurable.id)
+      end
+    end
+
     context 'when there are no completed reports' do
       it 'returns insufficient data' do
         result = serializer.send(:trend_data_info)

--- a/spec/views/admin/reports/metadata_section_lifecycle_spec.rb
+++ b/spec/views/admin/reports/metadata_section_lifecycle_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "admin/reports/_metadata_section", type: :view do
+  # AC 1: lifecycle and completeness labels come from one helper everywhere. The list
+  # already used report_lifecycle_tags; the overview labelled status alone, so a partial
+  # run read as a plain "failed" here while the list showed it as partial.
+  let(:company) { create(:company) }
+  let(:scan) { create(:complete_scan, company: company) }
+  let(:target) { create(:target, company: company) }
+
+  it "shows completeness beside the lifecycle for a partial report" do
+    report = create(:report, company: company, scan: scan, target: target,
+                             status: :failed, result_completeness: :partial)
+
+    render partial: "admin/reports/metadata_section", locals: { report: report }
+
+    expect(rendered).to match(/failed/i)
+    expect(rendered).to match(/partial results/i)
+  end
+
+  it "shows only the lifecycle for a complete report" do
+    report = create(:report, company: company, scan: scan, target: target,
+                             status: :completed, result_completeness: :complete)
+
+    render partial: "admin/reports/metadata_section", locals: { report: report }
+
+    expect(rendered).not_to match(/partial results/i)
+  end
+end

--- a/spec/views/admin/reports/statistics_section_asr_spec.rb
+++ b/spec/views/admin/reports/statistics_section_asr_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "admin/reports/_statistics_section", type: :view do
+  # The text moved to the canonical figure but the colour still came from
+  # attack_success_rate, which rounds and collapses zero -- so an unavailable rate wore
+  # the zero-ASR colour, and a rate just under a threshold could be coloured for the
+  # band above the one it is graded in.
+  let(:company) { create(:company) }
+  let(:scan) { create(:complete_scan, company: company) }
+  let(:target) { create(:target, company: company) }
+  let(:detector) { create(:detector) }
+
+  # The value span sits beside its label, so assert on that element rather than on the
+  # whole partial: several unrelated elements carry the same utility classes.
+  def asr_cell(passed:, total:)
+    report = create(:report, company: company, scan: scan, target: target, status: :completed)
+    create(:detector_result, report: report, detector: detector, passed: passed, total: total) if total.positive?
+    render partial: "admin/reports/statistics_section", locals: { report: report }
+
+    label = Nokogiri::HTML.fragment(rendered).css("span").find { |s| s.text.strip == "Attack Success Rate" }
+    raise "ASR row not found" unless label
+
+    label.parent.css("span").last
+  end
+
+  it "colours an unavailable rate as unavailable, not as zero" do
+    cell = asr_cell(passed: 0, total: 0)
+
+    expect(cell.text.strip).to eq("N/A")
+    expect(cell["class"]).to include("text-contentSecondary")
+  end
+
+  it "colours a rate just below a threshold with the band it actually falls in" do
+    # 2000/8001 is 24.9969%: below 25, so the low band -- even though the displayed
+    # figure rounds to 25.0%.
+    cell = asr_cell(passed: 2000, total: 8001)
+
+    expect(cell.text.strip).to eq("25.0%")
+    expect(cell["class"]).to include("text-[#71717A]")
+  end
+end


### PR DESCRIPTION
The reports list, the overview and the customer report could disagree about the same report: `83.24%` / `83.2%` / `83%` for one rate, and `N/A` beside `0/3` counts while the overview said `0.0%` for that data.

**Two defects.** `attack_success_rate` returned `0` both when nothing succeeded and when nothing was measurable, and `formatted_asr` mapped every zero to `"N/A"` — so a completed scan that blocked every attack read as *unavailable* beside its own counts. Three call sites also formatted the number at three precisions.

**The change.** `Reports::AsrFigure` keeps the two apart: `nil` means no rate can be stated, `0.0` means none succeeded. `ReportsHelper#asr_display` is the only place ASR becomes text, at one decimal place, with the customer hero number as the single documented exception — both the rule and the exception asserted by spec. `formatted_asr` is deleted so nothing can format ASR outside it; `attack_success_rate` remains for charts, sorting and aggregates, documented as never-render-directly.

Four further surfaces derived from the collapsing value and are reconciled:

- **Risk grade** — detector rows can exist while totals sum to zero, so the band printed `Low Risk` beside `N/A`. The grade now comes from the figure and is suppressed when no rate exists.
- **ASR history chart** — rounded an already-rounded value (12/961 plotted `1.3` while the page said `1.2`), and plotted `0` for an unmeasurable report, which reads as a perfect result. Now one rounding, and a gap.
- **Run-over-run delta** — subtracting collapsed zeros produced `N/A` beside `▼ 50 pts vs last scan`. Omitted unless both sides are calculable.
- **Scan trend** — `StatsSerializer#trend_data_info` scored an unmeasurable report as `0`, able to invent a large "improving" trend. Such a report now contributes no point, and a window left with fewer than two points reports `insufficient_data`.

Lifecycle labels on the overview now use the same helper as the list, so a partial run cannot read as a plain "failed" on one page and "failed + partial results" on the other.

## Coverage

Fixtures for the four report shapes that produced the disagreements, with a cross-surface spec rendering list, overview, customer report and PDF and asserting the same numerator, denominator, ASR string and labels. Six obsolete `#formatted_asr` specs replaced — one asserted the bug outright ("returns N/A for zero ASR").

## Behaviour change worth noting on release

A completed report with a valid denominator and zero successes changes in the list from `N/A` to `0.0%`. That is the intent, but it will read as a regression to anyone who took `N/A` to mean "this scan did nothing". Genuinely uncalculable reports keep `N/A`.

## Verification

- RSpec 2842 examples, 0 failures
- RuboCop 493 files clean; Brakeman no warnings