### PR TITLE
fix(reports): offer details wherever a report retained evidence

### DIFF
--- a/app/views/admin/reports/_metadata_section.html.erb
+++ b/app/views/admin/reports/_metadata_section.html.erb
@@ -21,7 +21,10 @@
 
         <div class="flex items-center gap-2">
           <span class="text-contentSecondary font-sans text-sm min-w-[50px]">UUID:</span>
-          <% if report.completed? %>
+          <%# Same gate as the reports list and the report header: usable evidence, not a
+              finished lifecycle. Keying on completed? left a failed report offering
+              "View Report" in its header above a dead plain-text UUID. %>
+          <% if report_has_viewable_results?(report) %>
             <%= link_to report.uuid, report_detail_path(report),
                 class: "text-primary hover:text-primary/80 font-sans text-sm no-underline transition-colors truncate",
                 target: "_blank" %>

--- a/spec/views/admin/reports/metadata_section_lifecycle_spec.rb
+++ b/spec/views/admin/reports/metadata_section_lifecycle_spec.rb
@@ -20,6 +20,41 @@ RSpec.describe "admin/reports/_metadata_section", type: :view do
     expect(rendered).to match(/partial results/i)
   end
 
+  describe "the UUID link" do
+    # The list and the report header offer their Details affordance whenever usable
+    # evidence exists, but this one still keyed on completed? -- so a failed report with
+    # retained results showed "View Report" in its header and a dead plain-text UUID
+    # right below it.
+    def uuid_cell(report)
+      render partial: "admin/reports/metadata_section", locals: { report: report }
+      label = Nokogiri::HTML(rendered).css("span").find { |node| node.text.strip == "UUID:" }
+      raise "UUID row not found" unless label
+
+      label.parent
+    end
+
+    it "links to the details of a failed report that retained results" do
+      report = create(:report, company: company, scan: scan, target: target,
+                               status: :failed, result_completeness: :partial)
+
+      expect(uuid_cell(report).css("a")).to be_present
+    end
+
+    it "leaves the UUID unlinked when nothing was retained" do
+      report = create(:report, company: company, scan: scan, target: target,
+                               status: :failed, result_completeness: :none)
+
+      expect(uuid_cell(report).css("a")).to be_empty
+    end
+
+    it "still links a completed report" do
+      report = create(:report, company: company, scan: scan, target: target,
+                               status: :completed, result_completeness: :complete)
+
+      expect(uuid_cell(report).css("a")).to be_present
+    end
+  end
+
   it "shows only the lifecycle for a complete report" do
     report = create(:report, company: company, scan: scan, target: target,
                              status: :completed, result_completeness: :complete)


### PR DESCRIPTION
The reports list and the report header already gate their details affordance on retained evidence rather than a finished lifecycle. The overview's UUID link still keyed on `completed?`, so a failed report holding results offered **"View Report"** in its header and a dead plain-text UUID directly below it.

It now uses the same `report_has_viewable_results?` gate, so a failed report with retained evidence links to it, one holding nothing stays unlinked rather than offering a dead action, and completed reports are unaffected.

## Verification

- RSpec 2865 examples, 0 failures
- RuboCop 496 files clean
- Verified by reverting the gate to `completed?`: the failed-with-results case fails, so the spec pins the behaviour rather than passing by construction