### PR TITLE
fix(reports): reconcile probe, detector, and aggregation labels across reports

### DIFF
--- a/app/controllers/admin/probes_controller.rb
+++ b/app/controllers/admin/probes_controller.rb
@@ -30,10 +30,15 @@ module Admin
       @pagy, @probes = pagy(apply_sorting(@q.result))
 
       # Load filter options
-      @filter_detectors = Detector.all.map do |d|
-        short_name = d.name.split(".").last
-        translated_name = I18n.t("detectors.names.#{short_name}", default: short_name)
-        [ translated_name, d.id ]
+      # A select has nowhere to put the identifier as secondary text, so the qualifier is
+      # appended only where two detectors would otherwise offer the same option twice.
+      detectors = Detector.all.to_a
+      label_counts = detectors.group_by { |d| Detector.display_label(d.name) }.transform_values(&:size)
+      @filter_detectors = detectors.map do |d|
+        label = Detector.display_label(d.name)
+        qualifier = Detector.qualifier_for(d.name)
+        label = "#{label} (#{qualifier})" if qualifier && label_counts[label].to_i > 1
+        [ label, d.id ]
       end
       @filter_disclosure_statuses = Probe.disclosure_statuses.map { |name, id| [ name.humanize, id ] }
       @filter_techniques = Technique.order(:name).pluck(:name, :id)

--- a/app/controllers/admin/scans_controller.rb
+++ b/app/controllers/admin/scans_controller.rb
@@ -219,7 +219,7 @@ module Admin
         if is_community
           category_name = short_name
         else
-          category_name = I18n.t("detectors.names.#{short_name}", default: short_name)
+          category_name = Detector.display_label(detector.name)
         end
 
         category_data = {

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -152,6 +152,23 @@ module ReportsHelper
   # Per-prompt result for an attempt hash from probe_result.attempts.
   # succeeded: true (Attack Successful) / false (Blocked) / nil (unknown — legacy
   # attempt ingested before detector_results was captured).
+  # States what one row of the probe table is, and what its rate is taken over.
+  #
+  # Derived from the rows being rendered rather than from the report: is_variant_report?
+  # is true for any child, but a child recorded before threat_variant_id existed holds
+  # ordinary per-probe rows, and claiming probe/variant pairs there would misdescribe
+  # them. The denominator is ProbeResult#total, which Reports::Process assigns from
+  # garak's total_evaluated. garak counts that once per entry in attempt.detector_results
+  # (aligned with attempt.outputs), so it counts outputs: one prompt run with several
+  # generations contributes several. "Attempts" names a different collection again.
+  def probe_results_basis(probe_results)
+    per_variant = probe_results.any? { |result| result.threat_variant_id.present? }
+    subject = per_variant ? "probe and threat variant" : "probe"
+    scope = per_variant ? "that pair" : "that probe"
+
+    "One row per #{subject} — rate over the outputs evaluated for #{scope}"
+  end
+
   def attempt_result(attempt)
     {
       succeeded: attempt["attack_succeeded"],

--- a/app/models/detector.rb
+++ b/app/models/detector.rb
@@ -15,6 +15,38 @@ class Detector < ApplicationRecord
   scope :with_deleted, -> { unscoped }
   scope :deleted_only, -> { unscoped.where.not(deleted_at: nil) }
 
+  # Canonical presentation for a detector identifier, used by every surface that names
+  # one -- report detector statistics, scan definitions, probe pages and the controllers
+  # that build category lists.
+  #
+  # The friendly name comes from the last segment ("0din.MitigationBypass" ->
+  # "Generic Mitigation Bypass Checks"), which means two detectors from different
+  # namespaces can share a label. That is why #qualifier_for exists: without it, a report
+  # showed two identically-named rows carrying different numerators and denominators, and
+  # nothing on screen explained why they differed.
+  def self.display_label(detector_name)
+    return "Unknown" if detector_name.blank?
+
+    short = detector_name.to_s.split(".").last
+    I18n.t("detectors.names.#{short}", default: short)
+  end
+
+  # The identifier to show beside the label, or nil when the label already conveys it.
+  def self.qualifier_for(detector_name)
+    return nil if detector_name.blank?
+
+    full = detector_name.to_s
+    full == display_label(full) ? nil : full
+  end
+
+  def display_label
+    self.class.display_label(name)
+  end
+
+  def qualifier
+    self.class.qualifier_for(name)
+  end
+
   def soft_delete!
     update!(deleted_at: Time.current)
   end

--- a/app/services/stats/detector_activity_data.rb
+++ b/app/services/stats/detector_activity_data.rb
@@ -27,9 +27,8 @@ module Stats
         passed = row.passed_tests.to_i
 
         if row.name.to_s.start_with?("0din.")
-          short_name = row.name.split(".").last
           individual << {
-            name: I18n.t("detectors.names.#{short_name}", default: short_name),
+            name: Detector.display_label(row.name),
             total: total,
             passed: passed
           }

--- a/app/views/admin/probes/show.html.erb
+++ b/app/views/admin/probes/show.html.erb
@@ -62,8 +62,11 @@
           <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Detector</th>
           <td class="py-3 text-sm text-contentPrimary">
             <% if @probe.detector %>
-              <% short_name = @probe.detector.name.split(".").last %>
-              <%= I18n.t("detectors.names.#{short_name}", default: short_name) %>
+              <%= Detector.display_label(@probe.detector.name) %>
+              <% qualifier = Detector.qualifier_for(@probe.detector.name) %>
+              <% if qualifier %>
+                <span class="block text-contentSecondary font-mono text-xs"><%= qualifier %></span>
+              <% end %>
             <% else %>
               <span class="text-contentTertiary">—</span>
             <% end %>

--- a/app/views/admin/reports/_probe_card.html.erb
+++ b/app/views/admin/reports/_probe_card.html.erb
@@ -16,8 +16,8 @@
   probe = probe_result.probe
   detector = probe_result.detector
   detector_name = detector&.name || "Unknown"
-  short_name = detector_name != "Unknown" ? detector_name.split(".").last : "Unknown"
-  translated_name = I18n.t("detectors.names.#{short_name}", default: short_name)
+  translated_name = Detector.display_label(detector_name)
+  detector_qualifier = Detector.qualifier_for(detector_name)
 
   tokens_display = format_token_count(probe_result.input_tokens, probe_result.output_tokens)
 %>
@@ -57,6 +57,10 @@
             <div class="flex items-center gap-2 shrink-0">
               <span class="text-zinc-500 whitespace-nowrap">Detector:</span>
               <span class="text-white font-sans text-base font-medium whitespace-nowrap"><%= translated_name %></span>
+              <%# Which detector this row came from, when the friendly name is shared. %>
+              <% if detector_qualifier %>
+                <span class="block text-contentSecondary font-mono text-xs"><%= detector_qualifier %></span>
+              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/admin/reports/_probe_results_section.html.erb
+++ b/app/views/admin/reports/_probe_results_section.html.erb
@@ -61,6 +61,12 @@
     probe_results = local_assigns[:probe_results] || report.probe_results.to_a
   %>
   <% if probe_results.any? %>
+    <%# Mirrors the detector table's line. These are per-probe rates over a different
+        denominator than the per-detector rates in Detector Statistics -- saying so is
+        what stops the two reading as contradictory. %>
+    <p class="text-contentSecondary font-sans text-xs mb-2">
+      <%= probe_results_basis(probe_results) %>
+    </p>
     <%
 
       # Sort by Max Score descending (highest first), then ASR as tiebreaker

--- a/app/views/admin/reports/_statistics_section.html.erb
+++ b/app/views/admin/reports/_statistics_section.html.erb
@@ -87,9 +87,20 @@
   <button
     class="w-full px-4 py-3 flex items-center justify-between cursor-pointer hover:bg-zinc-800/50 transition-colors duration-200"
     data-action="click->report-redesigned#toggleDetectorStats">
-    <h2 class="text-xl font-sans font-semibold text-primary tracking-wide">
-      Detector Statistics
-    </h2>
+    <div class="text-left">
+      <h2 class="text-xl font-sans font-semibold text-primary tracking-wide">
+        Detector Statistics
+      </h2>
+      <%# States the level and the grouping basis once for the whole table: these rates are
+          per detector over the outputs that detector evaluated, which is a different
+          denominator from the per-probe rows elsewhere on this page. Without saying so,
+          the two read as contradicting each other. Reports::Process adds the same
+          total_evaluated to detector_stats[:total] as it assigns to ProbeResult#total, and
+          garak counts that per evaluated output -- not per prompt. %>
+      <p class="text-contentSecondary font-sans text-xs mt-0.5">
+        One row per detector — rate over the outputs that detector evaluated
+      </p>
+    </div>
     <span
       data-report-redesigned-target="detectorChevron"
       class="icon icon-sm icon-chevron-down text-zinc-400 transition-transform duration-200 rotate-180"></span>
@@ -110,12 +121,17 @@
             <% report.detector_results.includes(:detector).each do |detector_result| %>
               <%
                 detector_name = detector_result.detector&.name || "Unknown"
-                short_name = detector_name != "Unknown" ? detector_name.split(".").last : "Unknown"
-                translated_name = I18n.t("detectors.names.#{short_name}", default: short_name)
+                translated_name = Detector.display_label(detector_name)
+                qualifier = Detector.qualifier_for(detector_name)
               %>
               <tr class="border-b border-zinc-800 last:border-0">
                 <td class="text-white font-sans text-sm py-2 pr-4">
                   <%= translated_name %>
+                  <%# Two detectors can share a friendly name across namespaces, so the
+                      identifier is what tells otherwise identical rows apart. %>
+                  <% if qualifier %>
+                    <span class="block text-contentSecondary font-mono text-xs"><%= qualifier %></span>
+                  <% end %>
                 </td>
 
                 <% asr = detector_result.total > 0 ? (detector_result.passed.to_f / detector_result.total * 100) : 0 %>

--- a/app/views/admin/scans/show.html.erb
+++ b/app/views/admin/scans/show.html.erb
@@ -27,13 +27,38 @@
 
   # Build probes display
   probes_display = if @scan.probes.any?
+    readable_probe_ids = policy_scope(Probe).where(id: @scan.probe_ids).pluck(:id).to_set
     detector_groups = @scan.probes.includes(:detector).group_by(&:detector)
+    # Each group names its detector and lists the probes inside it. Previously a group
+    # showed only a count, so two detectors sharing a friendly name produced two rows that
+    # read identically with no way to see what was in either.
     safe_join(detector_groups.map { |detector, probes|
-      short_name = detector.name.split(".").last
-      translated_name = I18n.t("detectors.names.#{short_name}", default: short_name)
-      content_tag(:div, class: "flex items-center justify-between py-2 px-3 bg-backgroundSecondary border border-borderPrimary rounded-lg mb-2") do
-        content_tag(:span, translated_name, class: "text-sm font-medium text-contentPrimary") +
-        content_tag(:span, "#{probes.count} probe#{probes.count == 1 ? '' : 's'}", class: "inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-backgroundPrimary border border-borderPrimary text-contentSecondary")
+      translated_name = Detector.display_label(detector&.name)
+      qualifier = Detector.qualifier_for(detector&.name)
+      content_tag(:details, class: "py-2 px-3 bg-backgroundSecondary border border-borderPrimary rounded-lg mb-2") do
+        summary = content_tag(:summary, class: "flex items-center justify-between cursor-pointer") do
+          label = content_tag(:span, translated_name, class: "text-sm font-medium text-contentPrimary")
+          label += content_tag(:span, qualifier, class: "block text-contentSecondary font-mono text-xs") if qualifier
+          content_tag(:span, label) +
+            content_tag(:span, "#{probes.count} probe#{probes.count == 1 ? '' : 's'}", class: "inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-backgroundPrimary border border-borderPrimary text-contentSecondary")
+        end
+
+        probe_list = content_tag(:ul, class: "mt-2 ml-1 space-y-1") do
+          safe_join(probes.sort_by { |probe| probe.name.to_s }.map { |probe|
+            content_tag(:li) do
+              # A saved scan keeps probes that were later disabled, but ProbePolicy#show?
+              # denies those to non-super-admins -- linking them offers navigation that
+              # bounces off Pundit. They stay listed, unlinked.
+              if readable_probe_ids.include?(probe.id)
+                link_to(probe.name, probe_path(probe), class: "text-xs text-primary hover:underline")
+              else
+                content_tag(:span, probe.name, class: "text-xs text-contentSecondary")
+              end
+            end
+          })
+        end
+
+        summary + probe_list
       end
     })
   else

--- a/app/views/report_details/show.html.erb
+++ b/app/views/report_details/show.html.erb
@@ -98,8 +98,8 @@
         <% @report.detector_results.includes(:detector).each do |result| %>
           <%
             detector_name = result.detector&.name || "Unknown"
-            short_name = detector_name != "Unknown" ? detector_name.split(".").last : "Unknown"
-            translated_name = I18n.t("detectors.names.#{short_name}", default: short_name)
+            translated_name = Detector.display_label(detector_name)
+            detector_qualifier = Detector.qualifier_for(detector_name)
           %>
           <div class="<%= pdf_mode ? 'bg-white rounded border border-gray-200 p-3 flex flex-col' : 'bg-white rounded-lg shadow-sm border border-gray-200 p-4 flex flex-col' %>">
             <div class="<%= pdf_mode ? 'flex items-center mb-1.5 overflow-hidden' : 'flex items-center mb-2 overflow-hidden' %>">
@@ -110,6 +110,11 @@
                 <span class="<%= pdf_mode ? 'text-xs font-medium text-gray-700 truncate block' : 'text-sm font-medium text-gray-700 truncate block' %>" title="<%= translated_name %>">
                   <%= translated_name %>
                 </span>
+                <%# Two detectors sharing a friendly name would otherwise be identical
+                    cards; the identifier says which produced this result. %>
+                <% if detector_qualifier %>
+                  <span class="block text-gray-500 font-mono text-[10px] truncate" title="<%= detector_qualifier %>"><%= detector_qualifier %></span>
+                <% end %>
               </div>
               <% if result.max_score.present? %>
                 <div class="shrink-0 ml-2">
@@ -251,8 +256,7 @@
       <% probe = result.probe %>
       <%
         detector_name = result.detector&.name || "Unknown"
-        short_name = detector_name != "Unknown" ? detector_name.split(".").last : "Unknown"
-        translated_name = I18n.t("detectors.names.#{short_name}", default: short_name)
+        translated_name = Detector.display_label(detector_name)
         is_vulnerable = result.any_detector_passed
         card_border_class = is_vulnerable ?
           (pdf_mode ? 'border-red-200/80' : 'border-red-200/80 hover:border-red-300/60') :

--- a/spec/controllers/admin/scans_controller_spec.rb
+++ b/spec/controllers/admin/scans_controller_spec.rb
@@ -21,6 +21,58 @@ RSpec.describe Admin::ScansController, type: :controller do
     ActsAsTenant.current_tenant = company
   end
 
+  describe "the probe breakdown" do
+    # Groups previously showed only "N probes", so two detectors sharing a friendly name
+    # produced two rows reading identically with no way to see what was in either.
+    it "names each probe in the group and links it to its detail page" do
+      odin = create(:detector, name: "0din.MitigationBypass")
+      alpha = create(:probe, name: "AlphaProbe", detector: odin)
+      beta = create(:probe, name: "BetaProbe", detector: odin)
+      ActsAsTenant.with_tenant(company) { scan.probes = [ alpha, beta ] }
+
+      get :show, params: { id: scan.id }
+
+      doc = Nokogiri::HTML(response.body)
+      expect(doc.css("a[href='#{probe_path(alpha)}']")).to be_present
+      expect(doc.css("a[href='#{probe_path(beta)}']")).to be_present
+    end
+
+    it "does not link a probe the viewer is not authorized to open" do
+      # A saved scan keeps probes that a later sync disables, but ProbePolicy#show? denies
+      # those to anyone who is not a super admin, so linking one offers navigation that
+      # bounces off Pundit. Historical probes stay visible, just not linked.
+      member = create(:user, company: company)
+      member.update!(current_company: company)
+      sign_in member
+
+      odin = create(:detector, name: "0din.MitigationBypass")
+      live = create(:probe, name: "LiveProbe", detector: odin)
+      retired = create(:probe, name: "RetiredProbe", detector: odin, enabled: false)
+      ActsAsTenant.with_tenant(company) { scan.probes = [ live, retired ] }
+
+      get :show, params: { id: scan.id }
+
+      doc = Nokogiri::HTML(response.body)
+      expect(doc.css("a[href='#{probe_path(live)}']")).to be_present
+      expect(doc.css("a[href='#{probe_path(retired)}']")).to be_empty
+      expect(response.body).to include("RetiredProbe")
+    end
+
+    it "qualifies groups whose friendly names collide" do
+      odin = create(:detector, name: "0din.MitigationBypass")
+      upstream = create(:detector, name: "mitigation.MitigationBypass")
+      ActsAsTenant.with_tenant(company) do
+        scan.probes = [ create(:probe, name: "FromOdin", detector: odin),
+                        create(:probe, name: "FromUpstream", detector: upstream) ]
+      end
+
+      get :show, params: { id: scan.id }
+
+      expect(response.body).to include("0din.MitigationBypass")
+      expect(response.body).to include("mitigation.MitigationBypass")
+    end
+  end
+
   describe "GET #index" do
     it "returns success" do
       get :index

--- a/spec/models/detector_display_name_spec.rb
+++ b/spec/models/detector_display_name_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Detector, "display naming" do
+  # Detector labels were built inline in four places as
+  # I18n.t("detectors.names.#{name.split('.').last}"), keying on the last segment alone.
+  # Two detectors from different namespaces therefore rendered the same friendly name with
+  # different numbers beside them, which is what made a report's rows look contradictory.
+  describe ".display_label" do
+    it "uses the friendly name for a known detector" do
+      expect(described_class.display_label("0din.MitigationBypass")).to eq("Generic Mitigation Bypass Checks")
+    end
+
+    it "falls back to the bare class name when there is no friendly name" do
+      expect(described_class.display_label("divergence.Repeat")).to eq("Repeat")
+    end
+
+    it "handles an unqualified name" do
+      expect(described_class.display_label("MitigationBypass")).to eq("Generic Mitigation Bypass Checks")
+    end
+
+    it "tolerates a missing name" do
+      expect(described_class.display_label(nil)).to eq("Unknown")
+    end
+  end
+
+  describe ".qualifier_for" do
+    # The qualifier is what tells two identically-labelled rows apart.
+    it "is the full identifier when the friendly name hides it" do
+      expect(described_class.qualifier_for("0din.MitigationBypass")).to eq("0din.MitigationBypass")
+      expect(described_class.qualifier_for("mitigation.MitigationBypass")).to eq("mitigation.MitigationBypass")
+    end
+
+    it "distinguishes two detectors that share a friendly name" do
+      a = "0din.MitigationBypass"
+      b = "mitigation.MitigationBypass"
+
+      expect(described_class.display_label(a)).to eq(described_class.display_label(b))
+      expect(described_class.qualifier_for(a)).not_to eq(described_class.qualifier_for(b))
+    end
+
+    it "is nil when the label already says everything the identifier does" do
+      # No friendly mapping and no namespace: the label IS the identifier, so repeating it
+      # underneath would be noise.
+      expect(described_class.qualifier_for("Repeat")).to be_nil
+    end
+
+    it "tolerates a missing name" do
+      expect(described_class.qualifier_for(nil)).to be_nil
+    end
+  end
+
+  describe "#display_label" do
+    it "reads from the record's own name" do
+      detector = build(:detector, name: "0din.MitigationBypass")
+
+      expect(detector.display_label).to eq("Generic Mitigation Bypass Checks")
+      expect(detector.qualifier).to eq("0din.MitigationBypass")
+    end
+  end
+end

--- a/spec/requests/report_metric_reconciliation_spec.rb
+++ b/spec/requests/report_metric_reconciliation_spec.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The reported confusion, as two fixtures:
+#
+#   * one report showed a probe at 2.2% (4/180) on the overview and a detector at
+#     100% (180/180) in the details. Both were right -- different levels, different
+#     denominators -- but nothing on the page said so.
+#   * another showed two rows both reading "Generic Mitigation Bypass Checks", one
+#     4/4 and one 185/185, with no way to tell which was which.
+RSpec.describe "Reconciling report metrics", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { ActsAsTenant.with_tenant(company) { create(:user, :super_admin, company: company) } }
+  let(:scan) { ActsAsTenant.with_tenant(company) { create(:complete_scan, company: company) } }
+  let(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company) } }
+
+  before do
+    user.update!(current_company: company)
+    sign_in user
+    ActsAsTenant.current_tenant = company
+  end
+
+  context "a probe rate and a detector rate that look contradictory" do
+    let!(:report) do
+      ActsAsTenant.with_tenant(company) do
+        report = create(:report, company: company, scan: scan, target: target, status: :completed)
+        detector = create(:detector, name: "divergence.Repeat")
+        probe = create(:probe, name: "RepeatDiverges", detector: detector)
+        # 4 of 180 attempts succeeded for the probe...
+        create(:probe_result, report: report, probe: probe, detector: detector, passed: 4, total: 180)
+        # ...while the detector evaluated all 180 outputs and fired on every one.
+        create(:detector_result, report: report, detector: detector, passed: 180, total: 180)
+        report
+      end
+    end
+
+    # The two figures live on different surfaces -- detector stats on the overview, probe
+    # rows in the lazily-loaded probes tab -- which is part of why they were hard to
+    # reconcile. Each states its own level and basis.
+    it "states the detector table's level and basis on the overview" do
+      get report_path(report)
+
+      expect(response.body).to match(/one row per detector/i)
+      # Reports::Process assigns the same total_evaluated to detector_stats[:total] as to
+      # ProbeResult#total. garak's evaluator sets it to passes + fails counted once per
+      # entry in attempt.detector_results, which aligns with attempt.outputs -- so this
+      # counts outputs, and one prompt run with several generations counts several times.
+      expect(response.body).to match(/outputs that detector evaluated/i)
+      expect(response.body).to include("180 / 180").or include("180/180")
+    end
+
+    it "states the probe table's level and basis on the probes tab" do
+      get probes_tab_report_path(report)
+
+      expect(response.body).to match(/one row per probe/i)
+      expect(response.body).to match(/outputs evaluated for that probe/i)
+      expect(response.body).to include("4 / 180").or include("4/180")
+    end
+  end
+
+  context "two detectors sharing one friendly name" do
+    let!(:report) do
+      ActsAsTenant.with_tenant(company) do
+        report = create(:report, company: company, scan: scan, target: target, status: :completed)
+        create(:detector_result, report: report, detector: create(:detector, name: "0din.MitigationBypass"),
+                                 passed: 4, total: 4)
+        create(:detector_result, report: report, detector: create(:detector, name: "mitigation.MitigationBypass"),
+                                 passed: 185, total: 185)
+        report
+      end
+    end
+
+    it "distinguishes the rows by the identifier behind the shared label" do
+      get report_path(report)
+
+      expect(response.body).to include("0din.MitigationBypass")
+      expect(response.body).to include("mitigation.MitigationBypass")
+    end
+
+    it "distinguishes the detector cards on the customer report too" do
+      # The customer page and its PDF render their own detector cards; without the
+      # identifier they are two identical "Generic Mitigation Bypass Checks" tiles.
+      get report_detail_path(report)
+
+      expect(response.body).to include("0din.MitigationBypass")
+      expect(response.body).to include("mitigation.MitigationBypass")
+    end
+
+    it "distinguishes the detector behind each probe row" do
+      ActsAsTenant.with_tenant(company) do
+        odin = Detector.find_by(name: "0din.MitigationBypass")
+        create(:probe_result, report: report, probe: create(:probe, name: "SharedLabelProbe"),
+                              detector: odin, passed: 1, total: 2)
+      end
+
+      get probes_tab_report_path(report)
+
+      expect(response.body).to include("0din.MitigationBypass")
+    end
+  end
+
+  describe "a variant child report, whose rows are one per probe and variant" do
+    let(:parent) do
+      ActsAsTenant.with_tenant(company) { create(:report, company: company, scan: scan, target: target) }
+    end
+
+    let(:report) do
+      ActsAsTenant.with_tenant(company) do
+        child = create(:report, company: company, scan: scan, target: target,
+                                status: :completed, parent_report: parent)
+        probe = create(:probe, name: "SharedProbe")
+        # A variant child records one result per threat variant, so the same probe
+        # appears on several rows -- each with its own variant-scoped denominator.
+        2.times do |i|
+          create(:probe_result, report: child, probe: probe,
+                                threat_variant: create(:threat_variant, probe: probe, prompt: "Variant #{i}"),
+                                passed: 1, total: 5)
+        end
+        child
+      end
+    end
+
+    it "does not claim one row per probe when a probe spans several rows" do
+      get probes_tab_report_path(report)
+
+      expect(response.body).not_to include("One row per probe —")
+      expect(response.body).to include("One row per probe and threat variant")
+    end
+  end
+
+  describe "a child report whose results predate threat variants" do
+    let(:parent) do
+      ActsAsTenant.with_tenant(company) { create(:report, company: company, scan: scan, target: target) }
+    end
+
+    let(:report) do
+      ActsAsTenant.with_tenant(company) do
+        # is_variant_report? is true for any child, but a child recorded before
+        # threat_variant_id existed holds ordinary per-probe rows -- a shape the
+        # customer view still supports via variant_industry_tag's nil fallback.
+        child = create(:report, company: company, scan: scan, target: target,
+                                status: :completed, parent_report: parent)
+        create(:probe_result, report: child, probe: create(:probe, name: "LegacyProbe"),
+                              threat_variant: nil, passed: 1, total: 5)
+        child
+      end
+    end
+
+    it "describes the rows it actually renders, not the report type" do
+      get probes_tab_report_path(report)
+
+      expect(response.body).to include("One row per probe —")
+      expect(response.body).not_to include("One row per probe and threat variant")
+    end
+  end
+
+  describe "the denominator the probe rate is taken over" do
+    let(:report) do
+      ActsAsTenant.with_tenant(company) do
+        r = create(:report, company: company, scan: scan, target: target, status: :completed)
+        create(:probe_result, report: r, probe: create(:probe, name: "CountedProbe"), passed: 1, total: 4)
+        r
+      end
+    end
+
+    it "names evaluated outputs rather than attempts" do
+      # ProbeResult#total is garak's total_evaluated: one count per evaluated output.
+      # "Attempts" names a different collection, so using it here would restate the
+      # ticket's own defect in the copy meant to fix it.
+      get probes_tab_report_path(report)
+
+      expect(response.body).to include("outputs evaluated")
+      expect(response.body).not_to include("rate over the attempts")
+    end
+  end
+end

--- a/spec/views/admin/reports/detector_statistics_labels_spec.rb
+++ b/spec/views/admin/reports/detector_statistics_labels_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "admin/reports/_statistics_section", type: :view do
+  # The reported confusion: one report showed two rows both reading "Generic Mitigation
+  # Bypass Checks" with different numbers (4/4 and 185/185), and a probe row of 4/180
+  # beside a detector row of 180/180 for related work. Both distinctions were real; the
+  # page explained neither.
+  let(:company) { create(:company) }
+  let(:scan) { create(:complete_scan, company: company) }
+  let(:target) { create(:target, company: company) }
+
+  def detector_rows
+    Nokogiri::HTML(rendered).css("table tbody tr").map { |tr| tr.css("td").first.text.squish }
+  end
+
+  it "tells apart two detectors that share a friendly name" do
+    report = create(:report, company: company, scan: scan, target: target, status: :completed)
+    odin = create(:detector, name: "0din.MitigationBypass")
+    upstream = create(:detector, name: "mitigation.MitigationBypass")
+    create(:detector_result, report: report, detector: odin, passed: 4, total: 4)
+    create(:detector_result, report: report, detector: upstream, passed: 185, total: 185)
+
+    render partial: "admin/reports/statistics_section", locals: { report: report }
+
+    rows = detector_rows
+    expect(rows.count { |r| r.include?("Generic Mitigation Bypass Checks") }).to eq(2)
+    expect(rows.join).to include("0din.MitigationBypass")
+    expect(rows.join).to include("mitigation.MitigationBypass")
+  end
+
+  it "states the level and grouping basis of the detector table" do
+    report = create(:report, company: company, scan: scan, target: target, status: :completed)
+    create(:detector_result, report: report, detector: create(:detector), passed: 1, total: 2)
+
+    render partial: "admin/reports/statistics_section", locals: { report: report }
+
+    expect(rendered).to match(/one row per detector/i)
+    expect(rendered).to match(/outputs that detector evaluated/i)
+  end
+
+  it "does not repeat the identifier when the label already is the identifier" do
+    # "divergence.Repeat" has no friendly mapping, so the row reads "Repeat"; the full
+    # identifier still differs from the label and is worth showing.
+    report = create(:report, company: company, scan: scan, target: target, status: :completed)
+    create(:detector_result, report: report, detector: create(:detector, name: "Repeat"), passed: 1, total: 2)
+
+    render partial: "admin/reports/statistics_section", locals: { report: report }
+
+    expect(detector_rows.first).to eq("Repeat")
+  end
+end


### PR DESCRIPTION
Report labels did not say what level they described, so figures that were both correct read as contradictions: a probe rate and a detector rate stand side by side over different denominators, and two detectors from different namespaces collapsed onto one friendly name and rendered as identical rows carrying different numbers.

- `Detector.display_label` / `Detector.qualifier_for` are now the single source of truth for detector naming, replacing nine independent `name.split(".").last` translations. The qualified identifier renders beside the label wherever a collision is possible — admin statistics, probe cards, and the customer report — so same-named rows are distinguishable.
- The probe and detector tables each state their level and denominator basis once. The probe line is computed from the rows being rendered rather than the report type: `is_variant_report?` is true for any child, including one whose results predate `threat_variant_id` and whose rows are ordinary per-probe rows.
- Both denominators are named as evaluated outputs, which is what garak counts. Its evaluator sums `passes + fails` once per entry in `attempt.detector_results` (aligned with `attempt.outputs`) and reports it as `total_evaluated`, which `Reports::Process` assigns to both `ProbeResult#total` and `detector_stats[:total]` — so one prompt run with several generations contributes several.
- Scan-definition detector groups expand to list their probes. Probes the viewer is not authorized to open stay listed but unlinked, since `ProbePolicy#show?` denies disabled probes to anyone who is not a super admin.
