### PR TITLE
fix(scans): default the scans list to All

### DIFF
--- a/app/controllers/admin/scans_controller.rb
+++ b/app/controllers/admin/scans_controller.rb
@@ -16,14 +16,18 @@ module Admin
       @unscheduled_count = Scan.unscheduled.count
       @all_count = Scan.count
 
-      # Handle scopes
+      # Handle scopes. Defaults to all: with `scheduled` as the default, a company whose
+      # scans are all one-time landed on "No scans found" while the tabs beside it counted
+      # every one of them -- the history was there, the initial filter excluded it. An
+      # unrecognised scope falls here too, so a stale bookmark shows everything rather
+      # than nothing.
       base_scope = case params[:scope]
+      when "scheduled"
+        Scan.scheduled
       when "unscheduled"
         Scan.unscheduled
-      when "all"
+      else
         Scan.all
-      else # scheduled is default
-        Scan.scheduled
       end
 
       # reports_count is now a real column (counter cache), no special handling needed
@@ -38,7 +42,9 @@ module Admin
       else
         @pagy, @scans = pagy(@q.result)
       end
-      @current_scope = params[:scope] || "scheduled"
+      # Mirrors the branch above, so the highlighted tab always names the filter the list
+      # was actually built from.
+      @current_scope = %w[scheduled unscheduled].include?(params[:scope]) ? params[:scope] : "all"
 
       # Load filter options
       @filter_targets = Target.order(:name).pluck(:name, :id)

--- a/spec/controllers/admin/scans_controller_spec.rb
+++ b/spec/controllers/admin/scans_controller_spec.rb
@@ -27,6 +27,103 @@ RSpec.describe Admin::ScansController, type: :controller do
       expect(response).to have_http_status(:success)
     end
 
+    describe "the default filter" do
+      # The default scope was `scheduled`, so a company whose scans are all one-time saw
+      # "No scans found" beside a tab reading All: 126. The counts were right; the list
+      # was filtered to a scope nothing matched.
+      def active_tab
+        doc = Nokogiri::HTML(response.body)
+        link = doc.css("a").find { |a| a["class"].to_s.include?("text-primary") && a["href"].to_s.include?("scope=") }
+        link && link["href"][/scope=(\w+)/, 1]
+      end
+
+      let!(:one_time) do
+        ActsAsTenant.with_tenant(company) do
+          create(:complete_scan, company: company, name: "OneTimeAlpha")
+        end
+      end
+
+      it "shows existing scans when no filter is given" do
+        get :index
+
+        expect(response.body).to include("OneTimeAlpha")
+        expect(response.body).not_to include("No scans found")
+      end
+
+      it "marks All as the active tab" do
+        get :index
+
+        expect(active_tab).to eq("all")
+      end
+
+      it "still shows the empty state for a company with no scans at all" do
+        ActsAsTenant.with_tenant(company) { Scan.find_each(&:destroy) }
+
+        get :index
+
+        expect(response.body).to include("No scans found")
+      end
+    end
+
+    describe "explicit filters" do
+      # Deterministic names: the shared `scan` fixture takes a Faker name, which can occur
+      # in the page's own chrome and make an include-assertion pass regardless of filter.
+      let!(:one_time) do
+        ActsAsTenant.with_tenant(company) do
+          create(:complete_scan, company: company, name: "OneTimeAlpha")
+        end
+      end
+
+      let!(:scheduled) do
+        ActsAsTenant.with_tenant(company) do
+          create(:complete_scan, :with_recurrence, company: company, name: "ScheduledAlpha")
+        end
+      end
+
+      it "still honours an explicit scheduled filter" do
+        get :index, params: { scope: "scheduled" }
+
+        expect(response.body).to include("ScheduledAlpha")
+        expect(response.body).not_to include("OneTimeAlpha")
+      end
+
+      it "still honours an explicit one-time filter" do
+        get :index, params: { scope: "unscheduled" }
+
+        expect(response.body).to include("OneTimeAlpha")
+        expect(response.body).not_to include("ScheduledAlpha")
+      end
+
+      it "carries the filter through pagination links" do
+        # A filter that survives the first page but not the second sends the reader back
+        # to an unfiltered list without saying so.
+        ActsAsTenant.with_tenant(company) { create_list(:complete_scan, 40, company: company) }
+
+        get :index, params: { scope: "unscheduled" }
+
+        pagination_links = Nokogiri::HTML(response.body).css("nav a").map { |a| a["href"].to_s }
+        paged = pagination_links.select { |href| href.include?("page=") }
+        expect(paged).not_to be_empty
+        expect(paged).to all(include("scope=unscheduled"))
+      end
+
+      it "treats an unrecognised scope as All rather than showing nothing" do
+        get :index, params: { scope: "nonsense" }
+
+        expect(response.body).to include("OneTimeAlpha")
+        expect(response.body).to include("ScheduledAlpha")
+      end
+    end
+
+    it "does not render the empty state for a company with a long scan history" do
+      # The reported case: 126 existing scans, none scheduled.
+      ActsAsTenant.with_tenant(company) { create_list(:complete_scan, 126, company: company) }
+
+      get :index
+
+      expect(response.body).not_to include("No scans found")
+    end
+
     it "renders the index template" do
       get :index
       expect(response.body).to include("Scans")


### PR DESCRIPTION
The scans list defaulted to the `scheduled` scope, so a company whose scans are all one-time landed on **"No scans found"** while the tabs beside it counted every one of them. The counts were right — the list was filtered to a scope nothing matched.

The list and the highlighted tab now derive from the same branch, so the active tab always names the filter the rows were built from. An unrecognised scope falls to All too, so a stale bookmark shows everything rather than nothing.

Specs cover the default showing existing scans and marking All active, explicit `scheduled` and `unscheduled` filters still working **and surviving pagination**, the empty state still appearing for a company with genuinely no scans, and a 126-scan fixture rendering no empty state.

The filter specs use deterministic scan names: the shared fixture takes a Faker name, which can occur in the page's own chrome and make an include-assertion pass regardless of which filter is active. Verified by reintroducing the bug — four specs fail, where three did before the names were pinned.

## Verification

- RSpec 2862 examples, 0 failures
- RuboCop 496 files clean