### PR TITLE
fix(reports): navigate by the identifier the link names

### DIFF
--- a/app/views/admin/reports/_metadata_section.html.erb
+++ b/app/views/admin/reports/_metadata_section.html.erb
@@ -15,22 +15,26 @@
       <%# Left Column %>
       <div class="space-y-2">
         <div class="flex items-center gap-2">
-          <span class="text-contentSecondary font-sans text-sm min-w-[50px]">ID:</span>
-          <span class="text-white font-sans text-sm"><%= report.id %></span>
+          <%# The link lives on the Report ID, so its text and its destination name the same
+              thing: /report_details/<id>. The UUID used to carry it, which meant reading a
+              uuid that navigated by numeric id. Gated on usable evidence, as the reports
+              list and the report header are. %>
+          <span class="text-contentSecondary font-sans text-sm min-w-[70px]">Report ID:</span>
+          <% if report_has_viewable_results?(report) %>
+            <%= link_to report.id, report_detail_path(report),
+                class: "text-primary hover:text-primary/80 font-sans text-sm no-underline transition-colors",
+                target: "_blank" %>
+          <% else %>
+            <span class="text-white font-sans text-sm"><%= report.id %></span>
+          <% end %>
         </div>
 
         <div class="flex items-center gap-2">
-          <span class="text-contentSecondary font-sans text-sm min-w-[50px]">UUID:</span>
-          <%# Same gate as the reports list and the report header: usable evidence, not a
-              finished lifecycle. Keying on completed? left a failed report offering
-              "View Report" in its header above a dead plain-text UUID. %>
-          <% if report_has_viewable_results?(report) %>
-            <%= link_to report.uuid, report_detail_path(report),
-                class: "text-primary hover:text-primary/80 font-sans text-sm no-underline transition-colors truncate",
-                target: "_blank" %>
-          <% else %>
-            <span class="text-white font-sans text-sm truncate"><%= report.uuid %></span>
-          <% end %>
+          <%# Kept as plain metadata rather than removed: this is the identifier garak's
+              logs and the on-disk scan artefacts are keyed on, so support work needs it
+              visible. It is simply not navigation. %>
+          <span class="text-contentSecondary font-sans text-sm min-w-[70px]">UUID:</span>
+          <span class="text-white font-sans text-sm truncate"><%= report.uuid %></span>
         </div>
 
         <div class="flex items-center gap-2">

--- a/spec/views/admin/reports/metadata_section_lifecycle_spec.rb
+++ b/spec/views/admin/reports/metadata_section_lifecycle_spec.rb
@@ -20,38 +20,49 @@ RSpec.describe "admin/reports/_metadata_section", type: :view do
     expect(rendered).to match(/partial results/i)
   end
 
-  describe "the UUID link" do
-    # The list and the report header offer their Details affordance whenever usable
-    # evidence exists, but this one still keyed on completed? -- so a failed report with
-    # retained results showed "View Report" in its header and a dead plain-text UUID
-    # right below it.
-    def uuid_cell(report)
+  describe "report identity and navigation" do
+    # The UUID used to carry the link, so the text named one identifier (a uuid) and the
+    # destination another (/report_details/<numeric id>). The numeric Report ID is now the
+    # labelled, linked value, and the UUID stays as plain metadata -- it is what garak's
+    # logs and on-disk scan artefacts are keyed on, so it is worth keeping visible.
+    def row_for(report, label)
       render partial: "admin/reports/metadata_section", locals: { report: report }
-      label = Nokogiri::HTML(rendered).css("span").find { |node| node.text.strip == "UUID:" }
-      raise "UUID row not found" unless label
+      node = Nokogiri::HTML(rendered).css("span").find { |span| span.text.strip == label }
+      raise "#{label} row not found" unless node
 
-      label.parent
+      node.parent
     end
 
-    it "links to the details of a failed report that retained results" do
-      report = create(:report, company: company, scan: scan, target: target,
-                               status: :failed, result_completeness: :partial)
-
-      expect(uuid_cell(report).css("a")).to be_present
+    let(:report) do
+      create(:report, company: company, scan: scan, target: target,
+                      status: :failed, result_completeness: :partial)
     end
 
-    it "leaves the UUID unlinked when nothing was retained" do
-      report = create(:report, company: company, scan: scan, target: target,
-                               status: :failed, result_completeness: :none)
-
-      expect(uuid_cell(report).css("a")).to be_empty
+    it "labels the numeric report id explicitly" do
+      expect(row_for(report, "Report ID:").text).to include(report.id.to_s)
     end
 
-    it "still links a completed report" do
-      report = create(:report, company: company, scan: scan, target: target,
-                               status: :completed, result_completeness: :complete)
+    it "links the report id to the report it names" do
+      link = row_for(report, "Report ID:").css("a").first
 
-      expect(uuid_cell(report).css("a")).to be_present
+      expect(link).to be_present
+      expect(link.text.strip).to eq(report.id.to_s)
+      expect(link["href"]).to eq("/report_details/#{report.id}")
+    end
+
+    it "leaves the report id unlinked when there is nothing to open" do
+      empty = create(:report, company: company, scan: scan, target: target,
+                              status: :failed, result_completeness: :none)
+
+      expect(row_for(empty, "Report ID:").css("a")).to be_empty
+      expect(row_for(empty, "Report ID:").text).to include(empty.id.to_s)
+    end
+
+    it "shows the uuid as plain metadata, never as navigation" do
+      cell = row_for(report, "UUID:")
+
+      expect(cell.text).to include(report.uuid)
+      expect(cell.css("a")).to be_empty
     end
   end
 


### PR DESCRIPTION
The report overview showed the numeric id as plain text and put the link on the UUID below it — so the link *read* as a uuid while its destination was `/report_details/<numeric id>`. Two identifiers, one affordance, naming different things.

The Report ID row is now labelled and carries the link, so its text and its destination are the same identifier. It stays gated on usable evidence, consistent with the reports list and the report header.

**The UUID stays, unlinked.** It is the identifier garak's logs and the on-disk scan artefacts (`<uuid>.report.jsonl`, `<uuid>_web.json`) are keyed on, and this section is its only surface in the UI — removing it would cost support work a debugging path. It is simply no longer an affordance.

Specs cover the label, that link text equals link destination, that the id is unlinked when there is nothing to open, and that the UUID is never a link.

## Verification

- RSpec 2866 examples, 0 failures
- RuboCop 496 files clean
- Verified by putting the link back on the UUID: two specs fail, so they pin the behaviour rather than passing by construction