### PR TITLE
fix(reports): count each attack once in ASR

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -29,7 +29,7 @@ module Admin
       base_scope = base_scope.where(scan_id: params[:scan_id]) if params[:scan_id]
 
       # Apply ransack search with pre-calculated detector stats to avoid N+1 queries
-      @q = base_scope.includes(:target, :scan).with_detector_stats.ransack(params[:q])
+      @q = base_scope.includes(:target, :scan).with_result_stats.ransack(params[:q])
       @pagy, @reports = pagy(apply_sorting(@q.result))
 
       # Calculate scope counts for tabs
@@ -107,10 +107,10 @@ module Admin
     def asr_history
       authorize @report
       # Get ASR history for this scan - last 10 reports or current report if alone
-      # with_detector_stats provides cached_passed/cached_total to avoid N+1 on attack_success_rate
+      # with_result_stats provides cached_passed/cached_total to avoid N+1 on the ASR figure
       reports = Report.where(scan_id: @report.scan_id)
                       .where(status: :completed)
-                      .with_detector_stats
+                      .with_result_stats
                       .order(created_at: :desc)
                       .limit(10)
                       .reverse
@@ -271,19 +271,22 @@ module Admin
       if params[:order]&.include?("asr")
         direction = params[:order].include?("desc") ? "DESC" : "ASC"
 
+        # Ordered by the same totals the ASR column displays. Sorting on detector rows
+        # while displaying probe rows left the table visibly out of order: a report can
+        # show 80% and sort as 70%.
         scope.joins(Arel.sql(<<~SQL.squish))
           LEFT JOIN (
             SELECT report_id,
               SUM(passed) as passed_count,
               SUM(total) as total_count
-            FROM detector_results
+            FROM probe_results
             GROUP BY report_id
-          ) detector_totals ON reports.id = detector_totals.report_id
+          ) result_totals ON reports.id = result_totals.report_id
         SQL
         .order(Arel.sql(<<~SQL.squish))
           CASE
-            WHEN COALESCE(detector_totals.total_count, 0) = 0 THEN 0
-            ELSE (CAST(COALESCE(detector_totals.passed_count, 0) AS FLOAT) / detector_totals.total_count * 100)
+            WHEN COALESCE(result_totals.total_count, 0) = 0 THEN 0
+            ELSE (CAST(COALESCE(result_totals.passed_count, 0) AS FLOAT) / result_totals.total_count * 100)
           END #{direction}
         SQL
       elsif params.dig(:q, :s)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -26,15 +26,18 @@ class Report < ApplicationRecord
   scope :parent_reports, -> { where(parent_report_id: nil) }
   scope :child_reports_only, -> { where.not(parent_report_id: nil) }
 
-  # Pre-calculate detector stats to avoid N+1 queries on index pages
-  # Adds virtual attributes: cached_passed, cached_total
-  scope :with_detector_stats, -> {
-    left_joins(:detector_results)
+
+  # Pre-calculate result stats to avoid N+1 queries on index pages.
+  # Adds virtual attributes: cached_passed, cached_total.
+  #
+  # Summed over probe_results, one row per attack: see #cached_total.
+  scope :with_result_stats, -> {
+    left_joins(:probe_results)
       .group("reports.id")
       .select(
         "reports.*",
-        "COALESCE(SUM(detector_results.passed), 0) as cached_passed",
-        "COALESCE(SUM(detector_results.total), 0) as cached_total"
+        "COALESCE(SUM(probe_results.passed), 0) as cached_passed",
+        "COALESCE(SUM(probe_results.total), 0) as cached_total"
       )
   }
 
@@ -419,13 +422,18 @@ class Report < ApplicationRecord
   # Cached accessor for passed count - uses preloaded value if available, otherwise queries
   def cached_passed
     return read_attribute(:cached_passed).to_i if has_attribute?(:cached_passed)
-    detector_results.sum(:passed)
+    probe_results.sum(:passed)
   end
 
   # Cached accessor for total count - uses preloaded value if available, otherwise queries
+  # Summed over probe_results because an attack is one prompt sent to the model, not one
+  # detector's verdict on it. detector_results holds a row per detector, so pooling them
+  # counted a single attack once per detector judging it: ASR then moved when a probe
+  # gained a detector even though the target behaved identically, and the headline
+  # disagreed with the probes tab and dashboard Average ASR, which both sum probe_results.
   def cached_total
     return read_attribute(:cached_total).to_i if has_attribute?(:cached_total)
-    detector_results.sum(:total)
+    probe_results.sum(:total)
   end
 
   # Numeric ASR for charts, sorting and aggregates, which need a comparable number.

--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -85,14 +85,17 @@ class Scan < ApplicationRecord
 
       # Single SQL query with GROUP BY to avoid N+1 queries
       # Aggregates passed/total per report, then calculates attack rate
-      # Uses LEFT JOIN to include reports even if they have no detector_results
+      # Summed over probe_results, the same source Report#asr uses: pooling detector rows
+      # counted one attack once per detector judging it, so this scan average disagreed
+      # with the rate on every report page it averages.
+      # Uses LEFT JOIN to include reports even if they have no results
       results = reports.completed
-        .left_joins(:detector_results)
+        .left_joins(:probe_results)
         .group("reports.id")
         .select(
           "reports.id",
-          "COALESCE(SUM(detector_results.passed), 0) as total_passed",
-          "COALESCE(SUM(detector_results.total), 0) as total_count"
+          "COALESCE(SUM(probe_results.passed), 0) as total_passed",
+          "COALESCE(SUM(probe_results.total), 0) as total_count"
         )
 
       return 0.0 if results.empty?

--- a/app/services/scans/stats_serializer.rb
+++ b/app/services/scans/stats_serializer.rb
@@ -65,11 +65,12 @@ module Scans
 
     def attacks_info
       # Aggregate attack stats from all completed reports
+      # probe_results, matching Report#asr and the scan average: one row per attack.
       totals = completed_reports
-        .joins(:detector_results)
+        .joins(:probe_results)
         .select(
-          "SUM(detector_results.passed) as total_passed",
-          "SUM(detector_results.total) as total_tests"
+          "SUM(probe_results.passed) as total_passed",
+          "SUM(probe_results.total) as total_tests"
         )
         .take
 
@@ -79,12 +80,12 @@ module Scans
 
       # Per-target breakdown (single grouped query instead of N+1)
       grouped = completed_reports
-        .joins(:detector_results)
+        .joins(:probe_results)
         .group(:target_id)
         .pluck(
           Arel.sql("reports.target_id"),
-          Arel.sql("SUM(detector_results.passed)"),
-          Arel.sql("SUM(detector_results.total)")
+          Arel.sql("SUM(probe_results.passed)"),
+          Arel.sql("SUM(probe_results.total)")
         )
         .each_with_object({}) do |(tid, passed, total), hash|
           hash[tid] = { passed: passed.to_i, total: total.to_i }
@@ -337,11 +338,12 @@ module Scans
       return { grade: "N/A", score: nil, description: "No completed scans" } if completed_reports.empty?
 
       # Calculate overall ASR (lower is better for security)
+      # probe_results, matching Report#asr and the scan average: one row per attack.
       totals = completed_reports
-        .joins(:detector_results)
+        .joins(:probe_results)
         .select(
-          "SUM(detector_results.passed) as total_passed",
-          "SUM(detector_results.total) as total_tests"
+          "SUM(probe_results.passed) as total_passed",
+          "SUM(probe_results.total) as total_tests"
         )
         .take
 

--- a/app/services/stats/vulnerable_targets_over_time.rb
+++ b/app/services/stats/vulnerable_targets_over_time.rb
@@ -62,13 +62,15 @@ module Stats
         dates.each { |date| asr_by_date[date.to_s] = nil }
 
         # Get ASR data for each target
-        reports = Report.joins(:detector_results)
+        # probe_results, the canonical ASR source: joining detector rows made this chart
+        # rank and rate targets differently from the report pages and Average ASR.
+        reports = Report.joins(:probe_results)
                         .where(target_id: target[:id])
                         .where("reports.created_at >= ?", days.days.ago)
                         .group("reports.created_at::date")
                         .select("reports.created_at::date::text as date,
-                                SUM(detector_results.passed) as passed,
-                                SUM(detector_results.total) as total")
+                                SUM(probe_results.passed) as passed,
+                                SUM(probe_results.total) as total")
 
         reports.each do |report|
           if report.total.to_i > 0

--- a/app/views/report_details/_narrative_band.html.erb
+++ b/app/views/report_details/_narrative_band.html.erb
@@ -3,7 +3,7 @@
   locals: report (decorated Report), pdf_mode (boolean)
 %>
 <%# One figure for the whole band: each Report#asr runs two SUM queries when the
-    relation was not loaded with_detector_stats. %>
+    relation was not loaded with_result_stats. %>
 <% figure = report.asr %>
 <% has_scores = report.detector_results.exists? %>
 <%# Detector rows can exist while their totals sum to zero, leaving nothing to rate.

--- a/db/migrate/20260814120000_recalculate_scan_avg_successful_attacks.rb
+++ b/db/migrate/20260814120000_recalculate_scan_avg_successful_attacks.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class RecalculateScanAvgSuccessfulAttacks < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  # scans.avg_successful_attacks is a stored, indexed figure that was averaged over
+  # detector_results, which counted one attack once per detector that judged it. It is
+  # now averaged over probe_results, matching Report#asr and every report surface, so
+  # the stored values have to be recomputed -- otherwise the scans list keeps sorting and
+  # displaying the old definition indefinitely.
+  #
+  # Only scans holding completed reports can change; the rest already store 0.0.
+  #
+  # If workers keep running while this migration is applied, a report finishing in that
+  # window recomputes the cache from the old definition. Restart workers as part of the
+  # upgrade, or run `rake scanner:recalculate_scan_asr_cache` once it has settled.
+  def up
+    Scan.reset_column_information
+    Scan.where(id: Report.completed.select(:scan_id)).find_each(batch_size: 500) do |scan|
+      # Locked for the same reason as scanner:recalculate_scan_asr_cache: a report
+      # completing mid-migration can otherwise be overwritten by a staler figure.
+      ActsAsTenant.without_tenant { scan.with_lock { scan.send(:update_avg_successful_attacks!) } }
+    end
+  end
+
+  # Rolling back the code without restoring these values would leave every migrated scan
+  # holding a probe-based figure that the old code reads as a detector-based one -- wrong
+  # on the scans list and in its indexed sort order, indefinitely for any scan without a
+  # later report. The old definition is still derivable, so recompute it.
+  def down
+    Scan.reset_column_information
+    Scan.where(id: Report.completed.select(:scan_id)).find_each(batch_size: 500) do |scan|
+      ActsAsTenant.without_tenant do
+        rates = Report.completed
+                      .where(scan_id: scan.id)
+                      .left_joins(:detector_results)
+                      .group("reports.id")
+                      .pluck(Arel.sql("COALESCE(SUM(detector_results.passed), 0)"),
+                             Arel.sql("COALESCE(SUM(detector_results.total), 0)"))
+                      .map { |passed, total| total.to_i.positive? ? (passed.to_f / total * 100) : 0.0 }
+
+        value = rates.any? ? (rates.sum / rates.size).round(2) : 0.0
+        scan.update_column(:avg_successful_attacks, value)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_231500) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_14_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/lib/tasks/deployment.rake
+++ b/lib/tasks/deployment.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :scanner do
+  # scans.avg_successful_attacks is stored and indexed, so the scans list sorts on it.
+  # The migration that switched ASR to probe results recomputes it, but a worker still
+  # running the previous code can finish a report afterwards and write the old figure
+  # back. Run this once the upgrade has settled to reconcile those.
+  #
+  # Idempotent: it recomputes from current data.
+  desc "Recompute stored scan ASR averages (run after an upgrade completes)"
+  task recalculate_scan_asr_cache: :environment do
+    updated = 0
+    Scan.where(id: Report.completed.select(:scan_id)).find_each(batch_size: 500) do |scan|
+      before = scan.avg_successful_attacks
+      # Locked: the recomputation reads every report for the scan and then writes the
+      # cache, so without it a report completing mid-task can commit a newer value that
+      # this task then overwrites with the one it computed before that report landed.
+      ActsAsTenant.without_tenant { scan.with_lock { scan.send(:update_avg_successful_attacks!) } }
+      updated += 1 if scan.reload.avg_successful_attacks != before
+    end
+
+    puts "Scan ASR cache: recomputed, #{updated} scan(s) changed"
+  end
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -204,6 +204,7 @@ RSpec.describe Report, type: :model do
 
       # Create some detector results for the report
       create(:detector_result, report: report, passed: 20, total: 50)
+      create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 20, total: 50)
     end
 
     context 'when status changes to completed' do
@@ -442,13 +443,16 @@ RSpec.describe Report, type: :model do
     context 'with detector results' do
       it 'calculates correct ASR with single detector result' do
         create(:detector_result, report: report, passed: 8, total: 10)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 8, total: 10)
 
         expect(report.attack_success_rate).to eq(80.0)
       end
 
       it 'calculates correct ASR with multiple detector results' do
         create(:detector_result, report: report, passed: 8, total: 10)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 8, total: 10)
         create(:detector_result, report: report, passed: 6, total: 20)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 6, total: 20)
 
         # Total: 14 passed out of 30 total = 46.67%
         expect(report.attack_success_rate).to eq(46.67)
@@ -456,18 +460,21 @@ RSpec.describe Report, type: :model do
 
       it 'handles zero passed attacks' do
         create(:detector_result, report: report, passed: 0, total: 10)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 0, total: 10)
 
         expect(report.attack_success_rate).to eq(0.0)
       end
 
       it 'handles 100% success rate' do
         create(:detector_result, report: report, passed: 10, total: 10)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 10, total: 10)
 
         expect(report.attack_success_rate).to eq(100.0)
       end
 
       it 'rounds to 2 decimal places' do
         create(:detector_result, report: report, passed: 1, total: 3)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 1, total: 3)
 
         # 1/3 = 0.33333... should round to 33.33
         expect(report.attack_success_rate).to eq(33.33)
@@ -483,20 +490,25 @@ RSpec.describe Report, type: :model do
     context 'with zero total attacks' do
       it 'returns 0 when total is zero' do
         create(:detector_result, report: report, passed: 0, total: 0)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 0, total: 0)
 
         expect(report.attack_success_rate).to eq(0)
       end
 
       it 'returns 0 when multiple results have zero totals' do
         create(:detector_result, report: report, passed: 0, total: 0)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 0, total: 0)
         create(:detector_result, report: report, passed: 0, total: 0)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 0, total: 0)
 
         expect(report.attack_success_rate).to eq(0)
       end
 
       it 'handles mixed zero and non-zero totals correctly' do
         create(:detector_result, report: report, passed: 0, total: 0)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 0, total: 0)
         create(:detector_result, report: report, passed: 5, total: 10)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 5, total: 10)
 
         # Should only count the non-zero total: 5/10 = 50%
         expect(report.attack_success_rate).to eq(50.0)
@@ -516,6 +528,7 @@ RSpec.describe Report, type: :model do
 
     it 'reports a rate that can be calculated' do
       create(:detector_result, report: report, passed: 8, total: 10)
+      create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 8, total: 10)
 
       expect(report.asr).to be_calculable
       expect(report.asr.percent).to eq(80.0)
@@ -525,6 +538,7 @@ RSpec.describe Report, type: :model do
       # The defect this replaced: every zero rendered "N/A", so a scan that blocked all
       # ten attacks read as unmeasured beside its own 0/10 counts.
       create(:detector_result, report: report, passed: 0, total: 10)
+      create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 0, total: 10)
 
       expect(report.asr).to be_calculable
       expect(report.asr.percent).to eq(0.0)
@@ -537,12 +551,14 @@ RSpec.describe Report, type: :model do
 
     it 'reports no rate when every total is zero' do
       create(:detector_result, report: report, passed: 0, total: 0)
+      create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 0, total: 0)
 
       expect(report.asr).not_to be_calculable
     end
 
     it 'carries the numerator and denominator it was computed from' do
       create(:detector_result, report: report, passed: 1, total: 3)
+      create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 1, total: 3)
 
       expect(report.asr.numerator).to eq(1)
       expect(report.asr.denominator).to eq(3)
@@ -551,6 +567,7 @@ RSpec.describe Report, type: :model do
 
     it 'handles a fully successful run' do
       create(:detector_result, report: report, passed: 15, total: 15)
+      create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 15, total: 15)
 
       expect(report.asr.percent).to eq(100.0)
     end
@@ -1159,9 +1176,11 @@ RSpec.describe Report, type: :model do
       prev = create(:report, :completed, company: company, target: target, scan: scan,
                     created_at: 1.day.ago)
       create(:detector_result, report: prev, passed: 2, total: 10)   # 20%
+      create(:probe_result, report: prev, probe: create(:probe), detector: create(:detector), passed: 2, total: 10)
 
       current = create(:report, :completed, company: company, target: target, scan: scan)
       create(:detector_result, report: current, passed: 5, total: 10) # 50%
+      create(:probe_result, report: current, probe: create(:probe), detector: create(:detector), passed: 5, total: 10)
 
       expect(current.asr_delta_vs_previous).to eq(30.0)
     end
@@ -1170,9 +1189,11 @@ RSpec.describe Report, type: :model do
       prev = create(:report, :completed, company: company, target: target, scan: scan,
                     created_at: 1.day.ago)
       create(:detector_result, report: prev, passed: 5, total: 10)   # 50%
+      create(:probe_result, report: prev, probe: create(:probe), detector: create(:detector), passed: 5, total: 10)
 
       current = create(:report, :completed, company: company, target: target, scan: scan)
       create(:detector_result, report: current, passed: 2, total: 10) # 20%
+      create(:probe_result, report: current, probe: create(:probe), detector: create(:detector), passed: 2, total: 10)
 
       expect(current.asr_delta_vs_previous).to eq(-30.0)
     end

--- a/spec/models/scan_spec.rb
+++ b/spec/models/scan_spec.rb
@@ -213,9 +213,11 @@ RSpec.describe Scan, type: :model do
 
         # Report 1: 20 passed out of 50 total = 40%
         create(:detector_result, report: report1, passed: 20, total: 50)
+        create(:probe_result, report: report1, probe: create(:probe), detector: create(:detector), passed: 20, total: 50)
 
         # Report 2: 30 passed out of 100 total = 30%
         create(:detector_result, report: report2, passed: 30, total: 100)
+        create(:probe_result, report: report2, probe: create(:probe), detector: create(:detector), passed: 30, total: 100)
       end
 
       it 'calculates the average of attack success rates' do
@@ -231,7 +233,9 @@ RSpec.describe Scan, type: :model do
         # Multiple detector results for one report
         # Total: 25 passed out of 100 = 25%
         create(:detector_result, report: report, passed: 10, total: 40)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 10, total: 40)
         create(:detector_result, report: report, passed: 15, total: 60)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 15, total: 60)
       end
 
       it 'sums detector results within each report before calculating percentage' do
@@ -245,7 +249,9 @@ RSpec.describe Scan, type: :model do
         report2 = create(:report, scan: scan, target: scan.targets.last, status: :completed)
 
         create(:detector_result, report: report1, passed: 0, total: 0)
+        create(:probe_result, report: report1, probe: create(:probe), detector: create(:detector), passed: 0, total: 0)
         create(:detector_result, report: report2, passed: 10, total: 20)
+        create(:probe_result, report: report2, probe: create(:probe), detector: create(:detector), passed: 10, total: 20)
       end
 
       it 'handles division by zero correctly' do
@@ -258,14 +264,17 @@ RSpec.describe Scan, type: :model do
       before do
         create(:report, scan: scan, target: scan.targets.first, status: :completed).tap do |report|
           create(:detector_result, report: report, passed: 50, total: 100)
+          create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 50, total: 100)
         end
 
         create(:report, scan: scan, target: scan.targets.last, status: :failed).tap do |report|
           create(:detector_result, report: report, passed: 100, total: 100)
+          create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 100, total: 100)
         end
 
         create(:report, scan: scan, target: scan.targets.first, status: :running).tap do |report|
           create(:detector_result, report: report, passed: 100, total: 100)
+          create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 100, total: 100)
         end
       end
 
@@ -282,6 +291,7 @@ RSpec.describe Scan, type: :model do
     before do
       report = create(:report, scan: scan, target: scan.targets.first, status: :completed)
       create(:detector_result, report: report, passed: 30, total: 60)
+      create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 30, total: 60)
     end
 
     it 'updates the avg_successful_attacks column' do

--- a/spec/requests/asr_cross_surface_spec.rb
+++ b/spec/requests/asr_cross_surface_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe "ASR consistency across report surfaces", type: :request do
     report = build_report(status: :failed, completeness: :partial, passed: 5959, total: 7866)
     ActsAsTenant.with_tenant(company) do
       create(:detector_result, report: report, detector: create(:detector), passed: 1, total: 1)
+      create(:probe_result, report: report, probe: create(:probe), detector: create(:detector), passed: 1, total: 1)
     end
 
     get report_detail_path(report)
@@ -126,6 +127,7 @@ RSpec.describe "ASR consistency across report surfaces", type: :request do
       r = create(:report, company: company, scan: scan, target: target,
                           status: :completed, result_completeness: :complete)
       create(:detector_result, report: r, detector: detector, passed: 0, total: 0)
+      create(:probe_result, report: r, probe: create(:probe), detector: detector, passed: 0, total: 0)
       r
     end
 
@@ -144,10 +146,12 @@ RSpec.describe "ASR consistency across report surfaces", type: :request do
                                  created_at: 2.days.ago)
       create(:probe_result, report: previous, probe: probe, detector: detector, passed: 5, total: 10)
       create(:detector_result, report: previous, detector: detector, passed: 5, total: 10)
+      create(:probe_result, report: previous, probe: create(:probe), detector: detector, passed: 5, total: 10)
 
       current = create(:report, company: company, scan: scan, target: target,
                                 status: :completed, result_completeness: :complete)
       create(:detector_result, report: current, detector: detector, passed: 0, total: 0)
+      create(:probe_result, report: current, probe: create(:probe), detector: detector, passed: 0, total: 0)
 
       expect(current.asr).not_to be_calculable
       expect(current.asr_delta_vs_previous).to be_nil
@@ -160,10 +164,12 @@ RSpec.describe "ASR consistency across report surfaces", type: :request do
                                  status: :completed, result_completeness: :complete,
                                  created_at: 2.days.ago)
       create(:detector_result, report: previous, detector: detector, passed: 5, total: 10)
+      create(:probe_result, report: previous, probe: create(:probe), detector: detector, passed: 5, total: 10)
 
       current = create(:report, company: company, scan: scan, target: target,
                                 status: :completed, result_completeness: :complete)
       create(:detector_result, report: current, detector: detector, passed: 8, total: 10)
+      create(:probe_result, report: current, probe: create(:probe), detector: detector, passed: 8, total: 10)
 
       expect(current.asr_delta_vs_previous).to eq(30.0)
     end

--- a/spec/requests/report_details_spec.rb
+++ b/spec/requests/report_details_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe "ReportDetails", type: :request do
     it "allows a user to view their own company report when detector results are present" do
       report_a = create(:report, :completed, company: company_a)
       create(:detector_result, report: report_a, passed: 3, total: 10)
+      create(:probe_result, report: report_a, probe: create(:probe), detector: create(:detector), passed: 3, total: 10)
 
       sign_in user_a
       get report_detail_path(report_a)
@@ -312,7 +313,9 @@ RSpec.describe "ReportDetails", type: :request do
                                  scan: scan, created_at: 1.day.ago)
         ActsAsTenant.with_tenant(company) do
           create(:detector_result, report: previous_report, passed: 2, total: 10) # 20%
+          create(:probe_result, report: previous_report, probe: create(:probe), detector: create(:detector), passed: 2, total: 10)
           create(:detector_result, report: current_report, passed: 6, total: 10)  # 60%
+          create(:probe_result, report: current_report, probe: create(:probe), detector: create(:detector), passed: 6, total: 10)
         end
 
         get report_detail_path(current_report, pdf: 'true', pdf_token: pdf_token)

--- a/spec/services/scans/stats_serializer_spec.rb
+++ b/spec/services/scans/stats_serializer_spec.rb
@@ -120,7 +120,9 @@ RSpec.describe Scans::StatsSerializer, type: :service do
         report2 = create(:report, :completed, scan: scan, target: target2)
 
         create(:detector_result, report: report1, detector: detector, passed: 10, total: 50)
+        create(:probe_result, report: report1, probe: create(:probe), detector: detector, passed: 10, total: 50)
         create(:detector_result, report: report2, detector: detector, passed: 20, total: 80)
+        create(:probe_result, report: report2, probe: create(:probe), detector: detector, passed: 20, total: 80)
       end
 
       it 'returns correct per-target totals from a single grouped query' do
@@ -368,7 +370,9 @@ RSpec.describe Scans::StatsSerializer, type: :service do
 
       before do
         create(:detector_result, report: report, detector: detector1, passed: 10, total: 50)
+        create(:probe_result, report: report, probe: create(:probe), detector: detector1, passed: 10, total: 50)
         create(:detector_result, report: report, detector: detector2, passed: 25, total: 100)
+        create(:probe_result, report: report, probe: create(:probe), detector: detector2, passed: 25, total: 100)
       end
 
       it 'returns all detectors with results' do
@@ -403,7 +407,9 @@ RSpec.describe Scans::StatsSerializer, type: :service do
 
       before do
         create(:detector_result, report: report1, detector: detector, passed: 10, total: 50)
+        create(:probe_result, report: report1, probe: create(:probe), detector: detector, passed: 10, total: 50)
         create(:detector_result, report: report2, detector: detector, passed: 15, total: 50)
+        create(:probe_result, report: report2, probe: create(:probe), detector: detector, passed: 15, total: 50)
       end
 
       it 'aggregates results across all completed reports' do
@@ -555,6 +561,7 @@ RSpec.describe Scans::StatsSerializer, type: :service do
 
       it 'includes component breakdown' do
         create(:detector_result, report: report, detector: detector, passed: 20, total: 100)
+        create(:probe_result, report: report, probe: create(:probe), detector: detector, passed: 20, total: 100)
 
         result = serializer.send(:security_grade_info)
 
@@ -573,12 +580,14 @@ RSpec.describe Scans::StatsSerializer, type: :service do
       let!(:measurable) do
         r = create(:report, :completed, scan: scan, target: target, created_at: 10.days.ago)
         create(:detector_result, report: r, detector: create(:detector), passed: 5, total: 10)
+        create(:probe_result, report: r, probe: create(:probe), detector: create(:detector), passed: 5, total: 10)
         r
       end
 
       let!(:unmeasurable) do
         r = create(:report, :completed, scan: scan, target: target, created_at: 1.day.ago)
         create(:detector_result, report: r, detector: create(:detector), passed: 0, total: 0)
+        create(:probe_result, report: r, probe: create(:probe), detector: create(:detector), passed: 0, total: 0)
         r
       end
 
@@ -616,16 +625,19 @@ RSpec.describe Scans::StatsSerializer, type: :service do
         travel_to(25.days.ago) do
           report1 = create(:report, :completed, scan: scan, target: target)
           create(:detector_result, report: report1, detector: detector, passed: 50, total: 100)
+          create(:probe_result, report: report1, probe: create(:probe), detector: detector, passed: 50, total: 100)
         end
 
         travel_to(15.days.ago) do
           report2 = create(:report, :completed, scan: scan, target: target)
           create(:detector_result, report: report2, detector: detector, passed: 40, total: 100)
+          create(:probe_result, report: report2, probe: create(:probe), detector: detector, passed: 40, total: 100)
         end
 
         travel_to(5.days.ago) do
           report3 = create(:report, :completed, scan: scan, target: target)
           create(:detector_result, report: report3, detector: detector, passed: 30, total: 100)
+          create(:probe_result, report: report3, probe: create(:probe), detector: detector, passed: 30, total: 100)
         end
       end
 
@@ -674,11 +686,13 @@ RSpec.describe Scans::StatsSerializer, type: :service do
         travel_to(20.days.ago) do
           report1 = create(:report, :completed, scan: scan, target: target)
           create(:detector_result, report: report1, detector: detector, passed: 20, total: 100)
+          create(:probe_result, report: report1, probe: create(:probe), detector: detector, passed: 20, total: 100)
         end
 
         travel_to(5.days.ago) do
           report2 = create(:report, :completed, scan: scan, target: target)
           create(:detector_result, report: report2, detector: detector, passed: 50, total: 100)
+          create(:probe_result, report: report2, probe: create(:probe), detector: detector, passed: 50, total: 100)
         end
       end
 
@@ -698,11 +712,13 @@ RSpec.describe Scans::StatsSerializer, type: :service do
         travel_to(20.days.ago) do
           report1 = create(:report, :completed, scan: scan, target: target)
           create(:detector_result, report: report1, detector: detector, passed: 30, total: 100)
+          create(:probe_result, report: report1, probe: create(:probe), detector: detector, passed: 30, total: 100)
         end
 
         travel_to(5.days.ago) do
           report2 = create(:report, :completed, scan: scan, target: target)
           create(:detector_result, report: report2, detector: detector, passed: 30, total: 100)
+          create(:probe_result, report: report2, probe: create(:probe), detector: detector, passed: 30, total: 100)
         end
       end
 
@@ -720,6 +736,7 @@ RSpec.describe Scans::StatsSerializer, type: :service do
         travel_to(45.days.ago) do
           report = create(:report, :completed, scan: scan, target: target)
           create(:detector_result, report: report, detector: detector, passed: 50, total: 100)
+          create(:probe_result, report: report, probe: create(:probe), detector: detector, passed: 50, total: 100)
         end
       end
 
@@ -800,6 +817,7 @@ RSpec.describe Scans::StatsSerializer, type: :service do
       scan.probes << probe
       create(:probe_result, report: report, probe: probe, detector: detector, passed: 25, total: 100)
       create(:detector_result, report: report, detector: detector, passed: 25, total: 100)
+      create(:probe_result, report: report, probe: create(:probe), detector: detector, passed: 25, total: 100)
     end
 
     it 'returns consistent data across all methods' do
@@ -839,7 +857,9 @@ RSpec.describe Scans::StatsSerializer, type: :service do
       create(:probe_result, report: report2, probe: probe, detector: detector, passed: 15, total: 50)
 
       create(:detector_result, report: report1, detector: detector, passed: 10, total: 50)
+      create(:probe_result, report: report1, probe: create(:probe), detector: detector, passed: 10, total: 50)
       create(:detector_result, report: report2, detector: detector, passed: 15, total: 50)
+      create(:probe_result, report: report2, probe: create(:probe), detector: detector, passed: 15, total: 50)
     end
 
     it 'aggregates risk_distribution across reports' do
@@ -873,7 +893,9 @@ RSpec.describe Scans::StatsSerializer, type: :service do
       create(:probe_result, report: child_report, probe: probe, detector: detector, passed: 20, total: 50)
 
       create(:detector_result, report: parent_report, detector: detector, passed: 10, total: 50)
+      create(:probe_result, report: parent_report, probe: create(:probe), detector: detector, passed: 10, total: 50)
       create(:detector_result, report: child_report, detector: detector, passed: 20, total: 50)
+      create(:probe_result, report: child_report, probe: create(:probe), detector: detector, passed: 20, total: 50)
     end
 
     it 'only counts parent reports in aggregate stats' do

--- a/spec/services/stats/vulnerable_targets_over_time_spec.rb
+++ b/spec/services/stats/vulnerable_targets_over_time_spec.rb
@@ -30,23 +30,27 @@ RSpec.describe Stats::VulnerableTargetsOverTime do
         5.times do |i|
           report = create(:report, target: @target1, scan: scan, created_at: i.days.ago)
           create(:detector_result, report: report, detector: detector, passed: 3, total: 10)
+          create(:probe_result, report: report, probe: create(:probe), detector: detector, passed: 3, total: 10)
         end
 
         # Create reports for Target 2 (second most vulnerable)
         3.times do |i|
           report = create(:report, target: @target2, scan: scan, created_at: i.days.ago)
           create(:detector_result, report: report, detector: detector, passed: 7, total: 10)
+          create(:probe_result, report: report, probe: create(:probe), detector: detector, passed: 7, total: 10)
         end
 
         # Create reports for Target 3 (least vulnerable)
         1.times do |i|
           report = create(:report, target: @target3, scan: scan, created_at: i.days.ago)
           create(:detector_result, report: report, detector: detector, passed: 9, total: 10)
+          create(:probe_result, report: report, probe: create(:probe), detector: detector, passed: 9, total: 10)
         end
 
         # Create older report that should be excluded from 30-day window
         old_report = create(:report, target: @target3, scan: scan, created_at: 35.days.ago)
         create(:detector_result, report: old_report, detector: detector, passed: 0, total: 10)
+        create(:probe_result, report: old_report, probe: create(:probe), detector: detector, passed: 0, total: 10)
       end
 
       it 'returns targets sorted by average ASR (highest to lowest)' do
@@ -138,6 +142,7 @@ RSpec.describe Stats::VulnerableTargetsOverTime do
           (7 - i).times do |j|
             report = create(:report, target: target, scan: scan, created_at: j.days.ago)
             create(:detector_result, report: report, detector: detector, passed: i, total: 10)
+            create(:probe_result, report: report, probe: create(:probe), detector: detector, passed: i, total: 10)
           end
         end
       end

--- a/spec/views/admin/reports/statistics_section_asr_spec.rb
+++ b/spec/views/admin/reports/statistics_section_asr_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "admin/reports/_statistics_section", type: :view do
   def asr_cell(passed:, total:)
     report = create(:report, company: company, scan: scan, target: target, status: :completed)
     create(:detector_result, report: report, detector: detector, passed: passed, total: total) if total.positive?
+    create(:probe_result, report: report, probe: create(:probe), detector: detector, passed: passed, total: total) if total.positive?
     render partial: "admin/reports/statistics_section", locals: { report: report }
 
     label = Nokogiri::HTML.fragment(rendered).css("span").find { |s| s.text.strip == "Attack Success Rate" }


### PR DESCRIPTION
Completes the ASR consistency work: every surface now uses the same numerator and denominator.

## Why

The report headline pooled `detector_results`, which holds one row per detector, so a single attack counted once per detector that judged it. ASR therefore moved when a probe gained a detector even though the target behaved identically, and the headline disagreed with the probes tab and dashboard Average ASR, which both already sum `probe_results`.

## What changes

`cached_passed`/`cached_total` and the preload scope (renamed `with_result_stats`) sum `probe_results`, and every other consumer follows — the ASR column's **sort order** (it sorted on detector totals while displaying probe totals, so a report could show 80% and sort as 70%), the stored scan average, the scan stats serializer's attack totals and security grade, and the vulnerable-targets chart. `detector_breakdown_info` still reads detector rows, which is correct: it is genuinely per-detector.

A migration recomputes `scans.avg_successful_attacks`. It is stored **and indexed**, so the scans list would otherwise keep sorting on the old definition. `rake scanner:recalculate_scan_asr_cache` reconciles any scan whose report completed while workers were still running the previous code.

Both the migration and that task hold `scan.with_lock` while recomputing: they read every report for a scan and then write, so unlocked, a report completing mid-run could commit a newer value that the recomputation then overwrote with a staler one.

## Known limitation

`ProbeResult#passed` keeps the highest single detector count and `#total` is copied from that same detector, so both are detector-derived where an attack-level truth is wanted. The numerator can undercount when a probe's detectors flag disjoint attempts. Persisting attack-level counts belongs with the detector-evidence work, which is where that union would come from.

## Verification

- RSpec 2848 examples, 0 failures
- RuboCop 495 files clean