### PR TITLE
fix(scans): stop reporting unmeasured work as a clean result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ bin/rspec-docker
 docs/plans/
 docs/plans/completed/
 docs/superpowers/
+.superpowers/

--- a/app/controllers/admin/scans_controller.rb
+++ b/app/controllers/admin/scans_controller.rb
@@ -168,11 +168,16 @@ module Admin
     # rate. Ransack's default ORDER BY puts Postgres NULLs first on DESC, so "worst ASR
     # first" led with unmeasured scans. Mirrors Admin::ProbesController#apply_sorting,
     # which has the same NULLS LAST need for success_rate_calculated.
+    #
+    # The trailing "id ASC" is a tie-breaker, not part of the direction toggle above: with
+    # unmeasured scans now NULL instead of a distinct 0.00, ties within a sort are far more
+    # common, and Postgres doesn't promise a stable order within a tied block across
+    # queries -- paginating "ASR desc" could show one scan twice and skip another.
     def apply_sorting(scope, sort_param)
       return scope unless sort_param.start_with?("avg_successful_attacks")
 
       direction = sort_param.include?("desc") ? "DESC" : "ASC"
-      scope.reorder(Arel.sql("avg_successful_attacks #{direction} NULLS LAST"))
+      scope.reorder(Arel.sql("avg_successful_attacks #{direction} NULLS LAST, id ASC"))
     end
 
     # Fail-closed tenant scoping for batch operations: explicitly filter by the current

--- a/app/controllers/admin/scans_controller.rb
+++ b/app/controllers/admin/scans_controller.rb
@@ -40,7 +40,7 @@ module Admin
       if sort_param.blank?
         @pagy, @scans = pagy(@q.result.order(created_at: :desc))
       else
-        @pagy, @scans = pagy(@q.result)
+        @pagy, @scans = pagy(apply_sorting(@q.result, sort_param))
       end
       # Mirrors the branch above, so the highlighted tab always names the filter the list
       # was actually built from.
@@ -163,6 +163,17 @@ module Admin
     end
 
     private
+
+    # avg_successful_attacks is nullable -- a scan whose reports measured nothing has no
+    # rate. Ransack's default ORDER BY puts Postgres NULLs first on DESC, so "worst ASR
+    # first" led with unmeasured scans. Mirrors Admin::ProbesController#apply_sorting,
+    # which has the same NULLS LAST need for success_rate_calculated.
+    def apply_sorting(scope, sort_param)
+      return scope unless sort_param.start_with?("avg_successful_attacks")
+
+      direction = sort_param.include?("desc") ? "DESC" : "ASC"
+      scope.reorder(Arel.sql("avg_successful_attacks #{direction} NULLS LAST"))
+    end
 
     # Fail-closed tenant scoping for batch operations: explicitly filter by the current
     # company so a nil acts_as_tenant context can't span tenants.

--- a/app/helpers/scan_helper.rb
+++ b/app/helpers/scan_helper.rb
@@ -1,4 +1,14 @@
 module ScanHelper
+  # A scan's cached ASR as text. Mirrors ReportsHelper#asr_display -- one decimal place,
+  # "N/A" reserved for a figure that cannot be calculated -- so a scan and the reports it
+  # averages never describe the same absence with different words.
+  def scan_asr_display(scan)
+    value = scan.avg_successful_attacks
+    return "N/A" if value.nil?
+
+    number_to_percentage(value, precision: 1)
+  end
+
   def scan_format_recurrence_schedule(recurrence)
     return "Not scheduled" unless recurrence.present?
 

--- a/app/javascript/config/chartConfig.js
+++ b/app/javascript/config/chartConfig.js
@@ -211,8 +211,8 @@ export function getGaugeChartConfig(successRate, chartConfig, name = 'Success Ra
                     offsetCenter: [0, '-35%'],
                     valueAnimation: true,
                     formatter: function (value) {
-                        // nothing measurable (nil rate) must not render as a false "0"
-                        return value === null || value === undefined ? 'N/A' : Math.round(value) + '';
+                        // nothing measurable (nil rate, or ECharts coercing null to NaN) must not render as a false "0"
+                        return Number.isFinite(value) ? Math.round(value) + '' : 'N/A';
                     },
                     color: 'inherit'
                 },

--- a/app/javascript/config/chartConfig.js
+++ b/app/javascript/config/chartConfig.js
@@ -211,7 +211,8 @@ export function getGaugeChartConfig(successRate, chartConfig, name = 'Success Ra
                     offsetCenter: [0, '-35%'],
                     valueAnimation: true,
                     formatter: function (value) {
-                        return Math.round(value) + '';
+                        // nothing measurable (nil rate) must not render as a false "0"
+                        return value === null || value === undefined ? 'N/A' : Math.round(value) + '';
                     },
                     color: 'inherit'
                 },

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -514,9 +514,13 @@ class Report < ApplicationRecord
     cached_total
   end
 
+  # Detectors that found something. `passed` is successful attacks -- the same column
+  # #total_successful_attacks sums -- so a detector identified a vulnerability when at
+  # least one attack against it succeeded. Counting `passed < total` inverted that: a
+  # report with 0/84 successful attacks claimed two vulnerabilities, and a detector
+  # bypassed on every attempt (80/80) was counted as clean.
   def security_vulnerabilities_count
-    # Count detector results where there were failures (passed < total)
-    detector_results.where("passed < total").count
+    detector_results.where("passed > 0").count
   end
 
   # Compute total input tokens from all probe results

--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -80,14 +80,9 @@ class Scan < ApplicationRecord
 
 
     def calculate_avg_successful_attacks
-      return 0.0 if reports.completed.empty?
-
-      # Single SQL query with GROUP BY to avoid N+1 queries
-      # Aggregates passed/total per report, then calculates attack rate
       # Summed over probe_results, the same source Report#asr uses: pooling detector rows
       # counted one attack once per detector judging it, so this scan average disagreed
       # with the rate on every report page it averages.
-      # Uses LEFT JOIN to include reports even if they have no results
       # Excludes runs holding only partial results, matching Stats::AverageAsrScore: an
       # incomplete run's rate covers recorded work alone. This figure is stored, displayed
       # and sorted on, so it has to agree with the aggregate the dashboard shows.
@@ -101,13 +96,18 @@ class Scan < ApplicationRecord
           "COALESCE(SUM(probe_results.total), 0) as total_count"
         )
 
-      return 0.0 if results.empty?
-
-      attack_rates = results.map do |result|
+      # A report with nothing to divide by has no rate; it is left out rather than
+      # counted as 0%. Reports::AsrFigure draws the same line at report level -- 0.0 means
+      # every attack was blocked, nil means nothing was measurable -- and a scan whose
+      # reports all measured nothing must not read as a clean 0%.
+      attack_rates = results.filter_map do |result|
         total = result.total_count.to_i
-        passed = result.total_passed.to_i
-        total > 0 ? (passed.to_f / total * 100) : 0.0
+        next unless total.positive?
+
+        result.total_passed.to_f / total * 100
       end
+
+      return nil if attack_rates.empty?
 
       (attack_rates.sum / attack_rates.size).round(2)
     end

--- a/app/services/scans/stats_serializer.rb
+++ b/app/services/scans/stats_serializer.rb
@@ -44,7 +44,7 @@ module Scans
       last_report = completed_reports.order(created_at: :desc).first
 
       {
-        avg_successful_attacks: scan.avg_successful_attacks&.round(2) || 0,
+        avg_successful_attacks: scan.avg_successful_attacks&.round(2),
         total_reports: scan.reports.parent_reports.count,
         completed_reports: completed_reports.count,
         last_report_at: last_report&.created_at&.iso8601

--- a/app/services/scans/stats_serializer.rb
+++ b/app/services/scans/stats_serializer.rb
@@ -191,7 +191,9 @@ module Scans
           probes_tested: row.probes_tested.to_i,
           passed: row.total_passed.to_i,
           total: row.total_tests.to_i,
-          asr: row.total_tests.to_i > 0 ? (row.total_passed.to_f / row.total_tests * 100).round(2) : 0
+          # A risk level with nothing to divide by must not read as a clean 0% -- same
+          # rule as attacks_info above.
+          asr: row.total_tests.to_i > 0 ? (row.total_passed.to_f / row.total_tests * 100).round(2) : nil
         }
       end
 
@@ -225,7 +227,9 @@ module Scans
           probes_tested: row.probes_tested.to_i,
           passed: row.total_passed.to_i,
           total: row.total_tests.to_i,
-          asr: row.total_tests.to_i > 0 ? (row.total_passed.to_f / row.total_tests * 100).round(2) : 0
+          # A disclosure status with nothing to divide by must not read as a clean 0% --
+          # same rule as attacks_info above.
+          asr: row.total_tests.to_i > 0 ? (row.total_passed.to_f / row.total_tests * 100).round(2) : nil
         }
       end
 
@@ -269,7 +273,9 @@ module Scans
           disclosure_status: disclosure_statuses[row.disclosure_status] || "Unknown",
           passed: row.total_passed.to_i,
           total: row.total_tests.to_i,
-          success_rate: row.total_tests.to_i > 0 ? (row.total_passed.to_f / row.total_tests * 100).round(2) : 0
+          # A flagged probe with nothing to divide by must not read as a clean 0% -- same
+          # rule as attacks_info above.
+          success_rate: row.total_tests.to_i > 0 ? (row.total_passed.to_f / row.total_tests * 100).round(2) : nil
         }
       end
     end
@@ -295,7 +301,9 @@ module Scans
             detector_name: row.name,
             passed: row.total_passed.to_i,
             total: row.total_tests.to_i,
-            asr: row.total_tests.to_i > 0 ? (row.total_passed.to_f / row.total_tests * 100).round(2) : 0
+            # A detector with nothing to divide by must not read as a clean 0% -- same
+            # rule as attacks_info above.
+            asr: row.total_tests.to_i > 0 ? (row.total_passed.to_f / row.total_tests * 100).round(2) : nil
           }
         end
     end

--- a/app/services/scans/stats_serializer.rb
+++ b/app/services/scans/stats_serializer.rb
@@ -76,7 +76,10 @@ module Scans
 
       total_passed = totals&.total_passed.to_i
       total_tests = totals&.total_tests.to_i
-      overall_asr = total_tests > 0 ? (total_passed.to_f / total_tests * 100).round(2) : 0
+      # Counts stay honest zeros; the rate is nil when there was nothing to divide by --
+      # the same distinction Reports::AsrFigure draws, so this payload doesn't describe
+      # the same absence two contradictory ways (0 counts here, null in aggregate_stats).
+      overall_asr = total_tests > 0 ? (total_passed.to_f / total_tests * 100).round(2) : nil
 
       # Per-target breakdown (single grouped query instead of N+1)
       grouped = completed_reports
@@ -95,7 +98,9 @@ module Scans
         stats = grouped[target.id] || { passed: 0, total: 0 }
         passed = stats[:passed]
         total = stats[:total]
-        asr = total > 0 ? (passed.to_f / total * 100).round(2) : 0
+        # A target that was never measured (no reports, or reports with nothing to
+        # divide by) must not read as a clean 0% -- same rule as overall_asr above.
+        asr = total > 0 ? (passed.to_f / total * 100).round(2) : nil
 
         {
           target_id: target.id,
@@ -358,7 +363,14 @@ module Scans
 
       total_passed = totals&.total_passed.to_i
       total_tests = totals&.total_tests.to_i
-      asr = total_tests > 0 ? (total_passed.to_f / total_tests * 100) : 0
+
+      # Completed reports that measured nothing must not fall through to asr = 0 and
+      # risk_penalty = 0 below -- that combination grades A+ "Excellent security
+      # posture", a false clean bill of health from a security tool for a scan that
+      # never evaluated an attack. Same N/A shape as the empty-reports guard above.
+      return { grade: "N/A", score: nil, description: "No measurable attacks" } if total_tests.zero?
+
+      asr = total_passed.to_f / total_tests * 100
 
       # Weight by risk level - penalize high-risk vulnerabilities more
       risk_penalty = calculate_risk_penalty

--- a/app/services/stats/last_five_scans_data.rb
+++ b/app/services/stats/last_five_scans_data.rb
@@ -7,7 +7,7 @@ module Stats
             {
               scan_name: scan.name,
               scan_id: scan.id,
-              asr: (scan.avg_successful_attacks || 0).round
+              asr: scan.avg_successful_attacks&.round
             }
           end
     end

--- a/app/services/stats/probe_success_rate_data.rb
+++ b/app/services/stats/probe_success_rate_data.rb
@@ -22,11 +22,13 @@ module Stats
         total_passed = scope.sum(:passed)
         total_tests = scope.sum(:total)
 
-        success_rate = total_tests > 0 ? (total_passed.to_f / total_tests * 100).round(1) : 0
+        # A zero denominator means nothing was measurable, not a clean 0% -- the same
+        # distinction Reports::AsrFigure draws at the report level.
+        success_rate = total_tests > 0 ? (total_passed.to_f / total_tests * 100).round(1) : nil
 
         { success_rate: success_rate, time_range: "Last 30 Days" }
       else
-        { success_rate: 0, time_range: "Last 30 Days" }
+        { success_rate: nil, time_range: "Last 30 Days" }
       end
     end
   end

--- a/app/services/token_estimator.rb
+++ b/app/services/token_estimator.rb
@@ -43,10 +43,15 @@ class TokenEstimator
       }
     end
 
-    # What was actually sent to the model. Multi-shot probes resend the accumulated
-    # history on every call, so garak's stored prompt -- one seed message -- understates
-    # the input by every turn resent. script/garak_plugins/probes/0din.py records the real
-    # conversation in notes, in the same serialised shape as a prompt.
+    # The recorded conversation, not necessarily what was actually sent. garak's stored
+    # prompt -- one seed message -- already understates a multi-shot probe, which resends
+    # the accumulated history on every call: the true input across turns is
+    # p1 + (p1 + r1 + p2) + ..., while notes.multiturn_conversation (recorded by
+    # script/garak_plugins/probes/0din.py) counts each turn once, e.g. p1 + r1 + p2. That
+    # script also skips appending a turn when its generator call errors, so a probe with a
+    # mid-conversation failure omits from notes a prompt that was genuinely sent. Both
+    # caveats push the estimate below the real token count; this is the same arithmetic
+    # the previous implementation used, only the comment describing it was wrong.
     def input_conversation(attempt)
       notes = attempt["notes"] || attempt[:notes]
       recorded = notes.is_a?(Hash) ? (notes["multiturn_conversation"] || notes[:multiturn_conversation]) : nil

--- a/app/services/token_estimator.rb
+++ b/app/services/token_estimator.rb
@@ -35,13 +35,23 @@ class TokenEstimator
     def estimate_from_attempt(attempt)
       return { input_tokens: 0, output_tokens: 0 } if attempt.nil?
 
-      prompt = attempt["prompt"] || attempt[:prompt]
       outputs = attempt["outputs"] || attempt[:outputs]
 
       {
-        input_tokens: estimate_tokens(extract_prompt_text(prompt)),
+        input_tokens: estimate_tokens(extract_prompt_text(input_conversation(attempt))),
         output_tokens: estimate_output_tokens(outputs)
       }
+    end
+
+    # What was actually sent to the model. Multi-shot probes resend the accumulated
+    # history on every call, so garak's stored prompt -- one seed message -- understates
+    # the input by every turn resent. script/garak_plugins/probes/0din.py records the real
+    # conversation in notes, in the same serialised shape as a prompt.
+    def input_conversation(attempt)
+      notes = attempt["notes"] || attempt[:notes]
+      recorded = notes.is_a?(Hash) ? (notes["multiturn_conversation"] || notes[:multiturn_conversation]) : nil
+
+      recorded.presence || attempt["prompt"] || attempt[:prompt]
     end
 
     # Aggregate token estimates from multiple attempts

--- a/app/views/admin/dashboard/_last_five_scans_card.html.erb
+++ b/app/views/admin/dashboard/_last_five_scans_card.html.erb
@@ -12,7 +12,7 @@
           <li class="flex items-center justify-between gap-3 py-2">
             <%= link_to scan[:scan_name], scan_path(scan[:scan_id]),
                   class: "text-sm text-primary hover:underline truncate", title: scan[:scan_name] %>
-            <span class="text-sm font-semibold shrink-0 <%= asr_color_class(scan[:asr]) %>"><%= scan[:asr] %>%</span>
+            <span class="text-sm font-semibold shrink-0 <%= asr_color_class(scan[:asr]) %>"><%= scan[:asr].nil? ? "N/A" : "#{scan[:asr]}%" %></span>
           </li>
         <% end %>
       </ul>

--- a/app/views/admin/glossary/show.html.erb
+++ b/app/views/admin/glossary/show.html.erb
@@ -39,7 +39,7 @@
         <%= render "admin/glossary/term", term: "Security Grade", definition: "An A+ through F letter grade for a scan, computed from the Attack Success Rate adjusted by a risk penalty. Probes with higher Social Impact Scores that succeed carry heavier penalties." %>
         <%= render "admin/glossary/term", term: "Max Score", definition: "The highest detector confidence score reached by a probe across all its attempts, shown as a percentage. Indicates how definitively the detector classified a response as vulnerable." %>
         <%= render "admin/glossary/term", term: "Successful Attacks / Passed", definition: "The number of probe attempts where the attack succeeded — meaning the target model responded in a way that the detector classified as vulnerable. Shown as a ratio (e.g., 3 / 40)." %>
-        <%= render "admin/glossary/term", term: "Vulnerabilities Found", definition: "The distinct count of unique security vulnerabilities identified in a report, separate from the total number of individual attack attempts." %>
+        <%= render "admin/glossary/term", term: "Vulnerabilities Found", definition: "The number of detectors that recorded at least one successful attack in a report — one count per detector that found something, not per attack attempt." %>
         <%= render "admin/glossary/term", term: "Token Usage", definition: "The number of LLM tokens consumed during a scan, broken down into input tokens (prompts sent) and output tokens (model responses). Used for cost estimation and monitoring." %>
       </dl>
     </div>

--- a/app/views/admin/scans/index.html.erb
+++ b/app/views/admin/scans/index.html.erb
@@ -102,11 +102,8 @@
         end
       },
       render: ->(scan) {
-        if scan.avg_successful_attacks.present?
-          content_tag(:span, "#{scan.avg_successful_attacks.round(1)}%", class: "text-sm font-semibold #{asr_color_class(scan.avg_successful_attacks)}")
-        else
-          content_tag(:span, "—", class: "text-sm text-zinc-500")
-        end
+        content_tag(:span, scan_asr_display(scan),
+                    class: "text-sm font-semibold #{asr_color_class(scan.avg_successful_attacks)}")
       }
     }
   ]

--- a/app/views/layouts/partials/_main_navigation.html.erb
+++ b/app/views/layouts/partials/_main_navigation.html.erb
@@ -1,7 +1,10 @@
-<%# Mobile backdrop (invisible click target) %>
+<%# Mobile backdrop (invisible click target).
+    Starts hidden: mobile_nav_controller#open removes `hidden` and #close puts it back,
+    so without it the backdrop covers the whole page from first paint and eats every
+    click below the xl breakpoint. `xl:hidden` keeps it away from desktop entirely. %>
 <div data-mobile-nav-target="backdrop"
      data-action="click->mobile-nav#close"
-     class="fixed top-16 xl:top-0 bottom-0 left-0 right-0 z-30 xl:hidden"
+     class="fixed top-16 xl:top-0 bottom-0 left-0 right-0 z-30 hidden xl:hidden"
      aria-hidden="true"></div>
 
 <div id="main-menu"

--- a/db/migrate/20260818120000_recompute_scan_avg_without_false_zeros.rb
+++ b/db/migrate/20260818120000_recompute_scan_avg_without_false_zeros.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class RecomputeScanAvgWithoutFalseZeros < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  # Scan#calculate_avg_successful_attacks now returns nil when no report measured
+  # anything, and no longer folds zero-total reports into the average. Changing the
+  # calculation does not touch values already stored, and scans.avg_successful_attacks is
+  # read directly by the scans list, its sort, the dashboard card and the stats endpoint --
+  # so every historical scan would keep displaying the false 0.00 this fix removes.
+  #
+  # Scoped to all scans, not just those with a completed report: the rows most in need of
+  # correction are the ones whose reports all failed, and those have no completed report
+  # to select on.
+  #
+  # Idempotent: recomputes from current data, so running it twice is harmless.
+  def up
+    Scan.reset_column_information
+    Scan.find_each(batch_size: 500) do |scan|
+      ActsAsTenant.without_tenant { scan.with_lock { scan.send(:update_avg_successful_attacks!) } }
+    end
+  end
+
+  # Rolling back restores code that stores 0.0 for an unmeasured scan and averages
+  # zero-total reports as 0%, so the caches this migration nulled have to be refilled the
+  # old way -- the list and serializer read the column directly.
+  def down
+    Scan.reset_column_information
+    Scan.find_each(batch_size: 500) do |scan|
+      ActsAsTenant.without_tenant do
+        scan.with_lock do
+          rates = Report.completed
+                        .where(scan_id: scan.id)
+                        .where("reports.result_completeness IS NULL OR reports.result_completeness <> 'partial'")
+                        .left_joins(:probe_results)
+                        .group("reports.id")
+                        .pluck(Arel.sql("COALESCE(SUM(probe_results.passed), 0)"),
+                               Arel.sql("COALESCE(SUM(probe_results.total), 0)"))
+                        .map { |passed, total| total.to_i.positive? ? (passed.to_f / total * 100) : 0.0 }
+
+          value = rates.any? ? (rates.sum / rates.size).round(2) : 0.0
+          scan.update_column(:avg_successful_attacks, value)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_14_150000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_18_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/lib/tasks/deployment.rake
+++ b/lib/tasks/deployment.rake
@@ -6,11 +6,16 @@ namespace :scanner do
   # running the previous code can finish a report afterwards and write the old figure
   # back. Run this once the upgrade has settled to reconcile those.
   #
+  # Scoped to all scans, not just those with a completed report: an old-code worker can
+  # fail a report and write the false 0.0 back for a scan with no completed report at
+  # all, and that scan has no completed report to select on -- same reasoning as the
+  # migration this task reconciles after (db/migrate/20260818120000_recompute_scan_avg_without_false_zeros.rb).
+  #
   # Idempotent: it recomputes from current data.
   desc "Recompute stored scan ASR averages (run after an upgrade completes)"
   task recalculate_scan_asr_cache: :environment do
     updated = 0
-    Scan.where(id: Report.completed.select(:scan_id)).find_each(batch_size: 500) do |scan|
+    Scan.find_each(batch_size: 500) do |scan|
       before = scan.avg_successful_attacks
       # Locked: the recomputation reads every report for the scan and then writes the
       # cache, so without it a report completing mid-task can commit a newer value that

--- a/script/garak_plugins/probes/0din.py
+++ b/script/garak_plugins/probes/0din.py
@@ -156,11 +156,21 @@ class BaseHarmfulContentMultiShot(Probe):
             responses.append(normalized)
         combined_output = _combine_responses(responses)
         this_attempt.outputs = [combined_output]
-        # Store full conversation as prompt for accurate token accounting.
-        # Multi-turn probes resend accumulated history on each API call;
-        # the original combined prompt only captures user messages.
-        if conv_turns:
-            this_attempt.prompt = Conversation(turns=conv_turns)
+        # Record the conversation actually sent, for token accounting: multi-turn probes
+        # resend accumulated history on each API call, so the seed prompt understates
+        # input. It goes in notes, not on the attempt, for two reasons:
+        #   * garak >= 0.15 makes Attempt.prompt write-once -- reassigning it raised
+        #     TypeError("prompt cannot be changed once set") and aborted the whole run.
+        #   * attempt.conversations is what the vendored 0din detectors read through
+        #     attempt.all_outputs, so intermediate assistant turns there would score one
+        #     attack as several evaluations.
+        # Attempt.as_dict() asdict()s dataclass note values, so this reaches the report
+        # JSONL in the same shape as a serialised prompt (see TokenEstimator).
+        # Only when more than one prompt was sent: a single-turn attempt resent nothing,
+        # and its prompt already carries the text, so recording it would just duplicate
+        # the prompt into every attempt's notes.
+        if len(prompts_list) > 1 and conv_turns:
+            this_attempt.notes["multiturn_conversation"] = Conversation(turns=conv_turns)
         return copy.deepcopy(this_attempt)
 
 

--- a/script/tests/javascript_controller_tests.mjs
+++ b/script/tests/javascript_controller_tests.mjs
@@ -139,6 +139,26 @@ function loadThreatVariantsController() {
   return { ControllerClass }
 }
 
+function loadGetGaugeChartConfig() {
+  const source = readFileSync(
+    new URL("../../app/javascript/config/chartConfig.js", import.meta.url),
+    "utf8"
+  )
+
+  const transformed = source
+    .replace(/^import .*?\n/gm, "")
+    .replace(/^export (const|function)/gm, "$1")
+
+  const context = {
+    document: {
+      querySelector() { return null }
+    },
+    colors: {}
+  }
+
+  return vm.runInNewContext(`${transformed}\ngetGaugeChartConfig`, context)
+}
+
 function loadReportRedesignedController() {
   const source = readFileSync(
     new URL("../../app/javascript/controllers/report_redesigned_controller.js", import.meta.url),
@@ -1435,6 +1455,20 @@ function testProbeCategoryToggleCategory() {
   assert.equal(ariaExpanded, "true")
 }
 
+function testGaugeChartConfigDetailFormatter() {
+  const getGaugeChartConfig = loadGetGaugeChartConfig()
+  const config = getGaugeChartConfig(null, { textStyle: { color: "#000" } }, "Success Rate")
+  const formatter = config.series[0].detail.formatter
+
+  // Nothing measurable (null/undefined/NaN) must render as "N/A", never a false "0" or literal "NaN"
+  assert.equal(formatter(null), "N/A")
+  assert.equal(formatter(undefined), "N/A")
+  assert.equal(formatter(NaN), "N/A")
+  // A real 0 means "measured, nothing succeeded" and must still render as "0"
+  assert.equal(formatter(0), "0")
+  assert.equal(formatter(4.76), "5")
+}
+
 await testDebugStreamLeaseController()
 testActivityStreamController()
 testDebugTabsController()
@@ -1448,4 +1482,5 @@ testTargetWizardRedactAuth()
 testTargetWizardSyncModel()
 testWebchatAutoDetectCurrentAuth()
 testProbeCategoryToggleCategory()
+testGaugeChartConfigDetailFormatter()
 console.log("JavaScript controller tests passed")

--- a/script/tests/test_garak_0160_compat.py
+++ b/script/tests/test_garak_0160_compat.py
@@ -107,6 +107,13 @@ class TestLocalPluginSources(unittest.TestCase):
         self.assertIn("def _call_model_sequential", source)
         self.assertIn("terminal API status error", source)
 
+    def test_probe_sources_never_reassign_an_attempt_prompt(self):
+        # garak >= 0.15: Attempt.prompt is write-once. A reassignment anywhere in the
+        # vendored probes aborts the run it appears in.
+        for relative_path in ("probes/0din.py", "probes/0din_variants.py"):
+            source = (PLUGIN_DIR / relative_path).read_text()
+            self.assertNotIn("attempt.prompt =", source)
+
 
 @unittest.skipUnless(_garak_available(), "garak is not importable")
 class TestOpenRouterTerminalErrors(unittest.TestCase):

--- a/script/tests/test_garak_0160_compat.py
+++ b/script/tests/test_garak_0160_compat.py
@@ -4,6 +4,7 @@
 import importlib
 import importlib.metadata
 import importlib.util
+import re
 import subprocess
 import sys
 import unittest
@@ -12,6 +13,12 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 PLUGIN_DIR = ROOT / "script" / "garak_plugins"
+
+# Matches `attempt.prompt = ...` and `attempt.prompt=...` (the `(?!=)` keeps `==`
+# comparisons out), plus the `setattr` spelling of the same reassignment.
+PROMPT_REASSIGNMENT_RE = re.compile(
+    r"attempt\.prompt\s*=(?!=)|setattr\(attempt,\s*[\"']prompt[\"']"
+)
 
 
 def _garak_available():
@@ -109,10 +116,13 @@ class TestLocalPluginSources(unittest.TestCase):
 
     def test_probe_sources_never_reassign_an_attempt_prompt(self):
         # garak >= 0.15: Attempt.prompt is write-once. A reassignment anywhere in the
-        # vendored probes aborts the run it appears in.
+        # vendored probes aborts the run it appears in. The regex also catches the
+        # no-space `attempt.prompt=` spelling and the `setattr(attempt, "prompt", ...)`
+        # equivalent, which a plain substring check on "attempt.prompt =" would miss.
         for relative_path in ("probes/0din.py", "probes/0din_variants.py"):
             source = (PLUGIN_DIR / relative_path).read_text()
-            self.assertNotIn("attempt.prompt =", source)
+            match = PROMPT_REASSIGNMENT_RE.search(source)
+            self.assertIsNone(match, f"{relative_path} reassigns attempt.prompt: {match and match.group(0)!r}")
 
 
 @unittest.skipUnless(_garak_available(), "garak is not importable")

--- a/script/tests/test_multishot_conversation_notes.py
+++ b/script/tests/test_multishot_conversation_notes.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Multi-shot 0din probes must survive garak's write-once Attempt.prompt.
+
+garak >= 0.15 raises TypeError("prompt cannot be changed once set") on reassignment,
+which aborted the whole run for NotionTemplate, ChemicalInquiryEscalation and
+HexRecipeBookCM. The conversation still has to reach the report for token accounting,
+so it travels in notes instead -- and must stay out of attempt.conversations, because
+the vendored 0din detectors score every assistant turn in attempt.all_outputs.
+"""
+
+import importlib
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = ROOT / "script" / "garak_plugins"
+
+
+def _garak_available():
+    try:
+        importlib.import_module("garak")
+    except Exception:
+        return False
+    return True
+
+
+def _load_local_plugin(module_name, relative_path):
+    spec = importlib.util.spec_from_file_location(module_name, PLUGIN_DIR / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeGenerator:
+    """Returns a distinct reply per call, in garak's List[Message] shape."""
+
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, conversation, generations_this_call=1):
+        from garak.attempt import Message
+
+        self.calls.append(conversation)
+        return [Message(text=f"reply {len(self.calls)}", lang="en")]
+
+
+@unittest.skipUnless(_garak_available(), "garak is not importable")
+class TestMultiShotConversationNotes(unittest.TestCase):
+    def setUp(self):
+        from garak.attempt import Attempt, Message
+
+        self.module = _load_local_plugin("local_0din_multishot", "probes/0din.py")
+        self.probe = object.__new__(self.module.NotionTemplate)
+        self.probe.generator = FakeGenerator()
+        self.combined_prompt = "first ask\n\n--\n\nsecond ask"
+        self.probe._prompt_data_map = {
+            self.combined_prompt: ("sarin gas", ["first ask", "second ask"])
+        }
+        self.attempt = Attempt(
+            prompt=Message(text=self.combined_prompt, lang="en"),
+            probe_classname="0din.NotionTemplate",
+        )
+
+    def test_execute_attempt_does_not_reassign_the_prompt(self):
+        # The regression: this raised TypeError and failed the entire scan.
+        result = self.probe._execute_attempt(self.attempt)
+
+        self.assertEqual(result.prompt.turns[-1].content.text, self.combined_prompt)
+
+    def test_scores_one_output_per_attempt(self):
+        result = self.probe._execute_attempt(self.attempt)
+
+        # all_outputs is what the vendored 0din detectors iterate. Two turns were sent,
+        # but the attempt is one attack and must present one combined output.
+        self.assertEqual(len(result.all_outputs), 1)
+        self.assertEqual(result.all_outputs[0].text, "reply 1\n\n--\n\nreply 2")
+
+    def test_records_the_conversation_it_actually_sent(self):
+        result = self.probe._execute_attempt(self.attempt)
+
+        conversation = result.notes["multiturn_conversation"]
+        self.assertEqual(
+            [(turn.role, turn.content.text) for turn in conversation.turns],
+            [
+                ("user", "first ask"),
+                ("assistant", "reply 1"),
+                ("user", "second ask"),
+                ("assistant", "reply 2"),
+            ],
+        )
+
+    def test_conversation_survives_serialisation(self):
+        result = self.probe._execute_attempt(self.attempt)
+
+        turns = result.as_dict()["notes"]["multiturn_conversation"]["turns"]
+
+        # TokenEstimator.extract_prompt_text parses exactly this shape.
+        self.assertEqual([turn["role"] for turn in turns],
+                         ["user", "assistant", "user", "assistant"])
+        self.assertEqual(turns[0]["content"]["text"], "first ask")
+
+    def test_single_turn_attempt_records_no_conversation(self):
+        from garak.attempt import Attempt, Message
+
+        self.probe._prompt_data_map = None
+        attempt = Attempt(prompt=Message(text="only ask", lang="en"),
+                          probe_classname="0din.NotionTemplate")
+
+        result = self.probe._execute_attempt(attempt)
+
+        self.assertEqual(len(result.all_outputs), 1)
+        self.assertNotIn("multiturn_conversation", result.notes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/controllers/admin/scans_controller_spec.rb
+++ b/spec/controllers/admin/scans_controller_spec.rb
@@ -195,6 +195,23 @@ RSpec.describe Admin::ScansController, type: :controller do
 
         expect(response.body.index("MeasuredAlpha")).to be < response.body.index("UnmeasuredAlpha")
       end
+
+      # NULLS LAST alone has no tie-breaker, and unmeasured scans made ties far more
+      # common (every one of them is now NULL instead of a distinct 0.00). Postgres does
+      # not promise a stable order within a tied block across queries, so paginating
+      # "ASR desc" could show one scan twice and skip another. Assert the id tie-breaker
+      # is actually in the SQL rather than relying on Postgres happening to be stable.
+      it "breaks ties on avg_successful_attacks deterministically by id" do
+        sql_statements = []
+        callback = lambda { |*, payload| sql_statements << payload[:sql] }
+
+        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+          get :index, params: { q: { s: "avg_successful_attacks desc" } }
+        end
+
+        order_sql = sql_statements.find { |sql| sql.include?("ORDER BY avg_successful_attacks") }
+        expect(order_sql).to match(/avg_successful_attacks DESC NULLS LAST,\s*id\b/i)
+      end
     end
 
     it "does not render the empty state for a company with a long scan history" do

--- a/spec/controllers/admin/scans_controller_spec.rb
+++ b/spec/controllers/admin/scans_controller_spec.rb
@@ -167,6 +167,36 @@ RSpec.describe Admin::ScansController, type: :controller do
       end
     end
 
+    describe "sorting by avg_successful_attacks" do
+      # avg_successful_attacks is nullable -- a scan whose reports measured nothing has no
+      # rate. Postgres puts NULLs first on ORDER BY ... DESC by default, so sorting "worst
+      # ASR first" led with unmeasured scans ahead of every measured rate. Mirrors
+      # Admin::ProbesController's NULLS LAST handling for success_rate_calculated.
+      let!(:unmeasured) do
+        ActsAsTenant.with_tenant(company) do
+          create(:complete_scan, company: company, name: "UnmeasuredAlpha", avg_successful_attacks: nil)
+        end
+      end
+
+      let!(:measured) do
+        ActsAsTenant.with_tenant(company) do
+          create(:complete_scan, company: company, name: "MeasuredAlpha", avg_successful_attacks: 42.0)
+        end
+      end
+
+      it "puts the unmeasured scan last when sorting ASR descending" do
+        get :index, params: { q: { s: "avg_successful_attacks desc" } }
+
+        expect(response.body.index("MeasuredAlpha")).to be < response.body.index("UnmeasuredAlpha")
+      end
+
+      it "puts the unmeasured scan last when sorting ASR ascending too" do
+        get :index, params: { q: { s: "avg_successful_attacks asc" } }
+
+        expect(response.body.index("MeasuredAlpha")).to be < response.body.index("UnmeasuredAlpha")
+      end
+    end
+
     it "does not render the empty state for a company with a long scan history" do
       # The reported case: 126 existing scans, none scheduled.
       ActsAsTenant.with_tenant(company) { create_list(:complete_scan, 126, company: company) }

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1630,13 +1630,20 @@ RSpec.describe Report, type: :model do
     # `passed` is successful attacks (Report#total_successful_attacks sums the same column).
     # Counting `passed < total` read it as "attempts resisted", so a report where nothing
     # succeeded claimed vulnerabilities and the detector that found every one was ignored.
+    #
+    # Two fully-bypassed detectors (passed == total, both > 0) and one clean detector
+    # (passed == 0) make the old and new queries diverge: `passed < total` counts only
+    # the clean row (old = 1), `passed > 0` counts both bypassed rows (new = 2). A
+    # fixture with just one bypassed row and one clean row lands on the same integer
+    # under both queries and would not pin the regression.
     it 'counts detectors where at least one attack succeeded' do
       ActsAsTenant.with_tenant(company) do
         create(:detector_result, report: report, detector: create(:detector), passed: 4, total: 4)
+        create(:detector_result, report: report, detector: create(:detector), passed: 10, total: 10)
         create(:detector_result, report: report, detector: create(:detector), passed: 0, total: 80)
       end
 
-      expect(report.security_vulnerabilities_count).to eq(1)
+      expect(report.security_vulnerabilities_count).to eq(2)
     end
 
     it 'counts nothing when every attack was blocked' do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1616,4 +1616,44 @@ RSpec.describe Report, type: :model do
       end
     end
   end
+
+  describe '#security_vulnerabilities_count' do
+    let(:company) { create(:company) }
+    let(:scan) { ActsAsTenant.with_tenant(company) { create(:complete_scan, company: company) } }
+    let(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company) } }
+    let(:report) do
+      ActsAsTenant.with_tenant(company) do
+        create(:report, company: company, scan: scan, target: target, status: :completed)
+      end
+    end
+
+    # `passed` is successful attacks (Report#total_successful_attacks sums the same column).
+    # Counting `passed < total` read it as "attempts resisted", so a report where nothing
+    # succeeded claimed vulnerabilities and the detector that found every one was ignored.
+    it 'counts detectors where at least one attack succeeded' do
+      ActsAsTenant.with_tenant(company) do
+        create(:detector_result, report: report, detector: create(:detector), passed: 4, total: 4)
+        create(:detector_result, report: report, detector: create(:detector), passed: 0, total: 80)
+      end
+
+      expect(report.security_vulnerabilities_count).to eq(1)
+    end
+
+    it 'counts nothing when every attack was blocked' do
+      ActsAsTenant.with_tenant(company) do
+        create(:detector_result, report: report, detector: create(:detector), passed: 0, total: 4)
+        create(:detector_result, report: report, detector: create(:detector), passed: 0, total: 80)
+      end
+
+      expect(report.security_vulnerabilities_count).to eq(0)
+    end
+
+    it 'counts a detector that was fully bypassed' do
+      ActsAsTenant.with_tenant(company) do
+        create(:detector_result, report: report, detector: create(:detector), passed: 80, total: 80)
+      end
+
+      expect(report.security_vulnerabilities_count).to eq(1)
+    end
+  end
 end

--- a/spec/models/scan_spec.rb
+++ b/spec/models/scan_spec.rb
@@ -200,8 +200,23 @@ RSpec.describe Scan, type: :model do
     let(:scan) { create(:complete_scan) }
 
     context 'with no completed reports' do
-      it 'returns 0.0' do
-        expect(scan.calculate_avg_successful_attacks).to eq(0.0)
+      # nil, not 0.0: 0% is a scan that ran and blocked everything. A scan that never
+      # produced a result has no rate, and storing zero made the list and the dashboard
+      # report a clean bill of health for a scan that measured nothing.
+      it 'returns nil' do
+        expect(scan.calculate_avg_successful_attacks).to be_nil
+      end
+    end
+
+    context 'with completed reports that measured nothing' do
+      before do
+        report = create(:report, scan: scan, target: scan.targets.first, status: :completed)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector),
+                              passed: 0, total: 0)
+      end
+
+      it 'returns nil rather than averaging a rate it cannot compute' do
+        expect(scan.calculate_avg_successful_attacks).to be_nil
       end
     end
 
@@ -269,15 +284,26 @@ RSpec.describe Scan, type: :model do
         report1 = create(:report, scan: scan, target: scan.targets.first, status: :completed)
         report2 = create(:report, scan: scan, target: scan.targets.last, status: :completed)
 
-        create(:detector_result, report: report1, passed: 0, total: 0)
         create(:probe_result, report: report1, probe: create(:probe), detector: create(:detector), passed: 0, total: 0)
-        create(:detector_result, report: report2, passed: 10, total: 20)
         create(:probe_result, report: report2, probe: create(:probe), detector: create(:detector), passed: 10, total: 20)
       end
 
-      it 'handles division by zero correctly' do
-        # Average of 0% and 50% = 25%
-        expect(scan.calculate_avg_successful_attacks).to eq(25.0)
+      it 'averages only the reports that measured something' do
+        # The zero-total report has no rate. Counting it as 0% dragged the scan average
+        # to 25% for a scan whose one measured report was 50%.
+        expect(scan.calculate_avg_successful_attacks).to eq(50.0)
+      end
+    end
+
+    context 'when every measured report blocked every attack' do
+      before do
+        report = create(:report, scan: scan, target: scan.targets.first, status: :completed)
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector),
+                              passed: 0, total: 50)
+      end
+
+      it 'returns a measured zero' do
+        expect(scan.calculate_avg_successful_attacks).to eq(0.0)
       end
     end
 

--- a/spec/requests/asr_cross_surface_spec.rb
+++ b/spec/requests/asr_cross_surface_spec.rb
@@ -196,4 +196,18 @@ RSpec.describe "ASR consistency across report surfaces", type: :request do
     expect(unmeasurable.asr.calculable?).to be false
     expect(unmeasurable.asr.percent).to be_nil
   end
+
+  it "says the same thing about a scan that measured nothing as about its reports" do
+    # The reports list said N/A for the report while the scans list said 0.0% for the scan
+    # that contains it -- the same absence, described two ways, one of them as a result.
+    build_report(status: :failed, completeness: :none, passed: 0, total: 0)
+    ActsAsTenant.with_tenant(company) { scan.send(:update_avg_successful_attacks!) }
+
+    get reports_path
+    expect(response.body).to include("N/A")
+
+    get scans_path
+    expect(response.body).to include("N/A")
+    expect(scan.reload.avg_successful_attacks).to be_nil
+  end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The dashboard is the app's landing page, and until now nothing under spec/requests/
+# rendered it: the "Last Five Scans" card's ASR text -- "N/A" for a scan that measured
+# nothing, a percentage for one that did -- shipped unverified on the one surface every
+# user sees first. A nil avg_successful_attacks regressing back to "0%" here would have
+# gone unnoticed by any test.
+RSpec.describe "Dashboard", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { ActsAsTenant.with_tenant(company) { create(:user, :super_admin, company: company) } }
+
+  before do
+    user.update!(current_company: company)
+    sign_in user
+    ActsAsTenant.current_tenant = company
+  end
+
+  def last_five_scans_card
+    Nokogiri::HTML(response.body).at_xpath(
+      "//h3[normalize-space()='Last Five Scans']/ancestor::div[contains(@class,'rounded-lg')][1]"
+    )
+  end
+
+  it "shows N/A for a scan with no measurable ASR" do
+    ActsAsTenant.with_tenant(company) do
+      create(:complete_scan, company: company, name: "UnmeasuredScan", avg_successful_attacks: nil)
+    end
+
+    get root_path
+
+    card = last_five_scans_card
+    expect(card).to be_present
+    expect(card.text).to include("UnmeasuredScan")
+    expect(card.text).to include("N/A")
+  end
+
+  it "shows the rate for a scan with a measured ASR" do
+    ActsAsTenant.with_tenant(company) do
+      create(:complete_scan, company: company, name: "MeasuredScan", avg_successful_attacks: 73.0)
+    end
+
+    get root_path
+
+    card = last_five_scans_card
+    expect(card).to be_present
+    expect(card.text).to include("MeasuredScan")
+    expect(card.text).to include("73%")
+    expect(card.text).not_to include("N/A")
+  end
+end

--- a/spec/requests/mobile_navigation_spec.rb
+++ b/spec/requests/mobile_navigation_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The backdrop is a full-viewport click target at z-30 with pointer-events enabled. It is
+# hidden by mobile_nav_controller#close, so shipping it visible meant that on any viewport
+# below Tailwind's xl breakpoint (1280px) nothing on the page was clickable until the user
+# opened and closed the drawer once.
+RSpec.describe "Mobile navigation", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { ActsAsTenant.with_tenant(company) { create(:user, :super_admin, company: company) } }
+
+  before do
+    user.update!(current_company: company)
+    sign_in user
+    ActsAsTenant.current_tenant = company
+  end
+
+  it "renders the backdrop hidden until the drawer is opened" do
+    get scans_path
+
+    backdrop = Nokogiri::HTML(response.body).at_css('[data-mobile-nav-target="backdrop"]')
+
+    expect(backdrop).to be_present
+    expect(backdrop["class"].split).to include("hidden")
+  end
+
+  it "keeps the backdrop suppressed at xl and wider" do
+    get scans_path
+
+    backdrop = Nokogiri::HTML(response.body).at_css('[data-mobile-nav-target="backdrop"]')
+
+    expect(backdrop["class"].split).to include("xl:hidden")
+  end
+end

--- a/spec/requests/report_metric_reconciliation_spec.rb
+++ b/spec/requests/report_metric_reconciliation_spec.rb
@@ -194,6 +194,15 @@ RSpec.describe "Reconciling report metrics", type: :request do
 
       expect(response.body).to include("0 / 84")
       expect(report.security_vulnerabilities_count).to eq(0)
+
+      # The model assertion above pins the count; this pins the surface it actually
+      # renders on -- the bare integer next to the "Vulnerabilities Found" label in the
+      # overview's Key Statistics panel (app/views/admin/reports/_statistics_section.html.erb).
+      value = Nokogiri::HTML(response.body).at_xpath(
+        "//span[normalize-space()='Vulnerabilities Found']/following-sibling::span[1]"
+      )
+      expect(value).to be_present
+      expect(value.text.strip).to eq("0")
     end
   end
 end

--- a/spec/requests/report_metric_reconciliation_spec.rb
+++ b/spec/requests/report_metric_reconciliation_spec.rb
@@ -174,4 +174,26 @@ RSpec.describe "Reconciling report metrics", type: :request do
       expect(response.body).not_to include("rate over the attempts")
     end
   end
+
+  context "a report where every attack was blocked" do
+    let!(:report) do
+      ActsAsTenant.with_tenant(company) do
+        report = create(:report, company: company, scan: scan, target: target, status: :completed)
+        detector = create(:detector, name: "mitigation.MitigationBypass")
+        probe = create(:probe, name: "Blocked", detector: detector)
+        create(:probe_result, report: report, probe: probe, detector: detector, passed: 0, total: 84)
+        create(:detector_result, report: report, detector: detector, passed: 0, total: 84)
+        report
+      end
+    end
+
+    # "0 / 84 attacks succeeded" and "2 vulnerabilities found" cannot both describe the
+    # same report. The overview showed exactly that.
+    it "does not claim vulnerabilities next to a zero success rate" do
+      get report_path(report)
+
+      expect(response.body).to include("0 / 84")
+      expect(report.security_vulnerabilities_count).to eq(0)
+    end
+  end
 end

--- a/spec/services/scans/stats_serializer_spec.rb
+++ b/spec/services/scans/stats_serializer_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Scans::StatsSerializer, type: :service do
         expect(t2[:asr]).to eq(25.0)
       end
 
-      it 'includes targets with no completed reports as zero' do
+      it 'includes targets with no completed reports as unmeasured, not a clean 0%' do
         target3 = create(:target, :good, name: "Target 3")
         scan.targets << target3
 
@@ -155,7 +155,32 @@ RSpec.describe Scans::StatsSerializer, type: :service do
 
         expect(t3[:passed]).to eq(0)
         expect(t3[:total]).to eq(0)
-        expect(t3[:asr]).to eq(0)
+        expect(t3[:asr]).to be_nil
+      end
+    end
+
+    context 'when reports are completed but nothing was measured' do
+      # A target with probe_results totalling 0 must not read as a clean 0% -- that is
+      # the same false "attacks were evaluated and none succeeded" claim AsrFigure exists
+      # to prevent at the report level (see app/models/reports/asr_figure.rb).
+      let!(:report) { create(:report, :completed, scan: scan, target: target) }
+
+      before do
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector),
+                              passed: 0, total: 0)
+      end
+
+      it 'reports no rate rather than a false 0%, both overall and per-target' do
+        result = serializer.send(:attacks_info)
+
+        expect(result[:total_passed]).to eq(0)
+        expect(result[:total_tests]).to eq(0)
+        expect(result[:attack_success_rate]).to be_nil
+
+        t1 = result[:by_target].find { |t| t[:target_name] == target.name }
+        expect(t1[:passed]).to eq(0)
+        expect(t1[:total]).to eq(0)
+        expect(t1[:asr]).to be_nil
       end
     end
   end
@@ -531,6 +556,26 @@ RSpec.describe Scans::StatsSerializer, type: :service do
         expect(result[:grade]).to eq("N/A")
         expect(result[:score]).to be_nil
         expect(result[:description]).to eq("No completed scans")
+      end
+    end
+
+    context 'when there are completed reports that measured nothing' do
+      # completed_reports.empty? is false here, but total_tests is 0, so asr and
+      # risk_penalty both compute to 0 and the scan graded A+ "Excellent security
+      # posture" -- a false clean bill of health for a scan that measured nothing.
+      let!(:report) { create(:report, :completed, scan: scan, target: target) }
+
+      before do
+        create(:probe_result, report: report, probe: create(:probe), detector: create(:detector),
+                              passed: 0, total: 0)
+      end
+
+      it 'returns N/A rather than a false clean grade' do
+        result = serializer.send(:security_grade_info)
+
+        expect(result[:grade]).to eq("N/A")
+        expect(result[:score]).to be_nil
+        expect(result[:description]).to eq("No measurable attacks")
       end
     end
 

--- a/spec/services/scans/stats_serializer_spec.rb
+++ b/spec/services/scans/stats_serializer_spec.rb
@@ -223,6 +223,28 @@ RSpec.describe Scans::StatsSerializer, type: :service do
       end
     end
 
+    context 'when the completed report measured nothing for a risk level' do
+      # A risk level with probe_results totalling 0 must not read as a clean 0% -- the
+      # same false "attacks were evaluated and none succeeded" claim AsrFigure exists to
+      # prevent at the report level (see app/models/reports/asr_figure.rb).
+      let(:detector) { create(:detector) }
+      let(:critical_probe) { create(:probe, social_impact_score: "Critical Risk", detector: detector) }
+      let!(:report) { create(:report, :completed, scan: scan, target: target) }
+
+      before do
+        scan.probes << critical_probe
+        create(:probe_result, report: report, probe: critical_probe, detector: detector, passed: 0, total: 0)
+      end
+
+      it 'reports no rate rather than a false 0%' do
+        result = serializer.send(:risk_distribution_info)
+
+        expect(result["critical_risk"][:passed]).to eq(0)
+        expect(result["critical_risk"][:total]).to eq(0)
+        expect(result["critical_risk"][:asr]).to be_nil
+      end
+    end
+
     context 'when there are completed reports with probe results' do
       let(:detector) { create(:detector) }
 
@@ -291,6 +313,27 @@ RSpec.describe Scans::StatsSerializer, type: :service do
       end
     end
 
+    context 'when the completed report measured nothing for a disclosure status' do
+      # A disclosure status with probe_results totalling 0 must not read as a clean 0% --
+      # same rule as risk_distribution_info above.
+      let(:detector) { create(:detector) }
+      let(:zero_day_probe) { create(:probe, disclosure_status: "0-day", detector: detector) }
+      let!(:report) { create(:report, :completed, scan: scan, target: target) }
+
+      before do
+        scan.probes << zero_day_probe
+        create(:probe_result, report: report, probe: zero_day_probe, detector: detector, passed: 0, total: 0)
+      end
+
+      it 'reports no rate rather than a false 0%' do
+        result = serializer.send(:disclosure_breakdown_info)
+
+        expect(result["zero_day"][:passed]).to eq(0)
+        expect(result["zero_day"][:total]).to eq(0)
+        expect(result["zero_day"][:asr]).to be_nil
+      end
+    end
+
     context 'when there are completed reports with probe results' do
       let(:detector) { create(:detector) }
 
@@ -337,6 +380,29 @@ RSpec.describe Scans::StatsSerializer, type: :service do
     context 'when there are no completed reports' do
       it 'returns an empty array' do
         expect(serializer.send(:top_vulnerabilities_info)).to eq([])
+      end
+    end
+
+    context 'when a flagged probe has probe_results totalling 0' do
+      # any_detector_passed: true (a detector was bypassed) with total: 0 must not read
+      # as a clean 0% success_rate -- same rule as risk_distribution_info above.
+      let(:detector) { create(:detector) }
+      let(:probe) { create(:probe, name: "UnmeasuredProbe", category: "0din", social_impact_score: "Critical Risk", detector: detector) }
+      let!(:report) { create(:report, :completed, scan: scan, target: target) }
+
+      before do
+        scan.probes << probe
+        create(:probe_result, report: report, probe: probe, detector: detector,
+                              passed: 0, total: 0, any_detector_passed: true)
+      end
+
+      it 'reports no rate rather than a false 0%' do
+        result = serializer.send(:top_vulnerabilities_info)
+        vulnerability = result.find { |v| v[:probe_name] == "UnmeasuredProbe" }
+
+        expect(vulnerability[:passed]).to eq(0)
+        expect(vulnerability[:total]).to eq(0)
+        expect(vulnerability[:success_rate]).to be_nil
       end
     end
 
@@ -415,6 +481,26 @@ RSpec.describe Scans::StatsSerializer, type: :service do
     context 'when there are no completed reports' do
       it 'returns an empty array' do
         expect(serializer.send(:detector_breakdown_info)).to eq([])
+      end
+    end
+
+    context 'when a detector has detector_results totalling 0' do
+      # A detector with results totalling 0 must not read as a clean 0% -- same rule as
+      # risk_distribution_info above.
+      let(:detector) { create(:detector, name: "UnmeasuredDetector") }
+      let!(:report) { create(:report, :completed, scan: scan, target: target) }
+
+      before do
+        create(:detector_result, report: report, detector: detector, passed: 0, total: 0)
+      end
+
+      it 'reports no rate rather than a false 0%' do
+        result = serializer.send(:detector_breakdown_info)
+        unmeasured = result.find { |d| d[:detector_name] == "UnmeasuredDetector" }
+
+        expect(unmeasured[:passed]).to eq(0)
+        expect(unmeasured[:total]).to eq(0)
+        expect(unmeasured[:asr]).to be_nil
       end
     end
 

--- a/spec/services/stats/last_five_scans_data_spec.rb
+++ b/spec/services/stats/last_five_scans_data_spec.rb
@@ -40,9 +40,11 @@ RSpec.describe Stats::LastFiveScansData, type: :service do
     context 'when a scan has no computed ASR' do
       before { scan_with_asr(name: 'No ASR', asr: nil, created_at: 1.day.ago) }
 
-      it 'reports 0' do
+      # Reporting 0 here made a scan that measured nothing look like a scan that blocked
+      # everything. The card renders nil as "N/A".
+      it 'reports nil' do
         result = described_class.new.call
-        expect(result).to eq([ { scan_name: 'No ASR', scan_id: Scan.last.id, asr: 0 } ])
+        expect(result).to eq([ { scan_name: 'No ASR', scan_id: Scan.last.id, asr: nil } ])
       end
     end
 

--- a/spec/services/stats/probe_success_rate_data_spec.rb
+++ b/spec/services/stats/probe_success_rate_data_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Stats::ProbeSuccessRateData do
       subject { described_class.new }
 
       context 'when no probe results exist' do
-        it 'returns zero success rate' do
+        it 'returns no success rate rather than a false 0%' do
           result = subject.call
 
-          expect(result[:success_rate]).to eq(0)
+          expect(result[:success_rate]).to be_nil
           expect(result[:time_range]).to eq("Last 30 Days")
         end
       end
@@ -263,10 +263,10 @@ RSpec.describe Stats::ProbeSuccessRateData do
                 created_at: 20.days.ago)
         end
 
-        it 'handles zero division gracefully' do
+        it 'reports no rate rather than a false 0%, matching Reports::AsrFigure' do
           result = described_class.new.call
 
-          expect(result[:success_rate]).to eq(0)
+          expect(result[:success_rate]).to be_nil
         end
       end
     end

--- a/spec/services/token_estimator_spec.rb
+++ b/spec/services/token_estimator_spec.rb
@@ -199,6 +199,55 @@ RSpec.describe TokenEstimator do
     end
   end
 
+  describe 'multi-turn attempts' do
+    let(:turns) do
+      [
+        { 'role' => 'user', 'content' => { 'text' => 'first ask' } },
+        { 'role' => 'assistant', 'content' => { 'text' => 'reply one' } },
+        { 'role' => 'user', 'content' => { 'text' => 'second ask' } },
+        { 'role' => 'assistant', 'content' => { 'text' => 'reply two' } }
+      ]
+    end
+
+    # script/garak_plugins/probes/0din.py records what a multi-shot probe actually sent.
+    # The seed prompt garak stores is one turn, so counting it alone understates input by
+    # every turn the probe resent.
+    it 'counts the conversation the probe recorded, not just the seed prompt' do
+      attempt = {
+        'prompt' => { 'turns' => [ turns.first ] },
+        'notes' => { 'multiturn_conversation' => { 'turns' => turns } },
+        'outputs' => [ { 'text' => "reply one\n\n--\n\nreply two" } ]
+      }
+      equivalent = {
+        'prompt' => { 'turns' => turns },
+        'outputs' => [ { 'text' => "reply one\n\n--\n\nreply two" } ]
+      }
+
+      expect(described_class.estimate_from_attempt(attempt)[:input_tokens])
+        .to eq(described_class.estimate_from_attempt(equivalent)[:input_tokens])
+    end
+
+    it 'counts more input than the seed prompt alone' do
+      seed_only = { 'prompt' => { 'turns' => [ turns.first ] }, 'outputs' => [] }
+      attempt = {
+        'prompt' => { 'turns' => [ turns.first ] },
+        'notes' => { 'multiturn_conversation' => { 'turns' => turns } },
+        'outputs' => []
+      }
+
+      expect(described_class.estimate_from_attempt(attempt)[:input_tokens])
+        .to be > described_class.estimate_from_attempt(seed_only)[:input_tokens]
+    end
+
+    it 'falls back to the prompt when no conversation was recorded' do
+      attempt = { 'prompt' => { 'turns' => turns }, 'notes' => {}, 'outputs' => [] }
+      without_notes = { 'prompt' => { 'turns' => turns }, 'outputs' => [] }
+
+      expect(described_class.estimate_from_attempt(attempt))
+        .to eq(described_class.estimate_from_attempt(without_notes))
+    end
+  end
+
   describe ".extract_prompt_text" do
     it "returns string prompt unchanged" do
       expect(described_class.extract_prompt_text("Hello world")).to eq("Hello world")


### PR DESCRIPTION
Four defects found during an end-to-end verification session on the v1.16.0 release candidate. **None is a regression from the pending release** — all four predate it, and the garak-related one is live in production today.

## What was broken

**1. Three probes crashed every scan they appeared in.** `NotionTemplate`, `ChemicalInquiryEscalation` and `HexRecipeBookCM` reassigned `Attempt.prompt`, which garak >= 0.15 makes write-once (`TypeError: prompt cannot be changed once set`). The run aborted, so every other probe queued behind them lost its results too. Reproduced with `NotionTemplate` alone against an unmodified target: report failed with `garak_runtime_error` and zero probe results. garak 0.16.0 shipped in v1.15.2, so this is in production now.

The conversation those probes recorded for token accounting now travels in `attempt.notes["multiturn_conversation"]`. It deliberately does **not** go into `attempt.conversations`: the vendored detectors iterate `attempt.all_outputs`, so intermediate assistant turns there would score one attack as several evaluations and silently move ASR denominators.

**2. The nav backdrop swallowed every click below 1280px.** The mobile backdrop rendered without `hidden` — a full-viewport `z-30` overlay with `pointer-events: auto` — so on any narrower window nothing was clickable until the user opened and closed the drawer once. `mobile_nav_controller` assumes it starts hidden; its own docstring shows `class="hidden"`.

**3. "Vulnerabilities Found" counted the detectors that found nothing.** It counted `passed < total`, but `passed` is *successful attacks* (`Reports::Process#process_eval` inverts garak's value). A report with 0/84 successful attacks claimed 2 vulnerabilities; a detector bypassed on all 80 attempts was counted as clean.

**4. A scan that measured nothing reported 0% ASR.** `Scan#calculate_avg_successful_attacks` returned `0.0` when nothing was measurable, so a scan whose only report failed with zero results read "0.0%" on the scans list and dashboard while its own report correctly read "N/A". This extends the doctrine `Reports::AsrFigure` already sets at report level: `0.0` means attacks were evaluated and none succeeded; `nil` means nothing was measurable.

Follow-on review found the same false zero on adjacent surfaces, fixed here too: the `/scans/:id/stats` payload (including `security_grade_info`, which graded an unmeasured scan **A+ / "Excellent security posture"**), the scan-detail ASR gauge, and the reconciliation rake task, whose scope was narrower than the migration it supports.

## Verification

Full suite green: **2954 rspec examples**, **117 Python tests** (against real garak 0.16.0), JS tests, rubocop across 510 files, brakeman no warnings.

Verified in a browser against a live stack, on real scan data:

| Fix | Evidence |
|---|---|
| Probe crash | A scan of NotionTemplate + 2 other probes **completes**; all three record results (NotionTemplate 0/4 — one evaluation per attempt, so nothing leaked into `all_outputs`) |
| Backdrop | At 1200px on first load, `elementFromPoint` at viewport centre returns page content and a content link navigates — that interaction was dead before |
| Vulnerability count | A 0/84 report now reads **0** (was 2); a 4/84 report reads 1, counting the detector that actually found something |
| Scan ASR | Scans list shows **N/A** for scans that measured nothing and **0.0%** for one that measured 88 attempts with no successes, side by side; dashboard card agrees |
| Gauge | Reads **N/A** for an unmeasured scan |

The gauge was caught *by* that browser round: the serializer change made it render the literal string `NaN` (ECharts coerces a null series value to NaN before the formatter runs). Unit tests and three review passes missed it; a JS test now covers it.

## Data migration

`20260818120000_recompute_scan_avg_without_false_zeros` recomputes `scans.avg_successful_attacks` for **all** scans — deliberately wider than its precedent, because the rows most needing correction are those whose reports all failed, which have no completed report to select on. Data-only, idempotent, with a `down` that reimplements the old arithmetic rather than delegating to the new code.

## Note for release notes

`avg_successful_attacks` and the sibling rate keys in the `/scans/:id/stats` JSON now emit `null` where they emitted `0` for an unmeasured scan. No in-repo consumer reads them, but an external client doing arithmetic on those fields would see a null.

## Known follow-ups (deliberately not in this PR)

- **CI never runs the Python suite or `npm run test:js`** — so this PR's five new probe tests and the "never reassign the prompt" source guard are unexercised in CI. Pre-existing gap; wiring it up needs a CI image with garak. Highest-value next ticket.
- A scan whose only report is failed-with-partial-results shows N/A on the scans list while that report shows its real rate. Strictly better than the old `0.0%`, but a fix means reopening the partial-exclusion doctrine set by #149/#143.
- The dashboard's "Avg ASR" tile still renders `0.0%` where the card beside it says N/A (`Stats::AverageAsrScore` coerces NULL to 0).
- `Report#security_vulnerabilities_count` counts detector rows, which is near-binary since most 0din probes share one detector; `probe_results.any_detector_passed` would match what the rest of the UI shows. That changes the metric's unit, so it wants a deliberate decision.
- `notes["multiturn_conversation"]` is persisted alongside `prompt` and `outputs`, which already carry the same text — roughly doubling attempts JSON for the three multi-shot probes.
