### PR TITLE
fix(ui): stop unmeasured gauges and internal flash markers from reading as results

### DIFF
--- a/app/javascript/config/chartConfig.js
+++ b/app/javascript/config/chartConfig.js
@@ -125,7 +125,12 @@ export function getGaugeChartConfig(successRate, chartConfig, name = 'Success Ra
         backgroundColor: 'transparent',
         tooltip: {
             ...tooltipConfig,
-            formatter: '{b}: {c}%'
+            // The default '{b}: {c}%' template interpolates whatever value ECharts holds,
+            // so a null/NaN rate rendered the literal text "Success Rate: null%" -- the
+            // tooltip has to say N/A too, matching the centre label below.
+            formatter: function (params) {
+                return `${params.name}: ${Number.isFinite(params.value) ? params.value + '%' : 'N/A'}`;
+            }
         },
         series: [
             {
@@ -150,6 +155,13 @@ export function getGaugeChartConfig(successRate, chartConfig, name = 'Success Ra
                     }
                 },
                 pointer: {
+                    // A pointer at the zero position asserts "measured, and it's zero" just
+                    // as strongly as a "0" label would, so it must not be shown at all for a
+                    // non-finite (unmeasured) rate. successRate is the raw value passed in,
+                    // known here at config-build time -- unlike the formatters above/below,
+                    // which only see what ECharts has already coerced null to (NaN) by
+                    // render time.
+                    show: Number.isFinite(successRate),
                     icon: 'path://M12.8,0.7l12,40.1H0.7L12.8,0.7z',
                     length: '12%',
                     width: 10,

--- a/app/views/layouts/partials/_flash_messages.html.erb
+++ b/app/views/layouts/partials/_flash_messages.html.erb
@@ -1,10 +1,14 @@
 <%
   dismissible = local_assigns.fetch(:dismissible, true)
   wrapper_classes = local_assigns.fetch(:wrapper_classes, "px-2.5 lg:px-5 py-2")
+  # Only render user-facing flash types. Devise and other internals stash markers
+  # (e.g. flash[:timedout]) alongside the real message; those must never render.
+  displayable_types = %i[notice success alert error warning]
+  displayable_flash = flash.select { |type, _message| displayable_types.include?(type.to_sym) }
 %>
-<% if flash.any? %>
+<% if displayable_flash.any? %>
   <div class="flash-messages <%= wrapper_classes %>">
-    <% flash.each do |type, message| %>
+    <% displayable_flash.each do |type, message| %>
       <%
         # Map flash types to Tailwind classes
         alert_class = case type.to_sym

--- a/script/tests/javascript_controller_tests.mjs
+++ b/script/tests/javascript_controller_tests.mjs
@@ -1469,6 +1469,38 @@ function testGaugeChartConfigDetailFormatter() {
   assert.equal(formatter(4.76), "5")
 }
 
+function testGaugeChartConfigPointer() {
+  const getGaugeChartConfig = loadGetGaugeChartConfig()
+  const baseConfig = { textStyle: { color: "#000" } }
+
+  // A pointer parked at the zero position asserts "measured, and it's zero" just as
+  // strongly as a "0" label would, so it must be hidden entirely for a non-finite
+  // (unmeasured) rate rather than repointed.
+  assert.equal(getGaugeChartConfig(null, baseConfig, "Success Rate").series[0].pointer.show, false)
+  assert.equal(getGaugeChartConfig(undefined, baseConfig, "Success Rate").series[0].pointer.show, false)
+  assert.equal(getGaugeChartConfig(NaN, baseConfig, "Success Rate").series[0].pointer.show, false)
+
+  // A real 0 (or any measured value) is a real reading and must keep pointing at it.
+  assert.equal(getGaugeChartConfig(0, baseConfig, "Success Rate").series[0].pointer.show, true)
+  assert.equal(getGaugeChartConfig(83.24, baseConfig, "Success Rate").series[0].pointer.show, true)
+}
+
+function testGaugeChartConfigTooltipFormatter() {
+  const getGaugeChartConfig = loadGetGaugeChartConfig()
+  const config = getGaugeChartConfig(null, { textStyle: { color: "#000" } }, "Success Rate")
+  const tooltipFormatter = config.tooltip.formatter
+
+  // The default '{b}: {c}%' template interpolates whatever value ECharts holds, so a
+  // null/NaN rate rendered the literal text "Success Rate: null%" -- the tooltip must
+  // agree with the centre label instead of contradicting it.
+  assert.equal(tooltipFormatter({ name: "Success Rate", value: null }), "Success Rate: N/A")
+  assert.equal(tooltipFormatter({ name: "Success Rate", value: undefined }), "Success Rate: N/A")
+  assert.equal(tooltipFormatter({ name: "Success Rate", value: NaN }), "Success Rate: N/A")
+  // A real 0 or fractional rate is a measured result and must still render as a percent.
+  assert.equal(tooltipFormatter({ name: "Success Rate", value: 0 }), "Success Rate: 0%")
+  assert.equal(tooltipFormatter({ name: "Success Rate", value: 83.24 }), "Success Rate: 83.24%")
+}
+
 await testDebugStreamLeaseController()
 testActivityStreamController()
 testDebugTabsController()
@@ -1483,4 +1515,6 @@ testTargetWizardSyncModel()
 testWebchatAutoDetectCurrentAuth()
 testProbeCategoryToggleCategory()
 testGaugeChartConfigDetailFormatter()
+testGaugeChartConfigPointer()
+testGaugeChartConfigTooltipFormatter()
 console.log("JavaScript controller tests passed")

--- a/spec/views/layouts_flash_messages_spec.rb
+++ b/spec/views/layouts_flash_messages_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'layouts/partials/_flash_messages', type: :view do
+  it 'does not render internal flash markers like :timedout alongside the real message' do
+    flash[:alert] = 'Your session expired. Please sign in again to continue.'
+    flash[:timedout] = true
+
+    render partial: 'layouts/partials/flash_messages'
+
+    expect(alert_texts).to eq([ 'Your session expired. Please sign in again to continue.' ])
+  end
+
+  it 'renders every supported user-facing flash type' do
+    flash[:notice] = 'Notice message'
+    flash[:success] = 'Success message'
+    flash[:alert] = 'Alert message'
+    flash[:error] = 'Error message'
+    flash[:warning] = 'Warning message'
+
+    render partial: 'layouts/partials/flash_messages'
+
+    expect(alert_texts).to contain_exactly(
+      'Notice message', 'Success message', 'Alert message', 'Error message', 'Warning message'
+    )
+  end
+
+  def alert_texts
+    Nokogiri::HTML.fragment(rendered).css('[role="alert"]').map { |node| node.text.squish }
+  end
+end


### PR DESCRIPTION
Two UI surfaces that presented internal state as if it were a real result.

## The gauge still implied a measured zero (`6703c3e`)

v1.16.0 made `Stats::ProbeSuccessRateData` return `null` for a scan that measured nothing and gave the gauge's centre label a `Number.isFinite` guard, so it reads "N/A" instead of "NaN". That was only half the fix.

For a null rate the needle still sat at **exactly** the position a measured zero produces (verified by rendering the chart headlessly: identical `pointer_rotation` for `null` and `0`), and the shared tooltip's `'{b}: {c}%'` template expanded to the literal text `Success Rate: null%`. A pointer parked in the "Low" band asserts a measured near-zero ASR just as strongly as a "0" label would, so the scan, probe and target gauges all continued to imply a clean result for a scan that produced none.

- The pointer is hidden for a non-finite rate. This is keyed off the raw `successRate` argument at config-build time, not off what the formatters receive — ECharts has already coerced `null` to `NaN` by render time, which is why the identity checks inside the formatters were never enough.
- The tooltip renders "N/A" rather than `null%`.
- A real `0` is untouched: pointer shown at zero, tooltip `0%`. That is a measured result and must keep reading as one.

Both live in the shared `getGaugeChartConfig`, so all three gauges pick them up together; no controller changes.

## An internal flash marker rendered as a message (`8cc1da5`)

On session expiry Devise sets `flash[:timedout] = true` alongside the real alert. The flash partial iterated every key in the hash, so the login page showed a stray blue alert box containing the literal text `true` above the genuine "Your session expired. Please sign in again to continue." message.

The partial now renders only the five user-facing types the `alert_class` mapping already names (`notice`, `success`, `alert`, `error`, `warning`). It is an allowlist rather than a denylist of `timedout`, so any other internal marker stashed in the flash is excluded too.

## Verification

- `npm run test:js` — new assertions cover gauge pointer visibility and tooltip text across `null`/`undefined`/`NaN`/`0`/a real rate, watched failing before the fix.
- New `spec/views/layouts_flash_messages_spec.rb` — asserts the timeout case renders exactly one alert (the real message, no `true`), and that all five supported types still render. Both examples watched failing first; full `spec/views` green.
- The gauge change was confirmed in a browser on a scan whose reports produced nothing: the needle is gone and the gauge reads N/A, where it previously pointed into the "Low" band. The flash change is verified at the spec level, which reproduces the exact `alert` + `timedout` pair.
