### PR TITLE
fix(scans): correct scan token and runtime projections

### DIFF
--- a/app/helpers/scan_helper.rb
+++ b/app/helpers/scan_helper.rb
@@ -24,6 +24,26 @@ module ScanHelper
     @variant_eligible_probe_ids ||= ThreatVariant.distinct.pluck(:probe_id).to_set
   end
 
+  # A Scans::ProjectedFigure as a surface should show it. Durations never render as "0m"
+  # for a non-zero projection: the reported defect was an 89-minute scan displaying zero.
+  def scan_projection_value(figure, unit)
+    return number_with_delimiter(figure.amount) unless unit == :duration
+
+    seconds = figure.amount.to_i
+    return "0m" if seconds <= 0
+    return "< 1m" if seconds < 60
+
+    days = seconds / 86_400
+    hours = (seconds % 86_400) / 3600
+    minutes = (seconds % 3600) / 60
+
+    parts = []
+    parts << "#{days}d" if days.positive?
+    parts << "#{hours}h" if hours.positive?
+    parts << "#{minutes}m" if minutes.positive?
+    parts.join(" ")
+  end
+
   private
 
   def extract_rule_type(recurrence)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -674,10 +674,26 @@ class Report < ApplicationRecord
         total_tokens: input_tokens + output_tokens
       )
 
-      if scan.projected_input_tokens > 0
-        deviation = ((input_tokens - scan.projected_input_tokens).to_f / scan.projected_input_tokens * 100).round(2)
+      # Not Scan#projection: the scan page's view of a scan includes every completed run,
+      # but this report's own probe_results are already committed by the time this metric
+      # runs (after_update_commit), so a projection that includes them would be judging
+      # this report's actual usage against a figure partly made of that same usage.
+      # Excluding this report (and any variant children) keeps the two independent.
+      projected = Scans::Projection.new(scan, exclude_report_id: id).call.input
+      # Coverage must be complete, not merely available: a projection covering one probe
+      # of two omits the uncovered probe's work from `amount` yet still returns a number,
+      # and using it as the full-scan denominator produces a deviation that looks
+      # authoritative while silently excluding part of what actually ran.
+      if projected.available? && projected.amount.positive? && projected.covered == projected.total
+        # Scale to this report's scope before comparing. Scan#create_reports builds one
+        # report per target, so input_tokens above is ONE target's usage, while the
+        # projection covers every target in the scan. Comparing them directly emitted a
+        # systematic -50% deviation for a two-target scan, and reported a
+        # projected_input_tokens the report's own actual could never match.
+        per_target = projected.amount.to_f / [ scan.targets.size, 1 ].max
+        deviation = ((input_tokens - per_target) / per_target * 100).round(2)
         labels[:token_deviation_percent] = deviation
-        labels[:projected_input_tokens] = scan.projected_input_tokens
+        labels[:projected_input_tokens] = per_target.round
       end
     end
 

--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -5,7 +5,6 @@ class Scan < ApplicationRecord
 
     # Projection period for monthly token estimates (in days)
     PROJECTION_PERIOD_DAYS = 30
-    OUTPUT_MULTIPLIER = 2
 
     class IceCubeScheduleCoder
       def self.dump(schedule)
@@ -132,15 +131,11 @@ class Scan < ApplicationRecord
       reports.order(created_at: :desc, id: :desc).pick(:status)
     end
 
-  # Token usage estimation methods
-  # Note: Only INPUT tokens can be estimated (from probe prompts)
-  # Output tokens are unpredictable as they depend on model responses
-
-  # Returns the projected input tokens per scan based on selected probes
-  # Memoized to avoid repeated queries when called multiple times (e.g., in monthly_token_projection)
-  # @return [Integer] Sum of input_tokens from all selected probes
-  def projected_input_tokens
-    @projected_input_tokens ||= probes.sum(:input_tokens)
+  # What this scan is likely to cost and how long it is likely to take.
+  # See Scans::Projection for why this is derived from measured history rather than from
+  # the probes' stored prompt text.
+  def projection
+    @projection ||= Scans::Projection.new(self).call
   end
 
   # Returns the monthly token projection for scheduled scans
@@ -149,6 +144,9 @@ class Scan < ApplicationRecord
   def monthly_token_projection
     return nil unless scheduled?
 
+    per_scan = projection.input
+    return nil unless per_scan.available?
+
     schedule = IceCube::Schedule.new(Time.current)
     schedule.add_recurrence_rule(recurrence)
     runs = schedule.occurrences_between(
@@ -156,40 +154,7 @@ class Scan < ApplicationRecord
       PROJECTION_PERIOD_DAYS.days.from_now
     ).count
 
-    {
-      runs: runs,
-      tokens: runs * projected_input_tokens
-    }
-  end
-
-  # Estimate run time based on targets' token processing rates
-  # Returns nil if no API targets with measured rates
-  # @return [Hash, nil] { seconds: Integer, formatted: String, parallel_limit: Integer, unmeasured_targets: Integer }
-  def estimated_run_time
-    api_targets = targets.where(target_type: :api).where.not(tokens_per_second: nil)
-    return nil if api_targets.empty?
-
-    input_tokens = projected_input_tokens
-    return nil if input_tokens.zero?
-
-    # Calculate time for each target (seconds)
-    # Multiply by OUTPUT_MULTIPLIER to account for unpredictable output token generation
-    estimated_total_tokens = input_tokens * OUTPUT_MULTIPLIER
-    target_times = api_targets.map { |t| estimated_total_tokens.to_f / t.tokens_per_second }
-
-    # With parallelism: total sequential time / parallel limit
-    parallel_limit = SettingsService.parallel_scans_limit
-    estimated_seconds = (target_times.sum / parallel_limit).round
-
-    # Count unmeasured API targets
-    unmeasured = targets.where(target_type: :api, tokens_per_second: nil).count
-
-    {
-      seconds: estimated_seconds,
-      formatted: format_duration(estimated_seconds),
-      parallel_limit: parallel_limit,
-      unmeasured_targets: unmeasured
-    }
+    { runs: runs, tokens: runs * per_scan.amount }
   end
 
   # Returns actual token usage averages from completed reports
@@ -291,20 +256,6 @@ class Scan < ApplicationRecord
 
     def generate_uuid
       self.uuid = SecureRandom.uuid unless self.uuid
-    end
-
-    def format_duration(seconds)
-      return "0m" if seconds <= 0
-
-      days = seconds / 86400
-      hours = (seconds % 86400) / 3600
-      minutes = (seconds % 3600) / 60
-
-      parts = []
-      parts << "#{days}d" if days > 0
-      parts << "#{hours}h" if hours > 0
-      parts << "#{minutes}m" if minutes > 0 || parts.empty?
-      parts.join(" ")
     end
 
     def create_reports

--- a/app/models/scans/projected_figure.rb
+++ b/app/models/scans/projected_figure.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Scans
+  # One projected quantity — input tokens, output tokens, or runtime seconds — together
+  # with how it was arrived at.
+  #
+  # It exists to keep three states apart that a plain Integer could not:
+  #
+  #   measured     -- derived from what these probes actually cost before
+  #   estimated    -- derived from static prompt text, because they have never run
+  #   unavailable  -- neither basis exists; no number can honestly be shown
+  #
+  # The previous projection collapsed all three into one Integer, so a scan whose probes
+  # generate their prompts at runtime -- and therefore store no prompt text at all --
+  # projected 598 tokens against an actual 84,756. Surfaces now ask #available? rather
+  # than treating a small number as a measurement.
+  class ProjectedFigure
+    BASES = %i[measured estimated unavailable].freeze
+
+    attr_reader :amount, :basis, :covered, :total
+
+    def initialize(amount:, basis:, covered: 0, total: 0)
+      raise ArgumentError, "unknown basis #{basis.inspect}" unless BASES.include?(basis)
+
+      @amount = amount
+      @basis = basis
+      @covered = covered.to_i
+      @total = total.to_i
+    end
+
+    # Zero is a real projection (an empty scan costs nothing). Absence is nil.
+    def available?
+      !amount.nil?
+    end
+
+    def measured?
+      basis == :measured
+    end
+
+    def coverage_sentence
+      "#{covered} of #{total} probes covered"
+    end
+  end
+end

--- a/app/services/scans/history_eligibility.rb
+++ b/app/services/scans/history_eligibility.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Scans
+  # Which past reports may inform a projection.
+  #
+  # A projection is customer-facing, so it may only be built from runs that measured a
+  # real workload to completion: a run that failed, was stopped, or dropped eval rows
+  # measured less work than it planned, so feeding its totals in drags every later
+  # projection of the same probes downward -- the same direction as the defect this
+  # projection replaced.
+  #
+  # One place, so every rung of the ladder (own-run tokens, own-run duration, per-probe
+  # history, the seconds-per-output rate) agrees on what counts as evidence.
+  module HistoryEligibility
+    module_function
+
+    # `relation` must already reference the `reports` table -- either a Report relation or
+    # something joined to it (ProbeResult.joins(:report)). Adds conditions only, never a
+    # query, so callers keep their query count constant in probe count.
+    def apply(relation)
+      relation
+        .where(reports: { status: Report.statuses[:completed] })
+        # result_completeness is written on the terminal transition, so rows recorded
+        # before that column existed hold NULL. A completed run with no stored value is
+        # complete by virtue of having completed -- the same reading
+        # Report#previous_completed_report takes. `= 'complete'` alone would discard those
+        # rows, being unknown for NULL, and with them most of the tenant's history.
+        .where("reports.result_completeness IS NULL OR reports.result_completeness = 'complete'")
+    end
+  end
+end

--- a/app/services/scans/probe_history.rb
+++ b/app/services/scans/probe_history.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module Scans
+  # What each probe has actually cost this tenant before.
+  #
+  # This is the only honest basis for probes that build their prompts at runtime --
+  # encoding.Inject*, av_spam_scanning.*, divergence.Repeat and friends store no prompt
+  # text at all, so the static projection counted them as zero while they produced most
+  # of the real cost.
+  #
+  # Median rather than mean: the most expensive probes have the fewest runs, and one
+  # outlier run would otherwise dominate the projection.
+  #
+  # The median is over RUNS of a probe, not over probe_result rows. A run is a parent
+  # report plus any variant children, which share its scan_id -- and a variant child
+  # records its own probe_result row against the SAME base probe as its parent. Taking
+  # percentile_cont across individual rows therefore let a family of one 100-token parent
+  # row and ten 20-token variant rows read as ~20, when that family actually cost 300.
+  # Scans::Projection deliberately applies no variant multiplier (variant rows are meant
+  # to be represented in history already), so that error passed straight through and
+  # underprojected variant-carrying scans by orders of magnitude.
+  class ProbeHistory
+    # Same grouping Scans::Projection uses for a scan's own runs, so both rungs of the
+    # ladder agree on what one run is.
+    RUN_FAMILY = "COALESCE(reports.parent_report_id, reports.id)"
+
+    # Written out rather than built by interpolation: every column here is a literal, but
+    # a lambda that interpolates its argument reads as user-controlled SQL to Brakeman,
+    # and an ignore entry would silence the check rather than satisfy it.
+    MEDIAN_SELECT = <<~SQL.squish.freeze
+      probe_results.probe_id,
+      percentile_cont(0.5) WITHIN GROUP (ORDER BY probe_results.input_tokens),
+      percentile_cont(0.5) WITHIN GROUP (ORDER BY probe_results.output_tokens),
+      percentile_cont(0.5) WITHIN GROUP (ORDER BY probe_results.total)
+    SQL
+
+    def self.for(company:, probe_ids:, target_id: nil, exclude_report_id: nil)
+      new(company: company, probe_ids: probe_ids, target_id: target_id, exclude_report_id: exclude_report_id).call
+    end
+
+    def initialize(company:, probe_ids:, target_id: nil, exclude_report_id: nil)
+      @company = company
+      @probe_ids = Array(probe_ids)
+      @target_id = target_id
+      @exclude_report_id = exclude_report_id
+    end
+
+    def call
+      return {} if @probe_ids.empty?
+
+      # No target to prefer: the tenant-wide query alone is both rungs at once, so this
+      # stays the one query it always was.
+      return medians_for(target_scoped: false) unless @target_id
+
+      # Same-target history is stronger evidence (token counts vary with model verbosity),
+      # so it must win where it exists -- but a probe with no same-target sample is not a
+      # probe with no evidence: the tenant-wide query is the fallback for exactly that
+      # probe. `merge` keeps the same-target value wherever both queries have one.
+      medians_for(target_scoped: false).merge(medians_for(target_scoped: true))
+    end
+
+    private
+
+    def medians_for(target_scoped:)
+      rows = median_across_runs(target_scoped: target_scoped).pluck(Arel.sql(MEDIAN_SELECT))
+
+      rows.each_with_object({}) do |(probe_id, input, output, evaluated), acc|
+        # basis is :measured either way -- a tenant-wide fallback is still real recorded
+        # usage, just against a different target than the one being scanned. It is weaker
+        # evidence than a same-target sample (see the class comment), but the caller's
+        # ladder has only :measured/:estimated/:unavailable, and "measured against some
+        # other target" is closer to :measured than to a static-prompt :estimated.
+        acc[probe_id] = { input: input.to_i, output: output.to_i, evaluated: evaluated.to_i }
+      end
+    end
+
+    # Aggregate first, then take the median: one subquery sums each (run-family, probe)
+    # pair, and the outer query takes percentile_cont ACROSS those per-run totals. Still a
+    # single round trip -- a per-probe loop would issue 900+ queries on a real scan.
+    #
+    # The subquery is aliased `probe_results` so its summed columns keep the names the
+    # outer query, MEDIAN_SELECT and `group(:probe_id)` already use; ProbeResult carries no
+    # default scope, so nothing else is silently qualified against the real table.
+    def median_across_runs(target_scoped:)
+      totals_per_run = scope(target_scoped: target_scoped)
+        .group(Arel.sql(RUN_FAMILY), :probe_id)
+        .select(Arel.sql(
+          "probe_results.probe_id AS probe_id, " \
+          "SUM(probe_results.input_tokens) AS input_tokens, " \
+          "SUM(probe_results.output_tokens) AS output_tokens, " \
+          "SUM(probe_results.total) AS total"
+        ))
+
+      ProbeResult.from(Arel.sql("(#{totals_per_run.to_sql}) AS probe_results")).group(:probe_id)
+    end
+
+    def scope(target_scoped:)
+      # ProbeResult carries no company_id; the join is what scopes this to the tenant --
+      # for BOTH the same-target and the tenant-wide query, so the fallback that widens
+      # the query never widens it past this tenant.
+      #
+      # HistoryEligibility is what keeps failed and partial runs out of a customer-facing
+      # projection -- without it a scan that died a third of the way through sets the
+      # median every later scan is projected from. Same rule as every other rung of
+      # Scans::Projection's ladder.
+      relation = HistoryEligibility.apply(
+        ProbeResult.joins(:report).where(reports: { company_id: @company.id })
+      )
+        .where(probe_id: @probe_ids)
+        # Row-level, applied before the per-run sums below: a row that recorded no input
+        # measured nothing, and dropping it from its run's total is the same reading the
+        # unaggregated query took.
+        .where("probe_results.input_tokens > 0")
+
+      relation = relation.where(reports: { target_id: @target_id }) if target_scoped
+      # A caller scoring one particular report (e.g. a monitoring metric evaluating that
+      # report's actual usage) must see history as of before that report existed, or its
+      # own results would silently become part of the basis it's being judged against.
+      # Matches Scans::Projection#own_run_tokens: a variant child shares its parent's
+      # scan_id and would otherwise leave the parent's own results back in through the
+      # child's row, so both the report and its children are excluded together.
+      #
+      # Two separate conditions, not one negated OR: parent_report_id is NULL for every
+      # non-variant report, and `NOT (id = :id OR parent_report_id = :id)` evaluates to
+      # NULL (excluded by WHERE) for any such row via SQL's three-valued logic, not just
+      # for the report being excluded.
+      if @exclude_report_id
+        relation = relation
+          .where.not(reports: { id: @exclude_report_id })
+          .where("reports.parent_report_id IS NULL OR reports.parent_report_id != :id", id: @exclude_report_id)
+      end
+      relation
+    end
+  end
+end

--- a/app/services/scans/projection.rb
+++ b/app/services/scans/projection.rb
@@ -1,0 +1,338 @@
+# frozen_string_literal: true
+
+module Scans
+  # What a scan is likely to cost and how long it is likely to take.
+  #
+  # The projection this replaced was probes.sum(:input_tokens) -- each probe's stored
+  # prompt text counted once. On a reported 13-probe scan that produced 598 input tokens
+  # against an actual 84,756, because nine of the thirteen probes build their prompts at
+  # runtime and store none. No coefficient fixes that; the only basis that works is what
+  # the probes have actually cost before.
+  class Projection
+    # garak's own default (resources/garak.core.yaml). Scanner does not pass
+    # --generations, so this is the value every scan runs under. It applies ONLY to the
+    # estimated rung: measured history already includes it.
+    GENERATIONS = 5
+
+    # A run is a parent report plus any variant children, which share its scan_id. Same
+    # expression Scans::ProbeHistory groups by, so both rungs agree on what one run is.
+    RUN_FAMILY = Arel.sql("COALESCE(reports.parent_report_id, reports.id)")
+
+    Result = Struct.new(:input, :output, :total_tokens, :runtime, keyword_init: true)
+
+    # exclude_report_id: when a caller is scoring one particular report against a
+    # projection (e.g. a monitoring metric evaluating that report's own actual usage),
+    # that report -- and any variant children sharing its scan_id -- must be excluded
+    # from every history query. Otherwise, once the report has completed, it is already
+    # part of its own scan's "measured" history, and the projection it's judged against
+    # is partly itself.
+    def initialize(scan, exclude_report_id: nil)
+      @scan = scan
+      @exclude_report_id = exclude_report_id
+    end
+
+    def call
+      Result.new(
+        input: figure(:input),
+        output: figure(:output),
+        total_tokens: total_figure,
+        runtime: runtime_figure
+      )
+    end
+
+    private
+
+    attr_reader :scan, :exclude_report_id
+
+    def probes
+      @probes ||= scan.probes.to_a
+    end
+
+    def history
+      @history ||= ProbeHistory.for(
+        company: scan.company,
+        probe_ids: probes.map(&:id),
+        target_id: single_target_id,
+        exclude_report_id: exclude_report_id
+      )
+    end
+
+    # Same-target history is preferable, but only a single-target scan has one target to
+    # prefer. Multi-target scans fall back to all history.
+    def single_target_id
+      ids = scan.target_ids
+      ids.size == 1 ? ids.first : nil
+    end
+
+    def target_multiplier
+      [ scan.targets.size, 1 ].max
+    end
+
+    def contributions(kind)
+      probes.map { |probe| contribution(probe, kind) }
+    end
+
+    def contribution(probe, kind)
+      measured = history[probe.id]
+      return [ measured[kind], :measured ] if measured
+
+      static = probe.input_tokens.to_i
+      # Only input can be estimated from prompt text; output is unknowable without history.
+      return [ static * GENERATIONS, :estimated ] if kind == :input && static.positive?
+
+      [ nil, :unavailable ]
+    end
+
+    # What each past run of THIS scan recorded, keyed by run-family: which probes it
+    # measured, and what they cost. Summing a family captures variants, generations and
+    # per-request overhead without modelling any of them, so this rung is checked before
+    # reconstructing from per-probe history.
+    #
+    # NOTE: Report#input_tokens / #output_tokens are memoized Ruby methods over
+    # probe_results, NOT columns. Aggregating must go through probe_results;
+    # `scan.reports.sum(:input_tokens)` raises PG::UndefinedColumn.
+    #
+    # One query, memoized: it feeds both token kinds, the probe-set check in
+    # #comparable_runs and the runtime rung's family filter, so the scan page's query
+    # count stays constant in probe count. It returns one row per (run, probe) pair --
+    # a few thousand on a 900-probe scan with a handful of runs -- which is the price of
+    # knowing WHICH probes each run measured, and still one round trip.
+    def own_runs
+      @own_runs ||= exclude_scored_run(
+        HistoryEligibility.apply(
+          ProbeResult.joins(:report).where(reports: { scan_id: scan.id })
+        )
+      )
+        .group(RUN_FAMILY, :probe_id)
+        .pluck(RUN_FAMILY, :probe_id,
+               Arel.sql("SUM(probe_results.input_tokens)"),
+               Arel.sql("SUM(probe_results.output_tokens)"))
+        .each_with_object({}) do |(family, probe_id, input, output), acc|
+          run = acc[family] ||= { probe_ids: Set.new, input: 0, output: 0 }
+          run[:probe_ids] << probe_id
+          run[:input] += input.to_i
+          run[:output] += output.to_i
+        end
+    end
+
+    # Only a run of the probe set the scan has NOW may stand in for it. AutoUpdateScanProbesJob
+    # and the ordinary edit flow both mutate a scan's probes after it has run, and this rung
+    # reports its total as covering every current probe -- so a 1,000-token run followed by
+    # adding a probe with 5,000-token history kept projecting 1,000, marked :measured over
+    # the full set. A run that measured a probe since REMOVED is wrong in the same way, for
+    # work that will not happen, so the comparison is equality rather than containment.
+    #
+    # Per family rather than all-or-nothing: a newer run matching the current configuration
+    # still counts when an older one does not.
+    def comparable_runs
+      @comparable_runs ||= own_runs.select { |_family, run| run[:probe_ids] == current_probe_ids }
+    end
+
+    def current_probe_ids
+      @current_probe_ids ||= probes.map(&:id).to_set
+    end
+
+    # The median is over run-families, and `Scan#create_reports` builds ONE parent report
+    # PER TARGET -- so a two-target scan has two families per run and this median is one
+    # target's usage, not the scan's. #build_figure applies target_multiplier to it for
+    # the same reason the reconstructed rung does.
+    def own_run_tokens(kind)
+      totals = comparable_runs.values.map { |run| run[kind] }.select(&:positive?).sort
+
+      median(totals)&.round
+    end
+
+    # Interpolated, matching the percentile_cont(0.5) Scans::ProbeHistory takes in
+    # Postgres. The upper middle value (sorted[size / 2]) disagreed with it on every
+    # even-length sample -- [100, 5_000] projected 5_000 where the rung below it would say
+    # 2_550 -- and two-run or two-target histories are the common case, not an edge one.
+    # One helper, used by every Ruby-side median here, so the ladder cannot disagree with
+    # itself about what a median is.
+    def median(sorted)
+      return nil if sorted.empty?
+
+      middle = sorted.size / 2
+      return sorted[middle] if sorted.size.odd?
+
+      (sorted[middle - 1] + sorted[middle]) / 2.0
+    end
+
+    # The report being scored -- and any variant children sharing its scan_id, which
+    # group with it under COALESCE(reports.parent_report_id, reports.id) -- must not
+    # count as their own history.
+    #
+    # Two separate conditions, not `.where.not("id = :id OR parent_report_id = :id")`:
+    # parent_report_id is NULL for every non-variant report, and SQL's three-valued logic
+    # makes `NOT (FALSE OR NULL)` evaluate to NULL rather than TRUE, which a WHERE clause
+    # treats as "exclude" -- that single negated OR silently dropped every unrelated
+    # non-variant row in the scope, not just the report being excluded.
+    def exclude_scored_run(relation)
+      return relation unless exclude_report_id
+
+      relation
+        .where.not(reports: { id: exclude_report_id })
+        .where("reports.parent_report_id IS NULL OR reports.parent_report_id != :id", id: exclude_report_id)
+    end
+
+    # Memoized per kind: #call computes figure(:input) and figure(:output) directly, then
+    # total_figure computes both again to decide whether a total can be honestly shown.
+    # The round trips underneath are memoized in their own right (#own_runs, #history), so
+    # what this saves is the rebuild rather than the query -- but it is what keeps the
+    # query count independent of how many times a surface asks for a figure.
+    def figure(kind)
+      @figures ||= {}
+      @figures[kind] ||= build_figure(kind)
+    end
+
+    def build_figure(kind)
+      own = own_run_tokens(kind)
+      if own
+        # Per-target-family median x targets, matching the reconstructed rung below. The
+        # own-run rung used to return the median unmultiplied, so a two-target scan
+        # projected roughly one target's usage.
+        return ProjectedFigure.new(amount: own * target_multiplier, basis: :measured,
+                                   covered: probes.size, total: probes.size)
+      end
+
+      rows = contributions(kind)
+      known = rows.reject { |amount, _| amount.nil? }
+
+      return ProjectedFigure.new(amount: nil, basis: :unavailable, covered: 0, total: rows.size) if known.empty?
+
+      ProjectedFigure.new(
+        amount: known.sum { |amount, _| amount } * target_multiplier,
+        basis: known.all? { |_, basis| basis == :measured } ? :measured : :estimated,
+        covered: known.size,
+        total: rows.size
+      )
+    end
+
+    def total_figure
+      inputs = figure(:input)
+      outputs = figure(:output)
+      # A total is only honest when BOTH halves cover the SAME probes. Availability alone
+      # is too weak a guard: with probe A measured and probe B carrying only prompts,
+      # input covers both (A measured, B estimated) while output covers only A, because
+      # output cannot be estimated from prompt text. Both halves are then available, and
+      # summing them renders a confident total that silently omits B's output while
+      # claiming input's larger coverage -- the exact defect this projection replaced.
+      unless inputs.available? && outputs.available? && inputs.covered == outputs.covered
+        return ProjectedFigure.new(amount: nil, basis: :unavailable, covered: 0, total: probes.size)
+      end
+
+      ProjectedFigure.new(
+        amount: inputs.amount + outputs.amount,
+        basis: inputs.measured? && outputs.measured? ? :measured : :estimated,
+        covered: inputs.covered,
+        total: inputs.total
+      )
+    end
+
+    # modeled_seconds is always :estimated below, even when every probe's per-token
+    # figures came from fully :measured history (see #figure). That's not an
+    # inconsistency to fix: modeled_seconds still applies a company-wide rate (seconds
+    # per evaluated output) to THIS scan's projected output count, and a rate applied to
+    # a projection is weaker evidence than a recorded wall-clock duration from an actual
+    # past run of this scan. Runtime only ever claims :measured from own_run_seconds, one
+    # rung up -- never from a model, however well-measured its inputs.
+    def runtime_figure
+      own = own_run_seconds
+      return ProjectedFigure.new(amount: own, basis: :measured, covered: probes.size, total: probes.size) if own
+
+      modeled = modeled_seconds
+      if modeled
+        # modeled_seconds sums history.values, so ONLY probes with recorded history move
+        # this number: adding a never-run probe leaves it unchanged. Claiming
+        # probes.size covered made the basis line assert those probes were accounted for.
+        return ProjectedFigure.new(amount: modeled, basis: :estimated,
+                                   covered: history.size, total: probes.size)
+      end
+
+      ProjectedFigure.new(amount: nil, basis: :unavailable, covered: 0, total: probes.size)
+    end
+
+    # The best predictor of this scan's duration is this scan's own duration.
+    #
+    # Grouped by run-family exactly as #own_runs is, and summed within a family: a variant
+    # child is executed work belonging to its parent's run, so a 60-minute parent with a
+    # 30-minute child is a 90-minute run. Treating each report as an independent duration
+    # sample took the median of 60 and 30 and reported 60.
+    #
+    # Restricted to #comparable_runs for the same reason the token rung is: a run of a
+    # different probe set is not this scan's duration. A run that recorded no probe_results
+    # at all leaves no evidence of what it ran, so it cannot be claimed as :measured for the
+    # current configuration either -- HistoryEligibility already limits this to completed,
+    # complete runs, which record their results.
+    def own_run_seconds
+      families = comparable_runs.keys.to_set
+      return nil if families.empty?
+
+      by_run = HistoryEligibility.apply(exclude_scored_run(scan.reports))
+        .where.not(start_time: nil).where.not(end_time: nil)
+        .pluck(RUN_FAMILY, :start_time, :end_time)
+        .each_with_object(Hash.new(0)) do |(run_id, start_time, end_time), acc|
+          next unless families.include?(run_id)
+
+          acc[run_id] += (end_time - start_time).to_i
+        end
+
+      median(by_run.values.select(&:positive?).sort)&.round
+    end
+
+    # Scans are latency-bound, not throughput-bound: on a measured 79-minute run only
+    # 4.1 minutes were token time. So runtime is modeled per evaluated output, never as
+    # tokens divided by a target's tokens_per_second.
+    def modeled_seconds
+      # Targets are modelled as SERIAL, and this OVERSTATES multi-target runtime.
+      #
+      # StartPendingScansJob#perform limits a non-priority scan's reports by available
+      # slots and then starts each one in the same pass, so a scan's per-target reports DO
+      # overlap when slots allow. Two 100-second targets therefore project ~200 seconds
+      # against a wall clock nearer 100.
+      #
+      # Kept serial for now because the honest fix is not a divisor: actual overlap
+      # depends on slots free at dispatch, so it varies per run. Modelling it properly
+      # belongs with the run-shape work (projecting a run -- its per-target reports and
+      # their variant children -- as one unit) rather than as a coefficient here.
+      # Overstating runtime is the safe direction meanwhile; the defect this replaced
+      # rendered an 89-minute scan as "0m".
+      outputs = history.values.sum { |row| row[:evaluated] } * target_multiplier
+      return nil unless outputs.positive?
+
+      rate = seconds_per_output
+      return nil unless rate
+
+      (outputs * rate).round
+    end
+
+    # One grouped query, not one per report: the scan page must not issue a query per
+    # historical report.
+    def seconds_per_output
+      evaluated_by_report = exclude_scored_run(
+        HistoryEligibility.apply(
+          ProbeResult.joins(:report).where(reports: { company_id: scan.company_id })
+        )
+      )
+        .group(:report_id)
+        .sum(:total)
+
+      return nil if evaluated_by_report.empty?
+
+      durations = Report
+        .where(id: evaluated_by_report.keys)
+        .where.not(start_time: nil).where.not(end_time: nil)
+        .pluck(:id, :start_time, :end_time)
+
+      samples = durations.filter_map do |id, start_time, end_time|
+        evaluated = evaluated_by_report[id].to_i
+        seconds = (end_time - start_time).to_f
+        next unless evaluated.positive? && seconds.positive?
+
+        seconds / evaluated
+      end.sort
+
+      # Not rounded: this is a per-output rate, and #modeled_seconds rounds the product.
+      median(samples)
+    end
+  end
+end

--- a/app/services/scans/stats_serializer.rb
+++ b/app/services/scans/stats_serializer.rb
@@ -125,9 +125,18 @@ module Scans
     def token_info
       monthly = scan.monthly_token_projection
       actual = scan.actual_token_averages
+      projected_input = scan.projection.input
 
       result = {
-        projected_input_per_scan: scan.projected_input_tokens
+        projected_input_per_scan: projected_input.amount,
+        # Sibling metadata so a consumer of the bare amount can tell a full projection
+        # from a partial one instead of reading a low number as a complete measurement --
+        # the same distinction the scan page's coverage qualifier draws for this figure.
+        projected_input_basis: {
+          basis: projected_input.basis,
+          covered: projected_input.covered,
+          total: projected_input.total
+        }
       }
 
       if monthly

--- a/app/views/admin/scans/show.html.erb
+++ b/app/views/admin/scans/show.html.erb
@@ -157,26 +157,56 @@
     <h3 class="text-xl font-sans font-semibold text-primary tracking-wide mb-6">Token Usage Estimate</h3>
     <table class="w-full">
       <tbody class="divide-y divide-borderPrimary">
-        <tr>
-          <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Projected Per Scan</th>
-          <td class="py-3 text-sm text-contentPrimary">
-            <span class="text-xl font-bold text-primary">~<%= number_with_delimiter(@scan.projected_input_tokens) %></span>
-            <span class="text-contentTertiary ml-1">tokens (input only)</span>
-          </td>
-        </tr>
-        <% if (estimate = @scan.estimated_run_time) %>
+        <%
+          projection = @scan.projection
+          rows = [
+            [ "Projected Input", projection.input, :tokens ],
+            [ "Projected Output", projection.output, :tokens ],
+            [ "Projected Total", projection.total_tokens, :tokens ],
+            [ "Estimated Run Time", projection.runtime, :duration ]
+          ]
+        %>
+        <% rows.each do |label, figure, unit| %>
           <tr>
-            <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Estimated Run Time</th>
+            <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4"><%= label %></th>
             <td class="py-3 text-sm text-contentPrimary">
-              <span class="text-xl font-bold text-green-600 dark:text-green-400">~<%= estimate[:formatted] %></span>
-              <% if estimate[:unmeasured_targets] > 0 %>
-                <span class="text-amber-500 dark:text-amber-400 text-sm ml-2">
-                  (excludes <%= estimate[:unmeasured_targets] %> unmeasured target<%= 's' if estimate[:unmeasured_targets] > 1 %>)
-                </span>
+              <% if figure.available? %>
+                <span class="text-xl font-bold text-primary">~<%= scan_projection_value(figure, unit) %></span>
+                <% if unit == :tokens %>
+                  <span class="text-contentTertiary ml-1">tokens</span>
+                <% end %>
+                <%# Each figure covers only the probes IT could be built from, while the
+                    Basis row below states input's coverage for the whole block. Output
+                    cannot be estimated from prompt text, so a scan of one measured probe
+                    and one prompts-only probe shows an output number covering 1 of 2 under
+                    a line claiming 2 of 2. A row that differs says so on its own line
+                    rather than being read as a whole-scan figure. %>
+                <% if [ figure.covered, figure.total ] != [ projection.input.covered, projection.input.total ] %>
+                  <span class="text-contentTertiary ml-1">(<%= figure.coverage_sentence %>)</span>
+                <% end %>
+              <% else %>
+                <%# Saying "unavailable" is the point: the previous projection rendered an
+                    unprojectable scan as a confident small number. %>
+                <span class="text-contentTertiary">unavailable — <%= figure.coverage_sentence %></span>
               <% end %>
             </td>
           </tr>
         <% end %>
+        <tr>
+          <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Basis</th>
+          <td class="py-3 text-sm text-contentTertiary">
+            <%# Branches on the basis, not on measured?, because "not measured" is two
+                different states: an estimate built from prompt text, and no basis at all.
+                Reading the second as the first printed "estimated from probe prompts"
+                directly under a row saying unavailable with zero probes covered. %>
+            <%= case projection.input.basis
+                when :measured then "measured from previous runs of these probes"
+                when :estimated then "estimated from probe prompts"
+                else "no measured history or stored prompts for these probes"
+                end %>
+            · <%= projection.input.coverage_sentence %>
+          </td>
+        </tr>
         <% if (monthly = @scan.monthly_token_projection) %>
           <tr>
             <th class="py-3 pr-4 text-left text-sm font-medium text-contentSecondary w-1/4">Projected Per Month</th>
@@ -210,7 +240,7 @@
       </tbody>
     </table>
     <div class="mt-4 pt-4 border-t border-borderPrimary">
-      <p class="text-sm text-contentTertiary">Projections estimate INPUT tokens only. Output tokens depend on model responses. Estimates use cl100k_base tokenization (~10% variance by provider).</p>
+      <p class="text-sm text-contentTertiary">Projections use this scan's own measured history when available, falling back to an estimate from probe prompts. See the Basis row above for which applies.</p>
     </div>
   </div>
 

--- a/spec/controllers/admin/scans_controller_spec.rb
+++ b/spec/controllers/admin/scans_controller_spec.rb
@@ -367,6 +367,103 @@ RSpec.describe Admin::ScansController, type: :controller do
     end
   end
 
+  describe "the token usage estimate" do
+    it "labels input, output and total separately and states its basis" do
+      probe = create(:probe, name: "encoding.InjectBase64", input_tokens: 0, prompts: [])
+      ActsAsTenant.with_tenant(company) do
+        past = create(:complete_scan, company: company)
+        tgt = create(:target, company: company)
+        report = create(:report, company: company, scan: past, target: tgt, status: :completed)
+        create(:probe_result, report: report, probe: probe,
+                              input_tokens: 15_140, output_tokens: 322_879, total: 40)
+        scan.probes = [ probe ]
+        scan.targets = [ tgt ]
+      end
+
+      get :show, params: { id: scan.id }
+
+      expect(response.body).to include("Projected Input")
+      expect(response.body).to include("Projected Output")
+      expect(response.body).to include("Projected Total")
+      expect(response.body).to match(/measured from previous runs/i)
+    end
+
+    it "says a projection is unavailable instead of showing a confident small number" do
+      probe = create(:probe, name: "encoding.InjectHex", input_tokens: 0, prompts: [])
+      ActsAsTenant.with_tenant(company) do
+        scan.probes = [ probe ]
+        scan.targets = [ create(:target, company: company) ]
+      end
+
+      get :show, params: { id: scan.id }
+
+      expect(response.body).to match(/unavailable/i)
+    end
+
+    it "does not claim an estimate exists when there is no basis at all" do
+      # The basis line branched on measured?, so "not measured" printed "estimated from
+      # probe prompts" -- directly under a row saying unavailable with 0 of 1 probes
+      # covered. Absence of a basis is a third state, and it has to say so.
+      probe = create(:probe, name: "encoding.InjectHex", input_tokens: 0, prompts: [])
+      ActsAsTenant.with_tenant(company) do
+        scan.probes = [ probe ]
+        scan.targets = [ create(:target, company: company) ]
+      end
+
+      get :show, params: { id: scan.id }
+
+      expect(response.body).not_to match(/estimated from probe prompts/i)
+      expect(response.body).to match(/no measured history or stored prompts/i)
+    end
+
+    it "never renders a non-trivial scan as zero minutes" do
+      # The reported defect: 89.3 minutes of real runtime displayed as "0m".
+      probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+      ActsAsTenant.with_tenant(company) do
+        tgt = create(:target, company: company)
+        past = create(:complete_scan, company: company)
+        report = create(:report, company: company, scan: past, target: tgt, status: :completed)
+        create(:probe_result, report: report, probe: probe,
+                              input_tokens: 1_000, output_tokens: 1_000, total: 10)
+        scan.probes = [ probe ]
+        scan.targets = [ tgt ]
+        own_run = create(:report, company: company, scan: scan, target: tgt, status: :completed,
+                                  start_time: 89.minutes.ago, end_time: Time.current)
+        # The own-run rung only reuses a duration measured on the scan's current probe set,
+        # so the run has to record which probes it ran.
+        create(:probe_result, report: own_run, probe: probe,
+                              input_tokens: 1_000, output_tokens: 1_000, total: 10)
+      end
+
+      get :show, params: { id: scan.id }
+
+      expect(response.body).not_to match(/~\s*0m/)
+    end
+
+    it "qualifies a row that covers fewer probes than the shared basis line claims" do
+      # Output cannot be estimated from prompt text, so a measured probe alongside a
+      # prompts-only probe leaves input covering 2 of 2 and output covering 1 of 2. The
+      # page printed a single Basis line taken from input, presenting the output number as
+      # a whole-scan figure.
+      measured = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+      prompts_only = create(:probe, name: "PromptsOnly", input_tokens: 244, prompts: [ "hi" ])
+      ActsAsTenant.with_tenant(company) do
+        tgt = create(:target, company: company)
+        past = create(:complete_scan, company: company)
+        report = create(:report, company: company, scan: past, target: tgt, status: :completed)
+        create(:probe_result, report: report, probe: measured,
+                              input_tokens: 1_000, output_tokens: 8_500, total: 10)
+        scan.probes = [ measured, prompts_only ]
+        scan.targets = [ tgt ]
+      end
+
+      get :show, params: { id: scan.id }
+
+      expect(response.body).to include("2 of 2 probes covered") # the Basis line, from input
+      expect(response.body).to include("1 of 2 probes covered") # the output row's own coverage
+    end
+  end
+
   describe "DELETE #destroy" do
     it "deletes the scan" do
       expect {

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -943,15 +943,84 @@ RSpec.describe Report, type: :model do
           # Create probes with input_tokens and add them to the scan
           probe1 = create(:probe, input_tokens: 500)
           probe2 = create(:probe, input_tokens: 300)
-          report.scan.probes << [ probe1, probe2 ]
+          # Replaces (not appends to) the scan's probes: :complete_scan ships 2 default
+          # probes with no stored input_tokens and no history, which Scans::Projection
+          # can only mark :unavailable -- they'd count toward `total` but never `covered`.
+          # Appending onto them would leave this scan's projection at 2 of 4 probes
+          # covered, which the completeness guard (covered == total) now correctly
+          # treats as partial and skips both labels for. This test is about the
+          # deviation MATH, so it isolates the scan to exactly the 2 probes the
+          # comment below assumes.
+          report.scan.probes = [ probe1, probe2 ]
+
+          report.update!(status: :completed)
+
+          # record_all_completion_metrics passes exclude_report_id: id, so this report's
+          # own just-committed probe_results (input_tokens: 1000, from the shared `before`
+          # block) are excluded from the projection basis -- otherwise it would be judged
+          # against a figure partly made of itself (always 0% deviation). With no other
+          # completed report for this scan, and no prior history for probe1/probe2, the
+          # projection falls to the estimated rung: probe1 (500) + probe2 (300) = 800
+          # static input tokens, times GENERATIONS (5, garak's default generations per
+          # prompt) = 4000, times target_multiplier (report.scan is a :complete_scan,
+          # which factories 2 targets) = 8000 for the whole scan.
+          #
+          # The metric then scales that back to this report's scope: a report covers ONE
+          # target, so it is judged against 8000 / 2 = 4000. Comparing one target's
+          # actual against the whole scan's projection is what produced the previous
+          # expectation of -87.5% / 8000 -- a deviation an on-target run could not avoid.
+          # Deviation: (1000 actual - 4000 projected) / 4000 * 100 = -75.0%.
+          expect(MonitoringService).to have_received(:set_labels).with(
+            hash_including(
+              token_deviation_percent: -75.0,
+              projected_input_tokens: 4000
+            )
+          )
+        end
+
+        it 'compares a report against one target of a multi-target scan, not the whole scan' do
+          # A report that used EXACTLY what one target was projected to use must read as
+          # 0% deviation. report.scan is a :complete_scan (2 targets), and this report's
+          # own probe_results total 1000 input tokens (from the shared `before` block).
+          # Projection: 200 static x GENERATIONS (5) = 1000 per target, x 2 targets =
+          # 2000 for the scan; one target's share is 1000, matching the actual exactly.
+          # Comparing against the un-scaled 2000 reported -50% for a run that was on
+          # target -- a floor no two-target scan could ever get above.
+          expect(report.scan.targets.size).to eq(2)
+          # Replaces (not appends to) the scan's probes for the same reason as the test
+          # above: :complete_scan's 2 default zero-token probes would otherwise leave
+          # coverage at 1 of 3, which the completeness guard now (correctly) treats as
+          # partial and skips both labels for.
+          report.scan.probes = [ create(:probe, input_tokens: 200) ]
 
           report.update!(status: :completed)
 
           expect(MonitoringService).to have_received(:set_labels).with(
             hash_including(
-              token_deviation_percent: 25.0,
-              projected_input_tokens: 800
+              token_deviation_percent: 0.0,
+              projected_input_tokens: 1000
             )
+          )
+        end
+
+        it 'records neither label when the projection covers only part of the scan probes' do
+          # :complete_scan ships 2 default probes with no stored input_tokens (0, the DB
+          # default) and no history, so Scans::Projection cannot assign them a basis --
+          # they count toward `total` but not `covered`. Appending ONE more probe with
+          # real static input_tokens on top of those (unlike the two tests above, which
+          # replace the scan's probes to isolate the math) reproduces exactly the
+          # partial-coverage shape the completeness guard exists for: 1 of 3 covered.
+          expect(report.scan.probes.count).to eq(2)
+          report.scan.probes << create(:probe, input_tokens: 200)
+          expect(report.scan.probes.count).to eq(3)
+
+          report.update!(status: :completed)
+
+          # Before the covered == total guard, this recorded token_deviation_percent and
+          # projected_input_tokens from an amount that silently omitted 2 of the 3
+          # probes' work -- a partial denominator presented as a complete one.
+          expect(MonitoringService).to have_received(:set_labels).with(
+            hash_not_including(:token_deviation_percent, :projected_input_tokens)
           )
         end
       end

--- a/spec/models/scan_spec.rb
+++ b/spec/models/scan_spec.rb
@@ -635,39 +635,6 @@ RSpec.describe Scan, type: :model do
     let(:probe2) { create(:probe, name: 'TokenProbe2', input_tokens: 250) }
     let(:probe3) { create(:probe, name: 'TokenProbe3', input_tokens: 150) }
 
-    describe '#projected_input_tokens' do
-      it 'sums input_tokens from all probes' do
-        scan = build(:scan, company: company)
-        scan.targets = [ target ]
-        scan.probes = [ probe1, probe2, probe3 ]
-        scan.save!
-
-        expect(scan.projected_input_tokens).to eq(500) # 100 + 250 + 150
-      end
-
-      it 'returns 0 when no probes' do
-        scan = build(:scan, company: company)
-        scan.targets = [ target ]
-        scan.probes = [ create(:probe) ] # Need at least one for validation
-        scan.save!
-        scan.probes.clear # Clear after save to test empty case
-
-        expect(scan.projected_input_tokens).to eq(0)
-      end
-
-      it 'handles probes with nil input_tokens as 0' do
-        probe_with_nil = create(:probe, name: 'NilTokenProbe')
-        probe_with_nil.update_column(:input_tokens, 0)
-
-        scan = build(:scan, company: company)
-        scan.targets = [ target ]
-        scan.probes = [ probe1, probe_with_nil ]
-        scan.save!
-
-        expect(scan.projected_input_tokens).to eq(100)
-      end
-    end
-
     describe '#monthly_token_projection' do
       context 'when not scheduled' do
         it 'returns nil' do
@@ -685,7 +652,7 @@ RSpec.describe Scan, type: :model do
         it 'calculates approximately 720 runs per month' do
           scan = build(:scan, company: company)
           scan.targets = [ target ]
-          scan.probes = [ probe1 ] # 100 input_tokens
+          scan.probes = [ probe1 ] # 100 input_tokens, no run history -> estimated * GENERATIONS (5) = 500
           scan.recurrence = IceCube::Rule.hourly
           scan.save!
 
@@ -694,7 +661,7 @@ RSpec.describe Scan, type: :model do
           expect(projection).to be_a(Hash)
           expect(projection[:runs]).to be >= 700 # ~720 runs in 30 days
           expect(projection[:runs]).to be <= 750
-          expect(projection[:tokens]).to eq(projection[:runs] * 100)
+          expect(projection[:tokens]).to eq(projection[:runs] * 500)
         end
       end
 
@@ -702,7 +669,7 @@ RSpec.describe Scan, type: :model do
         it 'calculates approximately 30 runs per month' do
           scan = build(:scan, company: company)
           scan.targets = [ target ]
-          scan.probes = [ probe1, probe2 ] # 350 input_tokens
+          scan.probes = [ probe1, probe2 ] # 350 input_tokens, no run history -> estimated * GENERATIONS (5) = 1750
           scan.recurrence = IceCube::Rule.daily
           scan.save!
 
@@ -710,7 +677,7 @@ RSpec.describe Scan, type: :model do
 
           expect(projection[:runs]).to be >= 29
           expect(projection[:runs]).to be <= 31
-          expect(projection[:tokens]).to eq(projection[:runs] * 350)
+          expect(projection[:tokens]).to eq(projection[:runs] * 1750)
         end
       end
 
@@ -718,7 +685,7 @@ RSpec.describe Scan, type: :model do
         it 'calculates approximately 4 runs per month' do
           scan = build(:scan, company: company)
           scan.targets = [ target ]
-          scan.probes = [ probe1 ] # 100 input_tokens
+          scan.probes = [ probe1 ] # 100 input_tokens, no run history -> estimated * GENERATIONS (5) = 500
           scan.recurrence = IceCube::Rule.weekly
           scan.save!
 
@@ -726,7 +693,7 @@ RSpec.describe Scan, type: :model do
 
           expect(projection[:runs]).to be >= 4
           expect(projection[:runs]).to be <= 5
-          expect(projection[:tokens]).to eq(projection[:runs] * 100)
+          expect(projection[:tokens]).to eq(projection[:runs] * 500)
         end
       end
     end
@@ -829,216 +796,35 @@ RSpec.describe Scan, type: :model do
         expect(Scan::PROJECTION_PERIOD_DAYS).to eq(30)
       end
     end
+  end
 
-    describe '#estimated_run_time' do
-      let(:target_with_rate) { create(:target, :with_token_rate, company: company) }
-      let(:target_without_rate) { create(:target, company: company, tokens_per_second: nil) }
-      let(:webchat_target) { create(:target, :webchat, company: company, tokens_per_second: 30.0) }
-      let(:probe_100) { create(:probe, name: 'Probe100', input_tokens: 100) }
-      let(:probe_200) { create(:probe, name: 'Probe200', input_tokens: 200) }
+  describe "#projection" do
+    let(:company) { create(:company) }
 
-      before do
-        allow(SettingsService).to receive(:parallel_scans_limit).and_return(5)
+    it "no longer projects from stored prompt text alone" do
+      # The defect: probes that build prompts at runtime stored no prompt text, so the
+      # old probes.sum(:input_tokens) counted them as zero.
+      scan = ActsAsTenant.with_tenant(company) { create(:complete_scan, company: company) }
+      target = ActsAsTenant.with_tenant(company) { create(:target, company: company) }
+      probe = create(:probe, name: "encoding.InjectBase64", input_tokens: 0, prompts: [])
+      ActsAsTenant.with_tenant(company) do
+        past = create(:complete_scan, company: company)
+        report = create(:report, company: company, scan: past, target: target, status: :completed)
+        create(:probe_result, report: report, probe: probe,
+                              input_tokens: 15_140, output_tokens: 322_879, total: 40)
+        scan.probes = [ probe ]
+        scan.targets = [ target ]
       end
 
-      context 'when no API targets with measured rates exist' do
-        it 'returns nil when all targets are unmeasured' do
-          scan = build(:scan, company: company)
-          scan.targets = [ target_without_rate ]
-          scan.probes = [ probe_100 ]
-          scan.save!
-
-          expect(scan.estimated_run_time).to be_nil
-        end
-
-        it 'returns nil when only webchat targets exist' do
-          scan = build(:scan, company: company)
-          scan.targets = [ webchat_target ]
-          scan.probes = [ probe_100 ]
-          scan.save!
-
-          expect(scan.estimated_run_time).to be_nil
-        end
-
-        it 'returns nil when no targets exist' do
-          scan = build(:scan, company: company)
-          scan.targets = [ target_with_rate ]
-          scan.probes = [ probe_100 ]
-          scan.save!
-          scan.targets.clear
-
-          expect(scan.estimated_run_time).to be_nil
-        end
-      end
-
-      context 'when projected_input_tokens is zero' do
-        it 'returns nil' do
-          scan = build(:scan, company: company)
-          scan.targets = [ target_with_rate ]
-          scan.probes = [ create(:probe, input_tokens: 0) ]
-          scan.save!
-
-          expect(scan.estimated_run_time).to be_nil
-        end
-      end
-
-      context 'when valid targets and probes exist' do
-        let(:scan) do
-          s = build(:scan, company: company)
-          s.targets = [ target_with_rate ]
-          s.probes = [ probe_100, probe_200 ]
-          s.save!
-          s
-        end
-
-        it 'returns a hash with required keys' do
-          result = scan.estimated_run_time
-
-          expect(result).to be_a(Hash)
-          expect(result).to have_key(:seconds)
-          expect(result).to have_key(:formatted)
-          expect(result).to have_key(:parallel_limit)
-          expect(result).to have_key(:unmeasured_targets)
-        end
-
-        it 'calculates estimated seconds correctly' do
-          # Input tokens: 100 + 200 = 300
-          # With OUTPUT_MULTIPLIER 2: estimated total = 600
-          # Target rate: 25.5 tok/s
-          # Time for one target: 600 / 25.5 = ~23.53 seconds
-          # With parallel_limit 5: 23.53 / 5 = ~4.71 seconds
-          result = scan.estimated_run_time
-
-          expect(result[:seconds]).to be >= 4
-          expect(result[:seconds]).to be <= 5
-        end
-
-        it 'includes parallel_limit from SettingsService' do
-          result = scan.estimated_run_time
-
-          expect(result[:parallel_limit]).to eq(5)
-        end
-
-        it 'counts unmeasured API targets' do
-          scan.targets << target_without_rate
-
-          result = scan.estimated_run_time
-
-          expect(result[:unmeasured_targets]).to eq(1)
-        end
-
-        it 'returns 0 unmeasured targets when all are measured' do
-          result = scan.estimated_run_time
-
-          expect(result[:unmeasured_targets]).to eq(0)
-        end
-      end
-
-      context 'with multiple targets' do
-        let(:target_fast) { create(:target, company: company, tokens_per_second: 100.0, tokens_per_second_sample_count: 1) }
-        let(:target_slow) { create(:target, company: company, tokens_per_second: 10.0, tokens_per_second_sample_count: 1) }
-
-        it 'sums time across all measured targets' do
-          scan = build(:scan, company: company)
-          scan.targets = [ target_fast, target_slow ]
-          scan.probes = [ probe_100 ] # 100 input tokens
-          scan.save!
-
-          allow(SettingsService).to receive(:parallel_scans_limit).and_return(1)
-
-          result = scan.estimated_run_time
-
-          # With OUTPUT_MULTIPLIER 2: estimated total = 200
-          # Fast target: 200 / 100 = 2 seconds
-          # Slow target: 200 / 10 = 20 seconds
-          # Total: 22 seconds / 1 parallel = 22 seconds
-          expect(result[:seconds]).to eq(22)
-        end
-
-        it 'divides by parallel limit' do
-          scan = build(:scan, company: company)
-          scan.targets = [ target_fast, target_slow ]
-          scan.probes = [ probe_100 ]
-          scan.save!
-
-          allow(SettingsService).to receive(:parallel_scans_limit).and_return(2)
-
-          result = scan.estimated_run_time
-
-          # Total: 22 seconds / 2 parallel = 11
-          expect(result[:seconds]).to eq(11)
-        end
-      end
-
-      context 'formatted duration' do
-        let(:target_slow) { create(:target, company: company, tokens_per_second: 1.0, tokens_per_second_sample_count: 1) }
-        let(:probe_large) { create(:probe, name: 'LargeProbe', input_tokens: 10000) }
-
-        it 'formats short durations as minutes' do
-          scan = build(:scan, company: company)
-          scan.targets = [ target_with_rate ]
-          scan.probes = [ probe_100 ]
-          scan.save!
-
-          result = scan.estimated_run_time
-
-          expect(result[:formatted]).to match(/\d+m/)
-        end
-
-        it 'formats hours correctly' do
-          scan = build(:scan, company: company)
-          scan.targets = [ target_slow ]
-          scan.probes = [ probe_large ]
-          scan.save!
-
-          allow(SettingsService).to receive(:parallel_scans_limit).and_return(1)
-
-          result = scan.estimated_run_time
-
-          # 10000 tokens / 1 tok/s = 10000 seconds = ~2.7 hours
-          expect(result[:formatted]).to include('h')
-        end
-      end
+      expect(scan.projection.input.amount).to eq(15_140)
     end
 
-    describe '#format_duration (private)' do
-      let(:scan) do
-        s = build(:scan, company: company)
-        s.targets = [ create(:target, company: company) ]
-        s.probes = [ create(:probe) ]
-        s.save!
-        s
-      end
+    it "no longer exposes the replaced projection methods" do
+      scan = ActsAsTenant.with_tenant(company) { create(:complete_scan, company: company) }
 
-      it 'returns "0m" for zero seconds' do
-        expect(scan.send(:format_duration, 0)).to eq('0m')
-      end
-
-      it 'returns "0m" for negative seconds' do
-        expect(scan.send(:format_duration, -10)).to eq('0m')
-      end
-
-      it 'formats minutes only' do
-        expect(scan.send(:format_duration, 120)).to eq('2m')
-      end
-
-      it 'formats hours and minutes' do
-        expect(scan.send(:format_duration, 3720)).to eq('1h 2m')
-      end
-
-      it 'formats days, hours, and minutes' do
-        expect(scan.send(:format_duration, 90120)).to eq('1d 1h 2m')
-      end
-
-      it 'shows 0m when only seconds with no full minutes' do
-        expect(scan.send(:format_duration, 30)).to eq('0m')
-      end
-
-      it 'handles large values' do
-        # 5 days, 3 hours, 45 minutes
-        seconds = (5 * 86400) + (3 * 3600) + (45 * 60)
-        expect(scan.send(:format_duration, seconds)).to eq('5d 3h 45m')
-      end
+      expect(scan).not_to respond_to(:projected_input_tokens)
+      expect(scan).not_to respond_to(:estimated_run_time)
+      expect(described_class).not_to be_const_defined(:OUTPUT_MULTIPLIER)
     end
   end
 end

--- a/spec/models/scans/projected_figure_spec.rb
+++ b/spec/models/scans/projected_figure_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Scans::ProjectedFigure do
+  it "reports an amount when the figure was measured" do
+    figure = described_class.new(amount: 82_765, basis: :measured, covered: 13, total: 13)
+
+    expect(figure).to be_available
+    expect(figure).to be_measured
+    expect(figure.amount).to eq(82_765)
+  end
+
+  it "has no amount when nothing could be projected" do
+    # The defect this type exists to prevent: an unprojectable scan rendered "~598"
+    # as though it were a measurement.
+    figure = described_class.new(amount: nil, basis: :unavailable, covered: 0, total: 13)
+
+    expect(figure).not_to be_available
+    expect(figure.amount).to be_nil
+  end
+
+  it "distinguishes an estimate from a measurement" do
+    figure = described_class.new(amount: 2_990, basis: :estimated, covered: 4, total: 13)
+
+    expect(figure).to be_available
+    expect(figure).not_to be_measured
+  end
+
+  it "states its coverage so a surface can show the basis" do
+    figure = described_class.new(amount: 100, basis: :measured, covered: 12, total: 13)
+
+    expect(figure.coverage_sentence).to eq("12 of 13 probes covered")
+  end
+
+  it "treats a zero amount as a real figure, not as missing" do
+    figure = described_class.new(amount: 0, basis: :measured, covered: 2, total: 2)
+
+    expect(figure).to be_available
+    expect(figure.amount).to eq(0)
+  end
+
+  it "refuses a basis it does not recognise" do
+    # The three states are the whole point of this type; an unrecognised fourth would
+    # silently render as though it were a measurement.
+    expect {
+      described_class.new(amount: 1, basis: :guessed, covered: 1, total: 1)
+    }.to raise_error(ArgumentError, /guessed/)
+  end
+end

--- a/spec/requests/scan_projection_accuracy_spec.rb
+++ b/spec/requests/scan_projection_accuracy_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The reported scan, as a shape rather than an id: 13 probes of which 9 store no prompt
+# text at all, the other 4 summing to 598 tokens, against recorded actuals of 84,756
+# input / 719,244 output over 89.3 minutes. The old projection showed 598 tokens and "0m".
+RSpec.describe "Scan projection accuracy", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { ActsAsTenant.with_tenant(company) { create(:user, :super_admin, company: company) } }
+  let(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company, name: "Grok 4.5") } }
+  let(:scan) { ActsAsTenant.with_tenant(company) { create(:complete_scan, company: company) } }
+
+  # name => [static input_tokens, measured median input, measured median output]
+  PROBE_SHAPE = {
+    "av_spam_scanning.EICAR"  => [ 0,   570,   4_454 ],
+    "av_spam_scanning.GTphish" => [ 0,  566,   3_751 ],
+    "av_spam_scanning.GTUBE"  => [ 0,   536,   3_654 ],
+    "ChemicalEscalationCM"    => [ 43,   40,     324 ],
+    "ChemicalFlowChartCM"     => [ 155, 153,     415 ],
+    "CorrectionRequest"       => [ 156, 618,   2_149 ],
+    "DANAgreementRules"       => [ 244, 354,     469 ],
+    "divergence.Repeat"       => [ 0, 1_578, 156_361 ],
+    "doctor.Puppetry"         => [ 0,   690,   8_758 ],
+    "encoding.InjectBase16"   => [ 0, 14_264, 390_186 ],
+    "encoding.InjectBase64"   => [ 0, 15_140, 322_879 ],
+    "encoding.InjectBraille"  => [ 0, 34_442, 190_743 ],
+    "encoding.InjectHex"      => [ 0, 13_814, 422_669 ]
+  }.freeze
+
+  before do
+    user.update!(current_company: company)
+    sign_in user
+    ActsAsTenant.current_tenant = company
+
+    ActsAsTenant.with_tenant(company) do
+      # The history lives on a DIFFERENT scan, so this scan has never run and the
+      # projection must reconstruct it from per-probe history -- the harder rung, and the
+      # one the reported defect exercised.
+      past = create(:complete_scan, company: company)
+      history_report = create(:report, company: company, scan: past, target: target, status: :completed,
+                                       start_time: 89.minutes.ago, end_time: Time.current)
+      probes = PROBE_SHAPE.map do |name, (static, input, output)|
+        probe = create(:probe, name: name, input_tokens: static, prompts: static.positive? ? [ "x" ] : [])
+        create(:probe_result, report: history_report, probe: probe,
+                              input_tokens: input, output_tokens: output, total: 414)
+        probe
+      end
+      scan.probes = probes
+      scan.targets = [ target ]
+    end
+  end
+
+  it "no longer projects the observed 598 tokens for this workload" do
+    expect(scan.projection.input.amount).not_to eq(598)
+  end
+
+  it "projects input within an order of magnitude of the recorded actual" do
+    actual = 84_756
+    projected = scan.projection.input.amount
+
+    expect(projected).to be > actual / 10
+    expect(projected).to be < actual * 10
+  end
+
+  it "does not render this scan as approximately zero minutes" do
+    get scan_path(scan)
+
+    expect(response.body).not_to match(/~\s*0m/)
+  end
+
+  it "counts input and output as distinct quantities" do
+    projection = scan.projection
+
+    expect(projection.output.amount).not_to eq(projection.input.amount * 2)
+    expect(projection.total_tokens.amount).to eq(projection.input.amount + projection.output.amount)
+  end
+
+  describe "sensitivity" do
+    it "changes when probes are removed" do
+      before_amount = scan.projection.input.amount
+      ActsAsTenant.with_tenant(company) { scan.probes = scan.probes.limit(3).to_a }
+
+      expect(Scans::Projection.new(scan.reload).call.input.amount).to be < before_amount
+    end
+
+    it "changes when a second target is added" do
+      before_amount = scan.projection.input.amount
+      ActsAsTenant.with_tenant(company) do
+        scan.targets = [ target, create(:target, company: company, name: "Second") ]
+      end
+
+      expect(Scans::Projection.new(scan.reload).call.input.amount).to be > before_amount
+    end
+  end
+
+  describe "a small workload" do
+    it "still projects rather than reporting nothing" do
+      small = ActsAsTenant.with_tenant(company) { create(:complete_scan, company: company) }
+      ActsAsTenant.with_tenant(company) do
+        small.probes = [ Probe.find_by(name: "ChemicalEscalationCM") ]
+        small.targets = [ target ]
+      end
+
+      expect(small.projection.input).to be_available
+    end
+  end
+end

--- a/spec/services/scans/probe_history_spec.rb
+++ b/spec/services/scans/probe_history_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Scans::ProbeHistory do
+  let(:company) { create(:company) }
+  let(:probe) { create(:probe, name: "encoding.InjectBase64") }
+
+  def record(input:, output:, total: 10, company_for: company, target: nil)
+    ActsAsTenant.with_tenant(company_for) do
+      scan = create(:complete_scan, company: company_for)
+      tgt = target || create(:target, company: company_for)
+      report = create(:report, company: company_for, scan: scan, target: tgt, status: :completed)
+      create(:probe_result, report: report, probe: probe,
+                            input_tokens: input, output_tokens: output, total: total)
+    end
+  end
+
+  it "returns the median, not the mean, of a probe's recorded usage" do
+    # divergence.Repeat averages 156k output tokens over four runs; the mean is what
+    # pushed the projection 2.1x over. The median resists that.
+    [ 100, 200, 5_000 ].each { |v| record(input: v, output: v * 2) }
+
+    result = described_class.for(company: company, probe_ids: [ probe.id ])
+
+    expect(result[probe.id][:input]).to eq(200)
+    expect(result[probe.id][:output]).to eq(400)
+  end
+
+  it "sums a run's variant children into that run before taking the median" do
+    # A variant child records its own probe_result row against the SAME base probe as its
+    # parent, so a percentile taken across individual rows read this family as ~20 tokens
+    # when the family actually cost 300. Scans::Projection deliberately applies no variant
+    # multiplier -- variant rows are meant to be represented in history already -- so the
+    # understatement went straight into the projection of any scan carrying variants.
+    ActsAsTenant.with_tenant(company) do
+      past = create(:complete_scan, company: company)
+      tgt = create(:target, company: company)
+      parent = create(:report, company: company, scan: past, target: tgt, status: :completed)
+      create(:probe_result, report: parent, probe: probe,
+                            input_tokens: 100, output_tokens: 200, total: 10)
+      # One variant child per run (Report allows a single child), carrying one
+      # probe_result per threat variant -- all against the same base probe, which is
+      # exactly what ProbeResult's (report, probe, threat_variant) uniqueness permits.
+      child = create(:report, company: company, scan: past, target: tgt,
+                              status: :completed, parent_report: parent)
+      subindustry = create(:threat_variant_subindustry)
+      10.times do
+        variant = create(:threat_variant, probe: probe, threat_variant_subindustry: subindustry)
+        create(:probe_result, report: child, probe: probe, threat_variant: variant,
+                              input_tokens: 20, output_tokens: 40, total: 2)
+      end
+    end
+
+    result = described_class.for(company: company, probe_ids: [ probe.id ])
+
+    expect(result[probe.id][:input]).to eq(300)     # 100 + 10 * 20, not the 20 a row-wise median gave
+    expect(result[probe.id][:output]).to eq(600)    # 200 + 10 * 40
+    expect(result[probe.id][:evaluated]).to eq(30)  # 10  + 10 * 2
+  end
+
+  it "takes the median ACROSS runs rather than summing them" do
+    # The fix above aggregates within a run; it must not aggregate across runs, or a probe
+    # would be projected at everything it has ever cost cumulatively.
+    [ 300, 100 ].each do |input|
+      ActsAsTenant.with_tenant(company) do
+        past = create(:complete_scan, company: company)
+        report = create(:report, company: company, scan: past,
+                                 target: create(:target, company: company), status: :completed)
+        create(:probe_result, report: report, probe: probe,
+                              input_tokens: input, output_tokens: input, total: 10)
+      end
+    end
+
+    result = described_class.for(company: company, probe_ids: [ probe.id ])
+
+    # percentile_cont interpolates: the median of two runs is their midpoint, not 400.
+    expect(result[probe.id][:input]).to eq(200)
+  end
+
+  it "ignores another tenant's history entirely" do
+    # ProbeResult has no company_id -- it is tenant-scoped only through its report, so an
+    # unscoped query silently reads every tenant's data and leaks how verbose their
+    # targets are.
+    other = create(:company)
+    record(input: 1_000_000, output: 1_000_000, company_for: other)
+    record(input: 500, output: 700)
+
+    result = described_class.for(company: company, probe_ids: [ probe.id ])
+
+    expect(result[probe.id][:input]).to eq(500)
+  end
+
+  it "reads only runs that measured a workload to completion" do
+    # An unfinished run is not evidence of what a probe costs: a failed or partial run
+    # measured less work than it planned.
+    record(input: 500, output: 700)
+    ineligible = [
+      ->(report) { report.update_columns(result_completeness: "partial") },
+      ->(report) { report.update_columns(status: Report.statuses[:failed]) }
+    ]
+    ineligible.each do |make_ineligible|
+      ActsAsTenant.with_tenant(company) do
+        scan = create(:complete_scan, company: company)
+        report = create(:report, company: company, scan: scan,
+                                 target: create(:target, company: company), status: :completed)
+        make_ineligible.call(report)
+        create(:probe_result, report: report, probe: probe,
+                              input_tokens: 999_999, output_tokens: 999_999, total: 10)
+      end
+    end
+
+    result = described_class.for(company: company, probe_ids: [ probe.id ])
+
+    # percentile_cont interpolates, so any leaked sample moves this off the lone
+    # eligible run's values rather than merely nudging them.
+    expect(result[probe.id][:input]).to eq(500)
+    expect(result[probe.id][:output]).to eq(700)
+  end
+
+  it "omits probes that have never run" do
+    never_run = create(:probe, name: "NeverRun")
+
+    result = described_class.for(company: company, probe_ids: [ probe.id, never_run.id ])
+
+    expect(result).not_to have_key(never_run.id)
+  end
+
+  it "prefers history for the requested target when asked" do
+    grok = ActsAsTenant.with_tenant(company) { create(:target, company: company, name: "Grok") }
+    record(input: 900, output: 900, target: grok)
+    record(input: 100, output: 100)
+
+    result = described_class.for(company: company, probe_ids: [ probe.id ], target_id: grok.id)
+
+    expect(result[probe.id][:input]).to eq(900)
+  end
+
+  it "falls back to tenant-wide history when the probe has none for the requested target" do
+    # A newly created target has no same-target history yet, but the tenant may have run
+    # this probe plenty against other targets -- discarding that entirely is the bug: it
+    # turns "no same-target sample" into "no evidence at all" for exactly the case
+    # (single-target scan, never-run target) this ladder rung exists to answer.
+    grok = ActsAsTenant.with_tenant(company) { create(:target, company: company, name: "Grok") }
+    other_target = ActsAsTenant.with_tenant(company) { create(:target, company: company, name: "Other") }
+    record(input: 700, output: 700, target: other_target)
+
+    result = described_class.for(company: company, probe_ids: [ probe.id ], target_id: grok.id)
+
+    expect(result[probe.id][:input]).to eq(700)
+  end
+
+  it "draws each probe from the right source when only some have same-target history" do
+    probe_two = create(:probe, name: "encoding.InjectBase16")
+    grok = ActsAsTenant.with_tenant(company) { create(:target, company: company, name: "Grok") }
+    other_target = ActsAsTenant.with_tenant(company) { create(:target, company: company, name: "Other") }
+
+    # `probe` has both same-target and other-target history -- same-target must win.
+    record(input: 900, output: 900, target: grok)
+    record(input: 100, output: 100, target: other_target)
+
+    # `probe_two` has only other-target history -- it must fall back rather than vanish.
+    ActsAsTenant.with_tenant(company) do
+      scan = create(:complete_scan, company: company)
+      report = create(:report, company: company, scan: scan, target: other_target, status: :completed)
+      create(:probe_result, report: report, probe: probe_two,
+                            input_tokens: 300, output_tokens: 300, total: 10)
+    end
+
+    result = described_class.for(company: company, probe_ids: [ probe.id, probe_two.id ], target_id: grok.id)
+
+    expect(result[probe.id][:input]).to eq(900)
+    expect(result[probe_two.id][:input]).to eq(300)
+  end
+
+  it "does not leak another company's history through the fallback path" do
+    # The fallback query is broader than the same-target one -- exactly where a tenant
+    # scoping mistake would slip in unnoticed.
+    other = create(:company)
+    grok = ActsAsTenant.with_tenant(company) { create(:target, company: company, name: "Grok") }
+    record(input: 1_000_000, output: 1_000_000, company_for: other)
+
+    result = described_class.for(company: company, probe_ids: [ probe.id ], target_id: grok.id)
+
+    expect(result).not_to have_key(probe.id)
+  end
+
+  it "reads every probe in one query regardless of how many there are" do
+    probes = Array.new(5) { |i| create(:probe, name: "Bulk#{i}") }
+    probes.each do |p|
+      ActsAsTenant.with_tenant(company) do
+        scan = create(:complete_scan, company: company)
+        report = create(:report, company: company, scan: scan,
+                                 target: create(:target, company: company), status: :completed)
+        create(:probe_result, report: report, probe: p, input_tokens: 10, output_tokens: 10, total: 1)
+      end
+    end
+
+    queries = 0
+    counter = ->(*, payload) { queries += 1 unless payload[:name].to_s =~ /SCHEMA|TRANSACTION/ }
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+      described_class.for(company: company, probe_ids: probes.map(&:id))
+    end
+
+    expect(queries).to eq(1)
+  end
+end

--- a/spec/services/scans/projection_spec.rb
+++ b/spec/services/scans/projection_spec.rb
@@ -1,0 +1,572 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Scans::Projection do
+  let(:company) { create(:company) }
+  let(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company) } }
+  let(:scan) { ActsAsTenant.with_tenant(company) { create(:complete_scan, company: company) } }
+
+  def history_for(probe, input:, output:, evaluated: 10)
+    ActsAsTenant.with_tenant(company) do
+      past = create(:complete_scan, company: company)
+      report = create(:report, company: company, scan: past, target: target, status: :completed)
+      create(:probe_result, report: report, probe: probe,
+                            input_tokens: input, output_tokens: output, total: evaluated)
+    end
+  end
+
+  it "projects a probe from what it actually cost, not from its stored prompts" do
+    # encoding.InjectBase64 stores no prompts at all; the static sum counted it as zero
+    # while it really cost ~15k input tokens.
+    probe = create(:probe, name: "encoding.InjectBase64", input_tokens: 0, prompts: [])
+    history_for(probe, input: 15_140, output: 322_879)
+    ActsAsTenant.with_tenant(company) { scan.probes = [ probe ]; scan.targets = [ target ] }
+
+    projection = described_class.new(scan).call
+
+    expect(projection.input.amount).to eq(15_140)
+    expect(projection.input.basis).to eq(:measured)
+  end
+
+  it "falls back to static prompts times generations for a probe that has never run" do
+    probe = create(:probe, name: "NeverRun", input_tokens: 244, prompts: [ "hi" ])
+    ActsAsTenant.with_tenant(company) { scan.probes = [ probe ]; scan.targets = [ target ] }
+
+    projection = described_class.new(scan).call
+
+    expect(projection.input.amount).to eq(244 * Scans::Projection::GENERATIONS)
+    expect(projection.input.basis).to eq(:estimated)
+  end
+
+  it "does not apply the generations multiplier to measured history" do
+    # Historical probe_results already reflect the generations that run used. Applying it
+    # again is the easiest way to build this wrong.
+    probe = create(:probe, name: "Measured", input_tokens: 100, prompts: [ "hi" ])
+    history_for(probe, input: 1_000, output: 2_000)
+    ActsAsTenant.with_tenant(company) { scan.probes = [ probe ]; scan.targets = [ target ] }
+
+    expect(described_class.new(scan).call.input.amount).to eq(1_000)
+  end
+
+  it "is unavailable when a probe has neither history nor prompts" do
+    probe = create(:probe, name: "encoding.InjectHex", input_tokens: 0, prompts: [])
+    ActsAsTenant.with_tenant(company) { scan.probes = [ probe ]; scan.targets = [ target ] }
+
+    projection = described_class.new(scan).call
+
+    expect(projection.input).not_to be_available
+    expect(projection.input.basis).to eq(:unavailable)
+  end
+
+  it "reports partial coverage when only some probes can be projected" do
+    measured = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+    unknown = create(:probe, name: "Unknown", input_tokens: 0, prompts: [])
+    history_for(measured, input: 500, output: 600)
+    ActsAsTenant.with_tenant(company) { scan.probes = [ measured, unknown ]; scan.targets = [ target ] }
+
+    projection = described_class.new(scan).call
+
+    expect(projection.input.covered).to eq(1)
+    expect(projection.input.total).to eq(2)
+  end
+
+  it "projects output separately rather than as a multiple of input" do
+    probe = create(:probe, name: "Verbose", input_tokens: 0, prompts: [])
+    history_for(probe, input: 1_000, output: 8_500)
+    ActsAsTenant.with_tenant(company) { scan.probes = [ probe ]; scan.targets = [ target ] }
+
+    projection = described_class.new(scan).call
+
+    expect(projection.output.amount).to eq(8_500)
+    expect(projection.total_tokens.amount).to eq(9_500)
+  end
+
+  it "prefers this scan's own past runs over reconstructing from probes" do
+    # A variant child shares its parent's scan_id, so summing a run's reports captures
+    # variants, generations and per-request overhead without modelling any of them.
+    probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+    history_for(probe, input: 1_000, output: 1_000)
+    ActsAsTenant.with_tenant(company) do
+      scan.probes = [ probe ]
+      scan.targets = [ target ]
+      # Report#input_tokens is a method over probe_results, not a column -- a run's totals
+      # have to be expressed as probe_result rows.
+      parent = create(:report, company: company, scan: scan, target: target, status: :completed)
+      create(:probe_result, report: parent, probe: probe,
+                            input_tokens: 80_000, output_tokens: 700_000, total: 400)
+      child = create(:report, company: company, scan: scan, target: target,
+                              status: :completed, parent_report: parent)
+      create(:probe_result, report: child, probe: probe,
+                            input_tokens: 4_756, output_tokens: 19_244, total: 14)
+    end
+
+    projection = described_class.new(scan).call
+
+    expect(projection.input.amount).to eq(84_756)
+    expect(projection.input.basis).to eq(:measured)
+  end
+
+  it "does not reuse its own past run once a probe has been added to the scan" do
+    # AutoUpdateScanProbesJob and the ordinary edit flow both mutate a scan's probes after
+    # it has run. The own-run rung reports its total as covering every CURRENT probe, so a
+    # 1,000-token run followed by adding a probe with 5,000-token history kept projecting
+    # 1,000 -- marked :measured over a probe the run never touched.
+    ran = create(:probe, name: "Ran", input_tokens: 0, prompts: [])
+    added = create(:probe, name: "AddedLater", input_tokens: 0, prompts: [])
+    history_for(ran, input: 1_000, output: 1_000)
+    history_for(added, input: 5_000, output: 5_000)
+    ActsAsTenant.with_tenant(company) do
+      scan.probes = [ ran ]
+      scan.targets = [ target ]
+      report = create(:report, company: company, scan: scan, target: target, status: :completed)
+      create(:probe_result, report: report, probe: ran,
+                            input_tokens: 1_000, output_tokens: 1_000, total: 10)
+      scan.probes = [ ran, added ]
+    end
+
+    projection = described_class.new(scan).call
+
+    # Reconstructed from per-probe history for both probes instead of the stale run total.
+    expect(projection.input.amount).to eq(6_000)
+    expect(projection.input.covered).to eq(2)
+  end
+
+  it "does not reuse its own past run once a probe has been removed from the scan" do
+    # The other direction: the run's total includes work the scan will no longer do, so
+    # presenting it as this scan's cost overstates it by whatever the removed probe cost.
+    kept = create(:probe, name: "Kept", input_tokens: 0, prompts: [])
+    dropped = create(:probe, name: "Dropped", input_tokens: 0, prompts: [])
+    history_for(kept, input: 1_000, output: 1_000)
+    ActsAsTenant.with_tenant(company) do
+      scan.probes = [ kept, dropped ]
+      scan.targets = [ target ]
+      report = create(:report, company: company, scan: scan, target: target, status: :completed)
+      create(:probe_result, report: report, probe: kept,
+                            input_tokens: 1_000, output_tokens: 1_000, total: 10)
+      create(:probe_result, report: report, probe: dropped,
+                            input_tokens: 9_000, output_tokens: 9_000, total: 10)
+      scan.probes = [ kept ]
+    end
+
+    projection = described_class.new(scan).call
+
+    expect(projection.input.amount).not_to eq(10_000)
+    expect(projection.input.amount).to eq(1_000)
+  end
+
+  it "interpolates an even-length median rather than taking the upper sample" do
+    # Two runs are two samples, not a preference for the larger one. The upper middle
+    # value projected 5_000 here while Scans::ProbeHistory's percentile_cont -- the rung
+    # directly below this one -- would have said 2_550 for the same pair.
+    probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+    ActsAsTenant.with_tenant(company) do
+      scan.probes = [ probe ]
+      scan.targets = [ target ]
+      [ 100, 5_000 ].each do |amount|
+        report = create(:report, company: company, scan: scan, target: target, status: :completed)
+        create(:probe_result, report: report, probe: probe,
+                              input_tokens: amount, output_tokens: amount, total: 10)
+      end
+    end
+
+    expect(described_class.new(scan).call.input.amount).to eq(2_550)
+  end
+
+  it "does not apply a variant multiplier on top of history" do
+    # An earlier draft multiplied by mapped-variant-count. Measurement showed 50 of 72
+    # variant children carry their own probe_results, so those rows are already in the
+    # history pool and multiplying would double-count them.
+    probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+    history_for(probe, input: 1_000, output: 1_000)
+    subindustry = create(:threat_variant_subindustry)
+    create(:threat_variant, probe: probe, threat_variant_subindustry: subindustry)
+    ActsAsTenant.with_tenant(company) do
+      scan.probes = [ probe ]
+      scan.targets = [ target ]
+      scan.threat_variant_subindustries = [ subindustry ]
+    end
+
+    expect(described_class.new(scan).call.input.amount).to eq(1_000)
+  end
+
+  it "multiplies by the number of targets, because each runs the whole probe set" do
+    probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+    history_for(probe, input: 1_000, output: 1_000)
+    second = ActsAsTenant.with_tenant(company) { create(:target, company: company, name: "Second") }
+    ActsAsTenant.with_tenant(company) { scan.probes = [ probe ]; scan.targets = [ target, second ] }
+
+    expect(described_class.new(scan).call.input.amount).to eq(2_000)
+  end
+
+  it "multiplies its own past run by target count, because one run's reports are one target each" do
+    # Scan#create_reports builds ONE parent report PER TARGET, so grouping past runs by
+    # COALESCE(parent_report_id, id) yields one family per target and the median across
+    # them is a SINGLE target's usage. The own-run rung used to return that unmultiplied,
+    # so a two-target scan projected roughly half of what it costs.
+    probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+    second = ActsAsTenant.with_tenant(company) { create(:target, company: company, name: "Second") }
+    ActsAsTenant.with_tenant(company) do
+      scan.probes = [ probe ]
+      scan.targets = [ target, second ]
+      [ target, second ].each do |tgt|
+        report = create(:report, company: company, scan: scan, target: tgt, status: :completed)
+        create(:probe_result, report: report, probe: probe,
+                              input_tokens: 10_000, output_tokens: 20_000, total: 100)
+      end
+    end
+
+    projection = described_class.new(scan).call
+
+    expect(projection.input.amount).not_to eq(10_000)
+    expect(projection.input.amount).to eq(20_000)
+    expect(projection.input.basis).to eq(:measured)
+  end
+
+  it "has no total when the two halves cover different probes" do
+    # Probe A is measured on both halves; probe B has prompt text but no history, so input
+    # can be estimated for it and output cannot. Both aggregates end up available -- input
+    # covering 2 probes, output covering 1 -- and summing them would render a confident
+    # total that silently omits B's output while claiming input's coverage.
+    measured = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+    prompts_only = create(:probe, name: "PromptsOnly", input_tokens: 244, prompts: [ "hi" ])
+    history_for(measured, input: 1_000, output: 8_500)
+    ActsAsTenant.with_tenant(company) { scan.probes = [ measured, prompts_only ]; scan.targets = [ target ] }
+
+    projection = described_class.new(scan).call
+
+    expect(projection.input).to be_available
+    expect(projection.output).to be_available
+    expect(projection.input.covered).to eq(2)
+    expect(projection.output.covered).to eq(1)
+    expect(projection.total_tokens).not_to be_available
+  end
+
+  it "has no total when output could not be projected" do
+    # A probe with prompts but no history estimates input and cannot estimate output.
+    # Adding them would render a total that silently omits the output half.
+    probe = create(:probe, name: "PromptsOnly", input_tokens: 244, prompts: [ "hi" ])
+    ActsAsTenant.with_tenant(company) { scan.probes = [ probe ]; scan.targets = [ target ] }
+
+    projection = described_class.new(scan).call
+
+    expect(projection.input).to be_available
+    expect(projection.output).not_to be_available
+    expect(projection.total_tokens).not_to be_available
+  end
+
+  it "totals both components when both are measured" do
+    probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+    history_for(probe, input: 1_000, output: 8_500)
+    ActsAsTenant.with_tenant(company) { scan.probes = [ probe ]; scan.targets = [ target ] }
+
+    expect(described_class.new(scan).call.total_tokens.amount).to eq(9_500)
+  end
+
+  describe "eligible history" do
+    # A probe with one legitimate 1_000-token run. percentile_cont interpolates, so any
+    # second sample that leaks in moves the median off 1_000 -- these assertions fail
+    # loudly rather than drifting a little.
+    let(:probe) { create(:probe, name: "Measured", input_tokens: 0, prompts: []) }
+
+    def ineligible_run(input:, &block)
+      ActsAsTenant.with_tenant(company) do
+        past = create(:complete_scan, company: company)
+        report = create(:report, company: company, scan: past, target: target, status: :completed)
+        block&.call(report)
+        create(:probe_result, report: report, probe: probe,
+                              input_tokens: input, output_tokens: input, total: 10)
+        report
+      end
+    end
+
+    before do
+      history_for(probe, input: 1_000, output: 1_000)
+      ActsAsTenant.with_tenant(company) { scan.probes = [ probe ]; scan.targets = [ target ] }
+    end
+
+    it "ignores a run that finished with partial results" do
+      # A run that dropped eval rows measured less work than it planned; letting it set the
+      # median drags every later projection of the same probes downward.
+      ineligible_run(input: 999_999) { |report| report.update_columns(result_completeness: "partial") }
+
+      expect(described_class.new(scan).call.input.amount).to eq(1_000)
+    end
+
+    it "ignores a run that failed" do
+      ineligible_run(input: 999_999) { |report| report.update_columns(status: Report.statuses[:failed]) }
+
+      expect(described_class.new(scan).call.input.amount).to eq(1_000)
+    end
+
+    it "ignores an ineligible run of THIS scan at the own-run rung too" do
+      # The own-run rung is checked before per-probe history, so eligibility has to be
+      # threaded through both or a partial run of this very scan sets the projection
+      # outright, never reaching the history it would have been overruled by.
+      ActsAsTenant.with_tenant(company) do
+        report = create(:report, company: company, scan: scan, target: target, status: :completed)
+        report.update_columns(result_completeness: "partial")
+        create(:probe_result, report: report, probe: probe,
+                              input_tokens: 999_999, output_tokens: 999_999, total: 10)
+      end
+
+      expect(described_class.new(scan).call.input.amount).to eq(1_000)
+    end
+  end
+
+  describe "exclude_report_id" do
+    it "projects without the report being scored, so the deviation is not measured against itself" do
+      # record_all_completion_metrics runs after_update_commit, so the completed report is
+      # already in the scan's own history by the time it is scored. Without exclusion,
+      # own_run_tokens would find only this report, and the projection would equal the
+      # very actual it's meant to be compared against.
+      probe = create(:probe, name: "Measured", input_tokens: 100, prompts: [ "hi" ])
+      report = ActsAsTenant.with_tenant(company) do
+        scan.probes = [ probe ]
+        scan.targets = [ target ]
+        create(:report, company: company, scan: scan, target: target, status: :completed)
+      end
+      create(:probe_result, report: report, probe: probe, input_tokens: 9_999, output_tokens: 1, total: 1)
+
+      projection = described_class.new(scan, exclude_report_id: report.id).call
+
+      expect(projection.input.amount).not_to eq(report.input_tokens)
+      # With the scored report's own history excluded and no other history for this probe,
+      # projection falls back to the estimated rung: static prompt tokens * GENERATIONS.
+      expect(projection.input.amount).to eq(100 * Scans::Projection::GENERATIONS)
+      expect(projection.input.basis).to eq(:estimated)
+    end
+
+    it "excludes the scored report from per-probe history, not only from its own-run total" do
+      # own_run_tokens and ProbeHistory are two separate queries; exclusion has to be
+      # threaded through both, or a probe with no OTHER history still leaks the excluded
+      # report's own probe_result back in via the history fallback rung.
+      probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+      report = ActsAsTenant.with_tenant(company) do
+        scan.probes = [ probe ]
+        scan.targets = [ target ]
+        create(:report, company: company, scan: scan, target: target, status: :completed)
+      end
+      create(:probe_result, report: report, probe: probe, input_tokens: 9_999, output_tokens: 1, total: 1)
+
+      projection = described_class.new(scan, exclude_report_id: report.id).call
+
+      expect(projection.input).not_to be_available
+    end
+
+    it "excludes a variant child of the scored report from both the own-run total and the history rung" do
+      # A variant child shares its parent's scan_id and groups with it under
+      # COALESCE(reports.parent_report_id, reports.id) in own_run_tokens, so excluding
+      # only the parent id would still let the child's tokens leak into that grouped
+      # total. Scans::ProbeHistory's scope applies the same id-or-parent-id exclusion, so
+      # the child's own probe_result doesn't leak into the history rung either.
+      probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+      history_for(probe, input: 1_000, output: 1_000)
+      parent = ActsAsTenant.with_tenant(company) do
+        scan.probes = [ probe ]
+        scan.targets = [ target ]
+        create(:report, company: company, scan: scan, target: target, status: :completed)
+      end
+      create(:probe_result, report: parent, probe: probe,
+                            input_tokens: 80_000, output_tokens: 700_000, total: 400)
+      child = create(:report, company: company, scan: scan, target: target,
+                              status: :completed, parent_report: parent)
+      create(:probe_result, report: child, probe: probe,
+                            input_tokens: 4_756, output_tokens: 19_244, total: 14)
+
+      projection = described_class.new(scan, exclude_report_id: parent.id).call
+
+      # 84_756 (80_000 + 4_756) is what own_run_tokens would return if the child leaked
+      # through -- the exact total the un-excluded "prefers this scan's own past runs"
+      # test above asserts. It must not appear here.
+      expect(projection.input.amount).not_to eq(84_756)
+      # Nor does the child's own result (4_756) survive into the history rung -- with
+      # both parent and child excluded there too, the only history left for this probe is
+      # the separate historical run set up by history_for above.
+      expect(projection.input.amount).to eq(1_000)
+      expect(projection.input.basis).to eq(:measured)
+    end
+  end
+
+  it "computes each figure once per #call, even though total_figure needs both again" do
+    # #call invokes figure(:input) and figure(:output) directly, then total_figure invokes
+    # both again to decide whether a total can be honestly shown. Without memoization,
+    # own_run_tokens (a query) would run twice per kind on every render of the scan page.
+    # A scenario where every figure resolves at the "own run" rung -- never reaching the
+    # history/estimate fallback -- keeps the expected query count from depending on
+    # ProbeHistory's fixture setup.
+    probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+    ActsAsTenant.with_tenant(company) do
+      scan.probes = [ probe ]
+      scan.targets = [ target ]
+      report = create(:report, company: company, scan: scan, target: target, status: :completed,
+                              start_time: 10.minutes.ago, end_time: Time.current)
+      create(:probe_result, report: report, probe: probe,
+                            input_tokens: 1_000, output_tokens: 1_000, total: 10)
+    end
+
+    queries = 0
+    counter = ->(*, payload) { queries += 1 unless payload[:name].to_s =~ /SCHEMA|TRANSACTION/ }
+    projection = nil
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+      projection = described_class.new(scan).call
+    end
+
+    expect(projection.input.basis).to eq(:measured)
+    expect(projection.output.basis).to eq(:measured)
+    expect(projection.runtime.basis).to eq(:measured)
+    # own_runs, own_run_seconds -- 2 queries. It was 3 while each token kind fetched its
+    # own grouped sum; own_runs now reads (run-family, probe) totals once and serves both
+    # kinds, the probe-set comparison and the runtime rung's family filter from it.
+    # `scan.probes = [ probe ]` above already loads the probes association in memory, so
+    # the `probes.size` reads inside each figure don't add a query here; on an unloaded
+    # association they'd add exactly one more (memoized after the first read), not one
+    # per figure.
+    expect(queries).to eq(2)
+  end
+
+  describe "runtime" do
+    it "uses this scan's own past runs when it has any" do
+      # The best predictor of how long a scan takes is how long it took last time.
+      probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+      history_for(probe, input: 1_000, output: 1_000)
+      ActsAsTenant.with_tenant(company) do
+        scan.probes = [ probe ]
+        scan.targets = [ target ]
+        report = create(:report, company: company, scan: scan, target: target, status: :completed,
+                                 start_time: 90.minutes.ago, end_time: Time.current)
+        # The run has to record WHICH probes it ran: this rung now only reuses a duration
+        # measured on the scan's current probe set, and a run with no probe_results leaves
+        # no evidence of what it ran. HistoryEligibility already limits this to completed,
+        # complete runs, which record their results.
+        create(:probe_result, report: report, probe: probe,
+                              input_tokens: 1_000, output_tokens: 1_000, total: 10)
+      end
+
+      runtime = described_class.new(scan).call.runtime
+
+      expect(runtime.basis).to eq(:measured)
+      expect(runtime.amount).to be_within(120).of(90.minutes.to_i)
+    end
+
+    it "does not reuse its own past duration once the scan's probe set has changed" do
+      # Same staleness as the token rung: a duration measured on one probe set is not this
+      # scan's duration after the set changed, and own_run_seconds is the only rung allowed
+      # to claim :measured. It falls through to the model, which reports the coverage it
+      # actually has (the added probe has no history, so it accounts for one of two).
+      ran = create(:probe, name: "Ran", input_tokens: 0, prompts: [])
+      added = create(:probe, name: "AddedLater", input_tokens: 0, prompts: [])
+      ActsAsTenant.with_tenant(company) do
+        scan.probes = [ ran ]
+        scan.targets = [ target ]
+        report = create(:report, company: company, scan: scan, target: target, status: :completed,
+                                 start_time: 60.minutes.ago, end_time: Time.current)
+        create(:probe_result, report: report, probe: ran,
+                              input_tokens: 1_000, output_tokens: 1_000, total: 10)
+        scan.probes = [ ran, added ]
+      end
+
+      runtime = described_class.new(scan).call.runtime
+
+      expect(runtime.basis).to eq(:estimated)
+      expect(runtime.covered).to eq(1)
+      expect(runtime.total).to eq(2)
+    end
+
+    it "models runtime from evaluated outputs when the scan has never run" do
+      probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+      ActsAsTenant.with_tenant(company) do
+        other = create(:complete_scan, company: company)
+        # The rate must come from a report that records BOTH its duration and how many
+        # outputs it evaluated -- seconds-per-output cannot be assembled from one run's
+        # clock and another run's output count.
+        report = create(:report, company: company, scan: other, target: target, status: :completed,
+                                 start_time: 100.seconds.ago, end_time: Time.current)
+        create(:probe_result, report: report, probe: probe,
+                              input_tokens: 1_000, output_tokens: 1_000, total: 100)
+        scan.probes = [ probe ]
+        scan.targets = [ target ]
+      end
+
+      runtime = described_class.new(scan).call.runtime
+
+      expect(runtime).to be_available
+      expect(runtime.basis).to eq(:estimated)
+      expect(runtime.amount).to be_within(2).of(100)
+    end
+
+    it "sums a run's variant children into that run rather than sampling them separately" do
+      # A variant child is executed work belonging to its parent's run, so a 60-minute
+      # parent with a 30-minute child is a 90-minute run. Treating each report as an
+      # independent duration sample took the median of [30, 60] and reported 60 -- less
+      # than the work the scan actually performed.
+      probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+      ActsAsTenant.with_tenant(company) do
+        scan.probes = [ probe ]
+        scan.targets = [ target ]
+        parent = create(:report, company: company, scan: scan, target: target, status: :completed,
+                                 start_time: 60.minutes.ago, end_time: Time.current)
+        # Recorded results, so the family's probe set can be compared with the scan's.
+        create(:probe_result, report: parent, probe: probe,
+                              input_tokens: 1_000, output_tokens: 1_000, total: 10)
+        create(:report, company: company, scan: scan, target: target, status: :completed,
+                        parent_report: parent, start_time: 30.minutes.ago, end_time: Time.current)
+      end
+
+      runtime = described_class.new(scan).call.runtime
+
+      expect(runtime.basis).to eq(:measured)
+      expect(runtime.amount).to be_within(120).of(90.minutes.to_i)
+    end
+
+    it "reports only the probes its model actually accounts for" do
+      # modeled_seconds sums history.values, so a probe with no history contributes zero
+      # evaluated outputs and cannot move the number. Reporting probes.size covered
+      # claimed the basis line had accounted for it.
+      measured = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+      never_run = create(:probe, name: "NeverRun", input_tokens: 0, prompts: [])
+      ActsAsTenant.with_tenant(company) do
+        other = create(:complete_scan, company: company)
+        report = create(:report, company: company, scan: other, target: target, status: :completed,
+                                 start_time: 100.seconds.ago, end_time: Time.current)
+        create(:probe_result, report: report, probe: measured,
+                              input_tokens: 1_000, output_tokens: 1_000, total: 100)
+        scan.probes = [ measured, never_run ]
+        scan.targets = [ target ]
+      end
+
+      runtime = described_class.new(scan).call.runtime
+
+      expect(runtime.basis).to eq(:estimated)
+      expect(runtime.covered).to eq(1)
+      expect(runtime.total).to eq(2)
+    end
+
+    it "is unavailable rather than zero when nothing can be modeled" do
+      # The reported defect: a 13-probe scan that ran for 89 minutes displayed "0m".
+      probe = create(:probe, name: "Unknown", input_tokens: 0, prompts: [])
+      ActsAsTenant.with_tenant(company) { scan.probes = [ probe ]; scan.targets = [ target ] }
+
+      expect(described_class.new(scan).call.runtime).not_to be_available
+    end
+
+    it "never divides by the concurrent-scan limit" do
+      # parallel_scans_limit is how many DIFFERENT scans may run at once (20 in prod).
+      # Dividing one scan's duration by it claimed the scan finishes 20x sooner.
+      probe = create(:probe, name: "Measured", input_tokens: 0, prompts: [])
+      history_for(probe, input: 1_000, output: 1_000)
+      ActsAsTenant.with_tenant(company) do
+        scan.probes = [ probe ]
+        scan.targets = [ target ]
+        report = create(:report, company: company, scan: scan, target: target, status: :completed,
+                                 start_time: 60.minutes.ago, end_time: Time.current)
+        create(:probe_result, report: report, probe: probe,
+                              input_tokens: 1_000, output_tokens: 1_000, total: 10)
+      end
+
+      allow(SettingsService).to receive(:parallel_scans_limit).and_return(20)
+
+      expect(described_class.new(scan).call.runtime.amount).to be_within(120).of(60.minutes.to_i)
+    end
+  end
+end

--- a/spec/services/scans/stats_serializer_spec.rb
+++ b/spec/services/scans/stats_serializer_spec.rb
@@ -160,6 +160,37 @@ RSpec.describe Scans::StatsSerializer, type: :service do
     end
   end
 
+  describe '#token_info' do
+    context 'when the projection is unavailable' do
+      it 'emits no amount' do
+        # scan has only default_probe (input_tokens: 0, the DB default, and no
+        # completed-report history), so Scans::Projection cannot assign a basis at
+        # all -- the exact case a bare Integer could not distinguish from a real zero.
+        result = serializer.send(:token_info)
+
+        expect(result[:projected_input_per_scan]).to be_nil
+        expect(result[:projected_input_basis]).to eq(basis: :unavailable, covered: 0, total: 1)
+      end
+    end
+
+    context 'when the projection covers only part of the scan probes' do
+      let!(:covered_probe) { create(:probe, input_tokens: 500) }
+
+      before { scan.probes << covered_probe }
+
+      it 'carries coverage metadata alongside the amount rather than a bare number' do
+        # default_probe still contributes nothing (input_tokens: 0), so only
+        # covered_probe is covered: 1 of the scan's 2 probes. The amount is a real
+        # (non-nil) number here -- the defect this fixes is a consumer reading a
+        # present amount as a complete measurement with no way to tell otherwise.
+        result = serializer.send(:token_info)
+
+        expect(result[:projected_input_per_scan]).to eq(2500) # 500 tokens * GENERATIONS(5) * 1 target
+        expect(result[:projected_input_basis]).to eq(basis: :estimated, covered: 1, total: 2)
+      end
+    end
+  end
+
   describe '#risk_distribution_info' do
     context 'when there are no completed reports' do
       it 'returns an empty hash' do


### PR DESCRIPTION
The scan page projected token usage and runtime before a scan ran, and both were wrong by orders of magnitude. On one real scan (13 probes, one target): **598 projected input tokens against 84,756 actual** — 142× under — and **"0m" against 89.3 minutes** — roughly 5,400× under. An expensive scan read as cheap and instant.

Four independent causes:

- **Probes that build prompts at runtime projected zero.** `probes.sum(:input_tokens)` counts stored prompt text once, but probes like `encoding.Inject*`, `av_spam_scanning.*` and `divergence.Repeat` store none — their text does not exist until the probe runs. On that scan, 9 of 13 probes contributed nothing while accounting for most of the cost.
- **Generations were ignored.** garak sends each prompt 5 times by default; the projection counted it once.
- **Per-request overhead was ignored** — a stable ×1.53–1.59 measured across many scans.
- **Runtime was modelled as throughput and divided by the wrong quantity.** `parallel_scans_limit` caps *concurrent scans*, so dividing one scan's duration by it claimed the scan finishes N× sooner. And scans are latency-bound: on a measured 79-minute run, only 4.1 minutes were token time.

No coefficient fixes this — most of that scan's probes are unprojectable from stored prompt data, so any multiplier tuned to close the gap would be fitted to one probe mix.

## What replaces it

`Scans::Projection` walks a ladder and returns `Scans::ProjectedFigure` values that can report **unavailable** rather than print a confident wrong number:

| rung | basis |
|---|---|
| `measured` | this scan's own completed runs, summing each run's reports |
| `measured` | per-probe median of tenant-scoped history, × target count |
| `estimated` | static prompts × generations |
| `unavailable` | no evidence at either level |

- **Runtime** is modelled from evaluated outputs × observed seconds-per-output — never tokens ÷ `tokens_per_second`, never divided by the concurrent-scan cap. A non-trivial scan can no longer render `0m`.
- **Input and output are projected independently** with a defined total; the fixed `OUTPUT_MULTIPLIER = 2` is gone (real ratios range from 0.18× to 8.5×).
- **`Scans::HistoryEligibility`** keeps failed and partial runs out of projections, so a run that measured less than it planned cannot drag later projections downward.
- **Coverage is stated, not implied** — the page shows which rung a figure came from and how many probes it covers; the stats JSON carries the same metadata rather than a bare number; the monitoring deviation metric is skipped when coverage is incomplete.

## Known limitation: a run's shape is not modelled as a unit

The ladder does not yet model a run as **one parent report per target, with variant children beneath each**. Five consequences are known, each verified in review and accepted here:

| case | direction |
|---|---|
| A probe previously run **with** variants inflates the median for a later **no-variant** scan; conversely a variant-enabled scan under-projects from base-only history | both |
| Own-run matching compares probe IDs only, so editing targets or variant selection can reuse a run from the old configuration | either |
| Eligibility is per report, so a completed parent with a failed variant child is accepted as a complete family | **under**-estimates |
| The monitoring deviation compares a report-scoped actual against a family-wide projection for variant runs | monitoring metric only |
| The shared basis line reads input's basis, so an estimated runtime can be labelled measured when coverage matches | display only |

These are one design gap rather than five defects, and the fix is a single change: give the projection an explicit **run** concept — the set of reports produced by one execution, across targets and variants — and project per run. That work is tracked separately and will apply to both this repo and its sibling, which carries the same limitation.

Nothing here reintroduces the reported defect, and this is strictly better than the previous behaviour in every configuration: the old code modelled neither targets nor variants at all.

## Verification

476 examples, 0 failures across the touched areas. RuboCop clean (507 files), Brakeman 0 warnings. The reported scan's shape is covered by a regression fixture built as a shape rather than an ID, and the ladder arithmetic, tenant isolation and constant query count each have their own specs.
