### PR TITLE
fix(ci): pin the changelog preset that breaks semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, develop ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,16 @@ jobs:
           node-version: 22
 
       - name: Install semantic-release plugins
-        run: npm install --no-save @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/exec @semantic-release/github conventional-changelog-conventionalcommits
+        # conventional-changelog-conventionalcommits is pinned to 9.3.1: its 10.x line pulls in
+        # @conventional-changelog/template, which refuses to render unless
+        # conventional-changelog-writer@9+ is loaded -- but @semantic-release/release-notes-generator
+        # (installed unpinned below) still bundles writer@8. Left unpinned, this failed every
+        # release with `Missing helper: "conventional-changelog-conventionalcommits requires
+        # conventional-changelog-writer@9 or newer"` the moment a 10.x version was published.
+        # 9.3.1 is the newest release that does not pull in the offending package.
+        # The other packages below are still unpinned and can break the same way; unpin this one
+        # again once @semantic-release/release-notes-generator ships with writer@9+.
+        run: npm install --no-save @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/exec @semantic-release/github conventional-changelog-conventionalcommits@9.3.1
 
       - name: Run semantic-release
         id: semantic

--- a/spec/controllers/admin/scans_controller_spec.rb
+++ b/spec/controllers/admin/scans_controller_spec.rb
@@ -10,10 +10,9 @@ RSpec.describe Admin::ScansController, type: :controller do
   let!(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company) } }
   let!(:probe) { create(:probe) }
   let!(:scan) do
-    # Explicit, unique name: the factory default (Faker::App.name) can land on "Alpha",
-    # which is a substring of the hard-coded "*Alpha" fixtures used below (OneTimeAlpha,
-    # ScheduledAlpha, MeasuredAlpha, UnmeasuredAlpha), risking a flaky substring collision
-    # in assertions against this scan's own rendered name.
+    # Explicit name: the factory default (Faker::App.name) can be "Alpha", a substring of
+    # the hard-coded "*Alpha" fixtures below. Hardens against a collision today's substring
+    # assertions happen not to expose -- not a fix for a live failure.
     ActsAsTenant.with_tenant(company) do
       create(:complete_scan, company: company, name: "UnscheduledBaseline#{SecureRandom.hex(4)}")
     end

--- a/spec/controllers/admin/scans_controller_spec.rb
+++ b/spec/controllers/admin/scans_controller_spec.rb
@@ -10,8 +10,12 @@ RSpec.describe Admin::ScansController, type: :controller do
   let!(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company) } }
   let!(:probe) { create(:probe) }
   let!(:scan) do
+    # Explicit, unique name: the factory default (Faker::App.name) can land on "Alpha",
+    # which is a substring of the hard-coded "*Alpha" fixtures used below (OneTimeAlpha,
+    # ScheduledAlpha, MeasuredAlpha, UnmeasuredAlpha), risking a flaky substring collision
+    # in assertions against this scan's own rendered name.
     ActsAsTenant.with_tenant(company) do
-      create(:complete_scan, company: company)
+      create(:complete_scan, company: company, name: "UnscheduledBaseline#{SecureRandom.hex(4)}")
     end
   end
 


### PR DESCRIPTION
Three independent CI/test fixes. The first one unblocks releases and is the reason this PR exists; the other two are small hardening.

## The next release would have failed (`96f5c39`)

`release.yml` installed the semantic-release plugin set unpinned. `conventional-changelog-conventionalcommits` 10.x depends on `@conventional-changelog/template`, which refuses to render unless `conventional-changelog-writer@9` or newer is loaded — but `@semantic-release/release-notes-generator@14` still bundles writer@8. So the first 10.x publish breaks every release with:

```
Missing helper: "conventional-changelog-conventionalcommits requires conventional-changelog-writer@9 or newer"
```

`10.4.0` was published 2026-08-18 21:37 UTC. The v1.16.0 release ran 21:28–21:48 UTC and resolved its dependencies minutes before that landed — the next run would have picked it up and failed.

Pinned to `9.3.1`, the newest release that does not pull the offending package in at all. The other plugins stay unpinned and can break the same way; the comment records that, and says to unpin once `release-notes-generator` ships writer@9+.

## Deterministic spec fixture name (`e88d4e4`)

`spec/factories/scans.rb` defaults `name { Faker::App.name }`, one of whose 82 values is `"Alpha"` — a substring of the `MeasuredAlpha` / `UnmeasuredAlpha` / `ScheduledAlpha` / `OneTimeAlpha` fixtures in `spec/controllers/admin/scans_controller_spec.rb`.

To be clear about scope: **no assertion in the file today is actually vulnerable to this** — an attempt to reproduce a failure by forcing the colliding name did not turn any example red, because only the full `*Alpha` strings are asserted. This is prophylactic: it gives the one factory-default-named scan in that file an explicit unique name, so adding a `not_to include(scan.name)`-style assertion later can't produce a one-run-in-82 false failure.

## Per-PR CI concurrency isolation (`53e13fd`)

`ci.yml`'s concurrency group was `${{ github.workflow }}-${{ github.head_ref || github.ref }}` with `cancel-in-progress: true`. The group now includes `github.event_name` and uses `github.ref`.

To be precise about what this fixes: push and pull_request runs were *already* in distinct groups (for `push`, `head_ref` is empty, so the key was `<workflow>-refs/heads/x`). The real improvements are that two open PRs sharing one head branch no longer cancel each other — `github.ref` for a PR is the unique `refs/pull/N/merge` — and the `workflow_call` invocation from `release.yml` can no longer share a group with a direct push to `main`. Cancellation of superseded runs within a single PR is preserved.

Other workflows were checked and left alone: `release.yml` has a concurrency group but only a `workflow_dispatch` trigger, and `ssdlc-actions.yml` has both triggers but declares no concurrency block.

## Known, not addressed here

`npx semantic-release` still resolves `semantic-release` itself unpinned at release time, so a future major there can reintroduce this same class of breakage. Out of scope for this PR.

## Verification

`release.yml` and `ci.yml` both still parse, and the install line still contains all six packages. `spec/controllers/admin/scans_controller_spec.rb` passes 45/45; RuboCop clean.
