### PR TITLE
fix(reports): keep partial evidence out of complete results and scan averages

### DIFF
--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -89,7 +89,11 @@ class Scan < ApplicationRecord
       # counted one attack once per detector judging it, so this scan average disagreed
       # with the rate on every report page it averages.
       # Uses LEFT JOIN to include reports even if they have no results
+      # Excludes runs holding only partial results, matching Stats::AverageAsrScore: an
+      # incomplete run's rate covers recorded work alone. This figure is stored, displayed
+      # and sorted on, so it has to agree with the aggregate the dashboard shows.
       results = reports.completed
+        .where("reports.result_completeness IS NULL OR reports.result_completeness <> 'partial'")
         .left_joins(:probe_results)
         .group("reports.id")
         .select(

--- a/app/services/reports/process.rb
+++ b/app/services/reports/process.rb
@@ -122,11 +122,22 @@ module Reports
     # Judged against the plan recorded at launch and never the scan's current probe list:
     # that list keeps growing afterwards, so a completed run would look short and be
     # flagged wrongly.
-    def completed_run_completeness(evals_dropped)
-      planned = report.planned_probe_count.to_i
-      return ProbeResult.where(report_id: report.id).count < planned ? :partial : :complete if planned.positive?
+    # Two independent ways a finished run can still be missing something, so both are
+    # checked: an eval row we could not record, and a planned probe that produced none.
+    #
+    # Row count alone cannot see the first: a probe judged by two detectors still leaves
+    # one ProbeResult when one of them is dropped, yet the lost detector may have carried
+    # the higher passed count, which is the one kept.
+    def completed_run_completeness(lost_eval_keys, unidentifiable_eval_dropped)
+      return :partial if lost_eval_keys.any?
 
-      evals_dropped ? :partial : :complete
+      planned = report.planned_probe_count.to_i
+      # An unidentifiable rejection is judged by the plan instead -- but only when there
+      # is one. Without a recorded plan there is nothing to fall back on, and treating the
+      # loss as nothing would present an incomplete run as whole.
+      return unidentifiable_eval_dropped ? :partial : :complete unless planned.positive?
+
+      ProbeResult.where(report_id: report.id).count < planned ? :partial : :complete
     end
 
     def process_jsonl_data(jsonl_string, mark_processing: true)
@@ -137,7 +148,9 @@ module Reports
       valid_lines = 0
       attempts_processed = false
       evals_processed = false
-      evals_dropped = false
+      dropped_eval_keys = Set.new
+      recorded_eval_keys = Set.new
+      unidentifiable_eval_dropped = false
       completion_processed = false
 
       jsonl_string.each_line do |line|
@@ -172,10 +185,21 @@ module Reports
             # An eval garak evaluated but we could not record -- an invalid row, or a
             # probe that no longer resolves. Either way that probe's numbers are gone
             # for good, so the run finished without leaving the whole picture.
+            #
+            # Keyed on the probe and detector the row belongs to, so a resumed scan that
+            # re-runs the probe clears its own earlier rejection. A row rejected for
+            # missing those fields has no key to clear later, so it is tracked separately
+            # rather than stranding a fully recovered run as partial. Strings only:
+            # recorded keys always hold strings, so a non-string like probe: 123 is
+            # present? yet could never be matched by the retry that clears it.
+            key = [ data["probe"], data["detector"] ]
             if process_eval(data)
               evals_processed = true
+              recorded_eval_keys << key
+            elsif key.all? { |part| part.is_a?(String) && part.present? }
+              dropped_eval_keys << key
             else
-              evals_dropped = true
+              unidentifiable_eval_dropped = true
             end
           when "completion"
             completion_processed = true if process_completion(data) == :processed
@@ -228,7 +252,10 @@ module Reports
         report.result_completeness = :partial
       elsif processed && valid_lines > 0
         report.status = :completed
-        report.result_completeness = completed_run_completeness(evals_dropped)
+        report.result_completeness = completed_run_completeness(
+          dropped_eval_keys - recorded_eval_keys,
+          unidentifiable_eval_dropped
+        )
       else
         Rails.logger.warn "Report #{report.id}: No probe results created despite processing lines, marking as failed"
         report.status = :failed

--- a/db/migrate/20260814120000_recalculate_scan_avg_successful_attacks.rb
+++ b/db/migrate/20260814120000_recalculate_scan_avg_successful_attacks.rb
@@ -31,6 +31,7 @@ class RecalculateScanAvgSuccessfulAttacks < ActiveRecord::Migration[8.1]
     Scan.reset_column_information
     Scan.where(id: Report.completed.select(:scan_id)).find_each(batch_size: 500) do |scan|
       ActsAsTenant.without_tenant do
+        scan.with_lock do
         rates = Report.completed
                       .where(scan_id: scan.id)
                       .left_joins(:detector_results)
@@ -41,6 +42,7 @@ class RecalculateScanAvgSuccessfulAttacks < ActiveRecord::Migration[8.1]
 
         value = rates.any? ? (rates.sum / rates.size).round(2) : 0.0
         scan.update_column(:avg_successful_attacks, value)
+        end
       end
     end
   end

--- a/db/migrate/20260814150000_recompute_scan_avg_excluding_partials.rb
+++ b/db/migrate/20260814150000_recompute_scan_avg_excluding_partials.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class RecomputeScanAvgExcludingPartials < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  # The previous recomputation (20260814120000) averaged every completed report, including
+  # ones holding only partial results. Changing the calculation does not touch values it
+  # already stored, and scans.avg_successful_attacks is read directly by the scans list and
+  # serializers -- so on any database already at that migration, historical scans would keep
+  # displaying and sorting by the inflated figure until some future report happened to
+  # trigger a recalculation.
+  #
+  # Idempotent: recomputes from current data, so running it twice is harmless.
+  def up
+    Scan.reset_column_information
+    Scan.where(id: Report.completed.select(:scan_id)).find_each(batch_size: 500) do |scan|
+      ActsAsTenant.without_tenant { scan.with_lock { scan.send(:update_avg_successful_attacks!) } }
+    end
+  end
+
+  # Rolling back one step restores code that averages every completed report, so the caches
+  # this migration narrowed have to be widened again -- a one-step rollback never invokes
+  # 20260814120000#down, and the list, sort and serializer paths read the column directly.
+  def down
+    Scan.reset_column_information
+    Scan.where(id: Report.completed.select(:scan_id)).find_each(batch_size: 500) do |scan|
+      ActsAsTenant.without_tenant do
+        scan.with_lock do
+          rates = Report.completed
+                        .where(scan_id: scan.id)
+                        .left_joins(:probe_results)
+                        .group("reports.id")
+                        .pluck(Arel.sql("COALESCE(SUM(probe_results.passed), 0)"),
+                               Arel.sql("COALESCE(SUM(probe_results.total), 0)"))
+                        .map { |passed, total| total.to_i.positive? ? (passed.to_f / total * 100) : 0.0 }
+
+          value = rates.any? ? (rates.sum / rates.size).round(2) : 0.0
+          scan.update_column(:avg_successful_attacks, value)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_14_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_14_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/spec/models/scan_spec.rb
+++ b/spec/models/scan_spec.rb
@@ -243,6 +243,27 @@ RSpec.describe Scan, type: :model do
       end
     end
 
+    context 'with a completed report holding only partial results' do
+      # A completed run can be partial when processing loses an eval. Average ASR excludes
+      # those because an incomplete run is not comparable; this cached figure is displayed
+      # and sorted on in the scans list, so it has to agree.
+      before do
+        whole = create(:report, scan: scan, target: scan.targets.first, status: :completed,
+                                result_completeness: :complete)
+        create(:probe_result, report: whole, probe: create(:probe), detector: create(:detector),
+                              passed: 20, total: 50)
+
+        partial = create(:report, scan: scan, target: scan.targets.last, status: :completed,
+                                  result_completeness: :partial)
+        create(:probe_result, report: partial, probe: create(:probe), detector: create(:detector),
+                              passed: 100, total: 100)
+      end
+
+      it 'averages only the runs whose results are whole' do
+        expect(scan.calculate_avg_successful_attacks).to eq(40.0)
+      end
+    end
+
     context 'with reports having zero total' do
       before do
         report1 = create(:report, scan: scan, target: scan.targets.first, status: :completed)

--- a/spec/services/reports/process_spec.rb
+++ b/spec/services/reports/process_spec.rb
@@ -106,17 +106,16 @@ RSpec.describe Reports::Process, type: :service do
         expect(report.result_completeness).to eq('partial')
       end
 
-      it 'marks a finished run that lost an eval row to malformed counts as partial' do
-        # evals_processed is set by the first eval that persists, so a run whose other
-        # eval rows were rejected still reaches the success branch. That probe's data
-        # is gone for good, so the results on offer are not the whole picture.
+      it 'does not hold a rejected duplicate against a pair it already recorded' do
+        # Same probe and detector as the good row, so nothing was lost -- and the order
+        # must not matter: rejected-then-recorded is covered below, this is the reverse.
         malformed = { entry_type: 'eval', detector: 'detector.test_detector',
                       probe: '0din.TestProbe', passed: nil, total_evaluated: nil }.to_json
 
         run_with([ init_line, attempt_line, eval_line, malformed, completion_line ])
 
         expect(report.status).to eq('completed')
-        expect(report.result_completeness).to eq('partial')
+        expect(report.result_completeness).to eq('complete')
       end
 
       it 'marks a finished run short of its recorded plan as partial' do
@@ -150,6 +149,75 @@ RSpec.describe Reports::Process, type: :service do
         report.update!(planned_probe_count: 1)
 
         run_with([ init_line, attempt_line, malformed, eval_line, completion_line ])
+
+        expect(report.status).to eq('completed')
+        expect(report.result_completeness).to eq('complete')
+      end
+
+      it 'marks a run partial when one of a probe\'s detectors was lost' do
+        # Two detectors judged the same probe and one eval was rejected. The probe still
+        # has its single ProbeResult, so the row count matches the plan -- but the lost
+        # detector could have carried the higher passed count, which is what
+        # ProbeResult#passed keeps. Row count alone cannot see that.
+        report.update!(planned_probe_count: 1)
+        second = { entry_type: 'eval', detector: 'detector.other_detector',
+                   probe: '0din.TestProbe', passed: nil, total_evaluated: nil }.to_json
+
+        run_with([ init_line, attempt_line, eval_line, second, completion_line ])
+
+        expect(report.status).to eq('completed')
+        expect(report.result_completeness).to eq('partial')
+      end
+
+      it 'does not hold a dropped eval against a run that recorded it on retry' do
+        # Resumed scans concatenate segments: the same probe and detector is rejected in
+        # one segment and recorded in a later one, so nothing was actually lost.
+        report.update!(planned_probe_count: 1)
+        malformed = { entry_type: 'eval', detector: 'detector.test_detector',
+                      probe: '0din.TestProbe', passed: nil, total_evaluated: nil }.to_json
+
+        run_with([ init_line, attempt_line, malformed, eval_line, completion_line ])
+
+        expect(report.status).to eq('completed')
+        expect(report.result_completeness).to eq('complete')
+      end
+
+      it 'does not strand a run whose rejected eval could not be identified' do
+        # Rejected for missing probe/detector, so there is no pair to key it on. A later
+        # valid eval can never match a nil key, which would leave a fully recovered run
+        # permanently partial. Unidentifiable rejections fall through to the plan check,
+        # which catches genuine loss by a short result count.
+        keyless = { entry_type: 'eval', passed: nil, total_evaluated: nil }.to_json
+        report.update!(planned_probe_count: 1)
+
+        run_with([ init_line, attempt_line, keyless, eval_line, completion_line ])
+
+        expect(report.status).to eq('completed')
+        expect(report.result_completeness).to eq('complete')
+      end
+
+      it 'still calls a run partial when an unidentifiable eval was lost and no plan was recorded' do
+        # No planned_probe_count (a run launched before the column, or by an older
+        # worker), so the count check cannot stand in. With nothing to fall back on, an
+        # unidentifiable rejection has to be treated as a loss rather than ignored.
+        report.update!(planned_probe_count: nil)
+        keyless = { entry_type: 'eval', passed: nil, total_evaluated: nil }.to_json
+
+        run_with([ init_line, attempt_line, keyless, eval_line, completion_line ])
+
+        expect(report.status).to eq('completed')
+        expect(report.result_completeness).to eq('partial')
+      end
+
+      it 'does not strand a run whose rejected eval carried a non-string probe' do
+        # present? is true for 123, but every recorded key holds strings, so a key like
+        # [123, "detector.test_detector"] could never be cleared by the retry that
+        # follows -- leaving a fully recovered run permanently partial.
+        report.update!(planned_probe_count: 1)
+        bad_type = { entry_type: 'eval', detector: 'detector.test_detector',
+                     probe: 123, passed: nil, total_evaluated: nil }.to_json
+
+        run_with([ init_line, attempt_line, bad_type, eval_line, completion_line ])
 
         expect(report.status).to eq('completed')
         expect(report.result_completeness).to eq('complete')


### PR DESCRIPTION
Two ways a partial run still counted as whole.

## A lost detector could hide inside a matching row count

When a plan was recorded, completeness was judged purely by comparing recorded results against it. But a probe judged by two detectors still leaves **one** `ProbeResult` when one of its evals is dropped — so the count matched the plan and the report read as complete. That matters because `ProbeResult#passed` keeps the *highest* detector count, so the row that went missing may have been the one carrying it.

Dropped evals are now tracked by probe **and** detector, and cleared when that same pair is recorded later. A resumed scan re-runs the probe and clears its own rejection; a genuinely lost detector does not.

Four cases, each pinned by a spec:

- **multi-detector loss** — a second detector's eval rejected, row count still matches the plan → partial
- **retry recovery** — the same pair rejected in one segment and recorded in a later one → complete, in either order
- **unidentifiable rejection** — a row rejected for missing probe/detector has no key to clear, so it defers to the plan check; with no recorded plan it counts as a loss rather than being assumed away
- **non-string identity** — `probe: 123` is `present?` but every recorded key holds strings, so such a key could never be cleared and would strand a recovered run

## The scan cache averaged partial reports

`Scan#calculate_avg_successful_attacks` took every completed report, including ones explicitly marked partial. `Stats::AverageAsrScore` excludes those because an incomplete run is not comparable, and this figure is **stored, displayed and sorted on**, so the scans list disagreed with the dashboard.

A second migration recomputes the stored values: changing the calculation does not touch what it already wrote, so historical scans would otherwise keep the inflated figure until some future report triggered a recalculation. Both migrations now hold `scan.with_lock` while recomputing, so a report completing mid-run cannot be overwritten by a staler figure.

## Verification

- RSpec 2854 examples, 0 failures
- RuboCop 496 files clean; Brakeman no warnings
- Both migrations cycle down and up cleanly