### PR TITLE
fix(scans): correctness fixes for target validation, credential cleanup, and retry budgets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,7 @@ ADMIN_INITIAL_PASSWORD=
 # Logging
 # RAILS_LOG_LEVEL=info                 # Log level: debug, info, warn, error (default: info)
 # DEBUG_LOG_TAIL_BYTES=131072          # Live report execution-log tail bytes (0 disables live tails)
+# MAX_INTERRUPT_RETRIES=3              # Retries for a scan interrupted by e.g. a rolling deploy before it fails permanently
 
 # Microsoft Clarity Analytics (Demo Only)
 # Clarity provides heatmaps and session recordings for UX analysis

--- a/app/javascript/controllers/dashboard_controller.js
+++ b/app/javascript/controllers/dashboard_controller.js
@@ -184,7 +184,10 @@ export default class extends Controller {
         fetch('/dashboard_stats/avg_asr_score?days=' + period)
             .then(response => response.json())
             .then(data => {
-                this.totalHits3Target.innerText = data.score + "%";
+                // A null score means nothing was measurable (e.g. every report in the
+                // window failed with no probe results) -- render N/A rather than the
+                // literal "null%", matching the neighboring Last Five Scans card.
+                this.totalHits3Target.innerText = Number.isFinite(data.score) ? data.score + "%" : "N/A";
                 this.upsertSparklineChart(
                     chartConfig,
                     this.sparklineChart3Target,

--- a/app/jobs/check_stale_reports_job.rb
+++ b/app/jobs/check_stale_reports_job.rb
@@ -35,11 +35,24 @@ class CheckStaleReportsJob < ApplicationJob
   # DB-persisted and it resumes rather than restarting from scratch.
   DEFAULT_MAX_INTERRUPT_RETRIES = 3
 
-  # Invalid or non-positive values fall back to the default rather than
-  # disabling the budget.
+  # Blank, non-integer, or non-positive values fall back to the default rather
+  # than disabling the budget. 0 is not treated as a deliberate "never retry"
+  # setting -- that would make CheckStaleReportsJob fail a report on its very
+  # first interruption, which is surprising enough to require a real off switch
+  # rather than a bare "0" a typo could produce.
+  #
+  # Uses strict Integer() parsing rather than String#to_i: to_i silently reads a
+  # partially-numeric value like "5oops" as 5 and a decimal like "1.5" as 1,
+  # so a configuration typo would silently change the retry budget instead of
+  # falling back to the default.
   def self.max_interrupt_retries
-    value = ENV.fetch("MAX_INTERRUPT_RETRIES", DEFAULT_MAX_INTERRUPT_RETRIES).to_i
+    raw = ENV["MAX_INTERRUPT_RETRIES"]
+    return DEFAULT_MAX_INTERRUPT_RETRIES if raw.blank?
+
+    value = Integer(raw, 10)
     value.positive? ? value : DEFAULT_MAX_INTERRUPT_RETRIES
+  rescue ArgumentError, TypeError
+    DEFAULT_MAX_INTERRUPT_RETRIES
   end
 
   def perform

--- a/app/jobs/check_stale_reports_job.rb
+++ b/app/jobs/check_stale_reports_job.rb
@@ -29,9 +29,18 @@ class CheckStaleReportsJob < ApplicationJob
   # Maximum start attempts before permanent failure.
   MAX_START_RETRIES = 3
 
-  # Maximum interrupt retries before permanent failure.
-  # Uses same limit as start retries for consistency.
-  MAX_INTERRUPT_RETRIES = 3
+  # Default maximum interrupt retries before permanent failure.
+  # Overridable via the MAX_INTERRUPT_RETRIES env var so the budget can absorb
+  # several deploy-time interruptions -- cheap, since a scan's progress is
+  # DB-persisted and it resumes rather than restarting from scratch.
+  DEFAULT_MAX_INTERRUPT_RETRIES = 3
+
+  # Invalid or non-positive values fall back to the default rather than
+  # disabling the budget.
+  def self.max_interrupt_retries
+    value = ENV.fetch("MAX_INTERRUPT_RETRIES", DEFAULT_MAX_INTERRUPT_RETRIES).to_i
+    value.positive? ? value : DEFAULT_MAX_INTERRUPT_RETRIES
+  end
 
   def perform
     check_stale_running_reports
@@ -69,7 +78,7 @@ class CheckStaleReportsJob < ApplicationJob
       heartbeat_age = (Time.current - report.heartbeat_at).round
       reason = "Scan stopped responding (no heartbeat for #{HEARTBEAT_TIMEOUT.inspect})"
 
-      if report.retry_count < MAX_INTERRUPT_RETRIES
+      if report.retry_count < self.class.max_interrupt_retries
         Rails.logger.warn(
           "[CheckStaleReports] Report #{report.id} (#{report.uuid}) has stale heartbeat " \
           "(last: #{report.heartbeat_at}, age: #{heartbeat_age}s) - marking as interrupted"
@@ -79,9 +88,9 @@ class CheckStaleReportsJob < ApplicationJob
         Rails.logger.error(
           "[CheckStaleReports] Report #{report.id} (#{report.uuid}) has stale heartbeat " \
           "(last: #{report.heartbeat_at}, age: #{heartbeat_age}s) - " \
-          "exceeded #{MAX_INTERRUPT_RETRIES} retries, marking as failed"
+          "exceeded #{self.class.max_interrupt_retries} retries, marking as failed"
         )
-        mark_report_failed(report, "#{reason} (after #{MAX_INTERRUPT_RETRIES} retry attempts)")
+        mark_report_failed(report, "#{reason} (after #{self.class.max_interrupt_retries} retry attempts)")
       end
     end
   end
@@ -107,7 +116,7 @@ class CheckStaleReportsJob < ApplicationJob
       age = (Time.current - report.updated_at).round
       reason = "Scan process never started (no heartbeat received after #{HEARTBEAT_TIMEOUT.inspect})"
 
-      if report.retry_count < MAX_INTERRUPT_RETRIES
+      if report.retry_count < self.class.max_interrupt_retries
         Rails.logger.warn(
           "[CheckStaleReports] Report #{report.id} (#{report.uuid}) is running " \
           "but never sent heartbeat (age: #{age}s) - marking as interrupted"
@@ -117,9 +126,9 @@ class CheckStaleReportsJob < ApplicationJob
         Rails.logger.error(
           "[CheckStaleReports] Report #{report.id} (#{report.uuid}) is running " \
           "but never sent heartbeat (age: #{age}s) - " \
-          "exceeded #{MAX_INTERRUPT_RETRIES} retries, marking as failed"
+          "exceeded #{self.class.max_interrupt_retries} retries, marking as failed"
         )
-        mark_report_failed(report, "#{reason} (after #{MAX_INTERRUPT_RETRIES} retry attempts)")
+        mark_report_failed(report, "#{reason} (after #{self.class.max_interrupt_retries} retry attempts)")
       end
     end
   end
@@ -174,7 +183,7 @@ class CheckStaleReportsJob < ApplicationJob
 
       reason = "Scan process orphaned (running with no owning process — pid cleared but status not updated)"
 
-      if report.retry_count < MAX_INTERRUPT_RETRIES
+      if report.retry_count < self.class.max_interrupt_retries
         Rails.logger.warn(
           "[CheckStaleReports] Report #{report.id} (#{report.uuid}) is orphaned " \
           "(running, pid=nil, heartbeat present) - marking as interrupted"
@@ -184,9 +193,9 @@ class CheckStaleReportsJob < ApplicationJob
         Rails.logger.error(
           "[CheckStaleReports] Report #{report.id} (#{report.uuid}) is orphaned " \
           "(running, pid=nil, heartbeat present) - " \
-          "exceeded #{MAX_INTERRUPT_RETRIES} retries, marking as failed"
+          "exceeded #{self.class.max_interrupt_retries} retries, marking as failed"
         )
-        mark_report_failed(report, "#{reason} (after #{MAX_INTERRUPT_RETRIES} retry attempts)")
+        mark_report_failed(report, "#{reason} (after #{self.class.max_interrupt_retries} retry attempts)")
       end
     end
   end
@@ -242,7 +251,7 @@ class CheckStaleReportsJob < ApplicationJob
   def mark_report_interrupted(report, reason)
     Rails.logger.warn(
       "[CheckStaleReports] Marking report #{report.id} as interrupted " \
-      "(retry #{report.retry_count + 1}/#{MAX_INTERRUPT_RETRIES}): #{reason}"
+      "(retry #{report.retry_count + 1}/#{self.class.max_interrupt_retries}): #{reason}"
     )
 
     report.update!(

--- a/app/jobs/check_stale_reports_job.rb
+++ b/app/jobs/check_stale_reports_job.rb
@@ -50,9 +50,28 @@ class CheckStaleReportsJob < ApplicationJob
     return DEFAULT_MAX_INTERRUPT_RETRIES if raw.blank?
 
     value = Integer(raw, 10)
-    value.positive? ? value : DEFAULT_MAX_INTERRUPT_RETRIES
-  rescue ArgumentError, TypeError
+    return value if value.positive?
+
+    Rails.logger.warn(
+      "[CheckStaleReports] MAX_INTERRUPT_RETRIES=#{raw.inspect} is not positive; " \
+      "using default #{DEFAULT_MAX_INTERRUPT_RETRIES}"
+    )
     DEFAULT_MAX_INTERRUPT_RETRIES
+  rescue ArgumentError, TypeError
+    Rails.logger.warn(
+      "[CheckStaleReports] MAX_INTERRUPT_RETRIES=#{raw.inspect} is not a valid integer; " \
+      "using default #{DEFAULT_MAX_INTERRUPT_RETRIES}"
+    )
+    DEFAULT_MAX_INTERRUPT_RETRIES
+  end
+
+  # Stuck-in-starting failures share Report#retry_count with interrupt recovery (see
+  # check_stuck_starting_reports below). Fail a stuck report only once the LARGER of
+  # the two budgets is exhausted, so a raised MAX_INTERRUPT_RETRIES isn't undercut by
+  # the hardcoded start-attempt limit when a report that already survived several
+  # deploy-time interruptions then hits a transient start stall.
+  def self.start_retry_ceiling
+    [ MAX_START_RETRIES, max_interrupt_retries ].max
   end
 
   def perform
@@ -214,7 +233,8 @@ class CheckStaleReportsJob < ApplicationJob
   end
 
   # Detect reports stuck in 'starting' status (process never started).
-  # Retries up to MAX_START_RETRIES times with exponential backoff.
+  # Retries up to the start-retry ceiling (max of MAX_START_RETRIES and the
+  # interrupt budget; see .start_retry_ceiling) with exponential backoff.
   def check_stuck_starting_reports
     stuck_reports = Report.starting
                           .where("updated_at < ?", STARTING_TIMEOUT.ago)
@@ -226,12 +246,12 @@ class CheckStaleReportsJob < ApplicationJob
       # Skip if no longer starting
       next unless report.starting?
 
-      if report.retry_count < MAX_START_RETRIES
+      if report.retry_count < self.class.start_retry_ceiling
         retry_report(report)
       else
         mark_report_failed(
           report,
-          "Failed after #{MAX_START_RETRIES} start attempts. " \
+          "Failed after #{self.class.start_retry_ceiling} start attempts. " \
           "Each attempt timed out after #{STARTING_TIMEOUT.inspect}."
         )
       end
@@ -241,7 +261,7 @@ class CheckStaleReportsJob < ApplicationJob
   def retry_report(report)
     Rails.logger.warn(
       "[CheckStaleReports] Report #{report.id} stuck in starting - " \
-      "moving to pending for retry (attempt #{report.retry_count + 1}/#{MAX_START_RETRIES})"
+      "moving to pending for retry (attempt #{report.retry_count + 1}/#{self.class.start_retry_ceiling})"
     )
 
     Report.transaction do

--- a/app/jobs/retry_interrupted_reports_job.rb
+++ b/app/jobs/retry_interrupted_reports_job.rb
@@ -38,8 +38,19 @@ class RetryInterruptedReportsJob < ApplicationJob
         next
       end
 
-      retry_interrupted_report(report)
-      count += 1
+      # The interrupt budget is authoritative here too, not just at the moment
+      # CheckStaleReportsJob first marked the report interrupted -- it can change
+      # (e.g. an operator lowers MAX_INTERRUPT_RETRIES) while a report sits in the
+      # interrupted queue waiting for the stabilization delay to elapse. Comparing
+      # against the live value here, not just at classification time, is what makes
+      # a lowered budget actually stop retries instead of only affecting reports
+      # interrupted after the change.
+      if report.retry_count < CheckStaleReportsJob.max_interrupt_retries
+        retry_interrupted_report(report)
+        count += 1
+      else
+        fail_exhausted_report(report)
+      end
     end
 
     Rails.logger.info("[RetryInterruptedReports] Queued #{count} interrupted reports for retry") if count > 0
@@ -68,6 +79,24 @@ class RetryInterruptedReportsJob < ApplicationJob
       )
       ReportDebugLog.clear_tail_for_report(report.id)
     end
+  end
+
+  def fail_exhausted_report(report)
+    budget = CheckStaleReportsJob.max_interrupt_retries
+    Rails.logger.error(
+      "[RetryInterruptedReports] Report #{report.id} (#{report.uuid}) has already used " \
+      "#{report.retry_count}/#{budget} interrupt retries -- failing instead of requeuing " \
+      "it (the interrupt budget may have been lowered since it was interrupted)"
+    )
+
+    report.update!(
+      status: :failed,
+      execution_token: nil,
+      logs: append_log(
+        report.logs,
+        "Failed: exceeded #{budget} interrupt retries (already used #{report.retry_count})"
+      )
+    )
   end
 
   def append_log(existing_logs, message)

--- a/app/jobs/retry_interrupted_reports_job.rb
+++ b/app/jobs/retry_interrupted_reports_job.rb
@@ -50,7 +50,7 @@ class RetryInterruptedReportsJob < ApplicationJob
   def retry_interrupted_report(report)
     Rails.logger.info(
       "[RetryInterruptedReports] Retrying report #{report.id} (#{report.uuid}) - " \
-      "attempt #{report.retry_count + 1}/#{CheckStaleReportsJob::MAX_INTERRUPT_RETRIES}"
+      "attempt #{report.retry_count + 1}/#{CheckStaleReportsJob.max_interrupt_retries}"
     )
 
     Report.transaction do

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -146,7 +146,8 @@ class Target < ApplicationRecord
   private
 
   def json_config_should_be_validated?
-    json_config.present? && api?
+    json_config.present? && api? &&
+      (new_record? || will_save_change_to_json_config? || will_save_change_to_target_type?)
   end
 
   def set_defaults_for_webchat

--- a/app/services/stats/average_asr_score.rb
+++ b/app/services/stats/average_asr_score.rb
@@ -64,7 +64,12 @@ module Stats
       result = ActiveRecord::Base.connection.select_value(
         ActiveRecord::Base.sanitize_sql_array([ sql, { since_date: since_date, company_id: company_id } ])
       )
-      (result.to_f || 0).round(2)
+      # NULLIF(SUM(probe_results.total), 0) already makes the inner per-report rate SQL
+      # NULL when there is nothing to divide by, so AVG() over zero qualifying rows is
+      # SQL NULL -- nothing was measurable. Preserve that as nil rather than coercing it
+      # to 0.0, which would read as a genuine "nothing succeeded" result (see
+      # Reports::AsrFigure and ReportsHelper#asr_display for the same distinction).
+      result.nil? ? nil : result.to_f.round(2)
     end
 
     def average_attack_success_rate_over_time(since_date = nil, interval = "day")

--- a/app/services/stats/average_asr_score.rb
+++ b/app/services/stats/average_asr_score.rb
@@ -33,7 +33,10 @@ module Stats
       @threshold = days.days.ago
     end
 
-    # Returns: { score: (Float), data: { dates: [...], rates: [...] } }
+    # Returns: { score: (Float or nil), data: { dates: [...], rates: [...] } }
+    # score is nil when nothing was measurable (see average_attack_success_rate);
+    # the hash is serialized directly to JSON by DashboardStatsController, so nil
+    # becomes a JSON null the frontend must render as "N/A", not "0%".
     def call
       generate_response(
         average_attack_success_rate(@threshold),
@@ -47,7 +50,8 @@ module Stats
       date_condition = since_date ? "AND reports.created_at >= :since_date" : ""
 
       # SECURITY: raw SQL bypasses acts_as_tenant's default scope, so we MUST filter by
-      # the current tenant's company_id explicitly. Fail closed (no tenant => no rows => 0).
+      # the current tenant's company_id explicitly. Fail closed (no tenant => no rows
+      # => nil, the same "nothing measurable" result as a tenant with no reports at all).
       company_id = ActsAsTenant.current_tenant&.id
 
       sql = <<~SQL.squish

--- a/app/views/admin/reports/_metadata_section.html.erb
+++ b/app/views/admin/reports/_metadata_section.html.erb
@@ -74,7 +74,7 @@
                 labelled differently on the two surfaces. %>
             <%= report_lifecycle_tags(report) %>
             <% if report.interrupted? && report.retry_count > 0 %>
-              <span class="text-xs text-contentTertiary">(retry <%= report.retry_count %>/<%= CheckStaleReportsJob::MAX_INTERRUPT_RETRIES %>)</span>
+              <span class="text-xs text-contentTertiary">(retry <%= report.retry_count %>/<%= CheckStaleReportsJob.max_interrupt_retries %>)</span>
             <% end %>
           </div>
         </div>

--- a/cypress/e2e/01_environment_variable_creation.cy.js
+++ b/cypress/e2e/01_environment_variable_creation.cy.js
@@ -202,7 +202,9 @@ describe('Environment Variable Creation', () => {
     cy.visit('/environment_variables')
     
     // Verify page elements
-    cy.contains('Environment Variables').should('be.visible')
+    cy.get('#custom-page-header h1')
+      .should('contain.text', 'Environment Variables')
+      .and('be.visible')
     cy.contains('a', 'New Environment Variable').should('be.visible')
     
     // Verify table headers exist (may not all be visible due to viewport)

--- a/cypress/e2e/99_cleanup.cy.js
+++ b/cypress/e2e/99_cleanup.cy.js
@@ -16,7 +16,9 @@ describe('99: cleanup tracked resources', function () {
     if (err.message.includes('did not contain the expected') && err.message.includes('turbo-frame')) {
       return false
     }
-    if (err.name === 'AbortError' && err.message === 'The user aborted a request.') {
+    // Match on err.name alone: the exact wording is engine-specific (Chromium says
+    // "The user aborted a request.", other engines say "The operation was aborted.").
+    if (err.name === 'AbortError') {
       return false
     }
     return true

--- a/cypress/e2e/99_cleanup.cy.js
+++ b/cypress/e2e/99_cleanup.cy.js
@@ -11,9 +11,12 @@ const shouldSkipByEnv = flagTrue(Cypress.env('SKIP_CLEANUP')) || flagTrue(Cypres
 // Always define the suite; gate execution in a before() hook so we can also
 // skip when any earlier test failed.
 describe('99: cleanup tracked resources', function () {
-  // Ignore Turbo frame errors that occur during cleanup (e.g., 404 responses after deletions)
+  // Ignore expected Turbo-frame and request-abort errors caused by cleanup navigation.
   Cypress.on('uncaught:exception', (err, runnable) => {
     if (err.message.includes('did not contain the expected') && err.message.includes('turbo-frame')) {
+      return false
+    }
+    if (err.name === 'AbortError' && err.message === 'The user aborted a request.') {
       return false
     }
     return true

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -93,6 +93,14 @@ These variables are process-level settings from the root `.env` file or containe
 - **Impact**: Higher values show more live execution-log context while a scan is running; lower values reduce database write size
 - **Restart required**: Restart Scanner after changing this value
 
+### MAX_INTERRUPT_RETRIES
+- **Purpose**: Number of times an interrupted scan (e.g. a pod restart during a rolling deploy) is automatically retried before it is marked permanently failed
+- **Default Value**: `3`
+- **Location**: Root `.env` file or container environment; read by `CheckStaleReportsJob`
+- **Invalid values**: Blank, non-integer, or non-positive values fall back to the default
+- **Impact**: Raising this lets a scan absorb more interruptions before failing. This is inexpensive because scan progress is persisted to the database and a retried scan resumes rather than restarting from scratch
+- **Restart required**: No; each job run reads the current value
+
 ### PARALLEL_ATTEMPTS
 > **Note**: This setting has been moved to the Settings page (`/settings`). It is no longer managed as an Environment Variable.
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -99,7 +99,7 @@ These variables are process-level settings from the root `.env` file or containe
 - **Location**: Root `.env` file or container environment; read by `CheckStaleReportsJob`
 - **Invalid values**: Blank, non-integer, or non-positive values fall back to the default
 - **Impact**: Raising this lets a scan absorb more interruptions before failing. This is inexpensive because scan progress is persisted to the database and a retried scan resumes rather than restarting from scratch
-- **Restart required**: No; each job run reads the current value
+- **Restart required**: Restart Scanner after changing this value
 
 ### PARALLEL_ATTEMPTS
 > **Note**: This setting has been moved to the Settings page (`/settings`). It is no longer managed as an Environment Variable.

--- a/script/db_notifier.py
+++ b/script/db_notifier.py
@@ -1321,12 +1321,19 @@ def notify_report_stopped(
                         # the ownership classification the lock exists to protect,
                         # rather than risk losing the release too.
                         conn.rollback()
-                        conn.autocommit = True
                         logger.warning(
                             f"Report {report_uuid} row lock not available within "
                             "timeout; falling back to an unlocked credential delete"
                         )
                         _delete_web_config(report_uuid)
+                        # lock_timeout only bounded the SELECT above. The UPDATE
+                        # below still targets this same contended row -- without its
+                        # own bound, it could block indefinitely (and be SIGKILLed
+                        # while blocked, on the SIGTERM path), defeating the point
+                        # of bounding the SELECT at all. autocommit is still off
+                        # from before the rollback, so this SET LOCAL scopes to the
+                        # one transaction the UPDATE runs and commits in below.
+                        cur.execute("SET LOCAL statement_timeout = '5s'")
                     else:
                         row = cur.fetchone()
                         current_token = row[0] if row is not None else None

--- a/script/db_notifier.py
+++ b/script/db_notifier.py
@@ -1304,7 +1304,20 @@ def notify_report_stopped(
                             "another execution attempt owns this report and may be using it"
                         )
                     else:
-                        (CONFIG_PATH / f"{report_uuid}_web.json").unlink(missing_ok=True)
+                        # A delete failure (EACCES on the config dir, EROFS, a file
+                        # owned by another uid, ...) must not prevent the UPDATE below
+                        # from running: an unguarded unlink() would propagate to the
+                        # outer except and skip it entirely, leaving the report
+                        # running/starting with a stale PID and a live token until
+                        # CheckStaleReportsJob times it out and burns a retry for a
+                        # process that had already exited cleanly.
+                        try:
+                            (CONFIG_PATH / f"{report_uuid}_web.json").unlink(missing_ok=True)
+                        except OSError as delete_error:
+                            logger.error(
+                                "SECURITY: failed to delete credential web config "
+                                f"file for {report_uuid}: {delete_error}"
+                            )
 
                 cur.execute(
                     """

--- a/script/db_notifier.py
+++ b/script/db_notifier.py
@@ -1349,38 +1349,6 @@ def notify_report_stopped(
         return None
 
 
-def execution_attempt_replaced(report_uuid: str, execution_token: str):
-    """Has a DIFFERENT attempt taken ownership of this report?
-
-    notify_report_stopped returning False is not evidence of this on its own: it also
-    returns False when the stored PID no longer matches, which happens routinely when
-    the recovery path clears the PID before the old process reaches its cleanup. Only
-    a different, non-null token means someone else owns the report -- and therefore
-    owns the UUID-keyed files that belong to it.
-
-    Returns True when another attempt owns it, False when this attempt does or nobody
-    does, and None when ownership could not be determined.
-    """
-    try:
-        with pooled_connection("primary") as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT execution_token FROM reports WHERE uuid = %s",
-                    (report_uuid,),
-                )
-                row = cur.fetchone()
-
-        if row is None:
-            return False
-
-        current_token = row[0]
-        return current_token is not None and str(current_token) != str(execution_token)
-
-    except Exception as e:
-        logger.error(f"Error checking execution ownership for {report_uuid}: {e}")
-        return None
-
-
 def _enqueue_process_report_job(report_id: int, queue_conn) -> int:
     """
     Enqueue ProcessReportJob in Solid Queue.

--- a/script/db_notifier.py
+++ b/script/db_notifier.py
@@ -10,8 +10,9 @@ Functions:
     notify_report_running(report_uuid, pid, execution_token): Claim running state
     notify_report_ready(report_uuid, *, execution_token): Store data and hand off
     notify_report_ready_from_synced(report_uuid, *, execution_token): Hand off
-    notify_report_stopped(report_uuid, expected_pid=None, *, execution_token):
-        Release this attempt's PID and ownership
+    notify_report_stopped(report_uuid, expected_pid=None, *, execution_token, cleanup_web_config=False):
+        Release this attempt's PID and ownership, optionally deleting the
+        credential web config under the same row lock
 
 Dependencies:
     psycopg2-binary>=2.9.0
@@ -1230,8 +1231,12 @@ def notify_report_running(report_uuid: str, pid: int, execution_token: str) -> b
 
 
 def notify_report_stopped(
-    report_uuid: str, expected_pid: int = None, *, execution_token: str
-) -> bool:
+    report_uuid: str,
+    expected_pid: int = None,
+    *,
+    execution_token: str,
+    cleanup_web_config: bool = False,
+) -> Optional[bool]:
     """
     Clear PID from report using pooled connection (owner-process guard).
 
@@ -1240,9 +1245,20 @@ def notify_report_stopped(
     a child that inherits the signal handler and calls this function will
     have a different os.getpid(), so the UPDATE WHERE clause won't match.
 
+    When cleanup_web_config is requested, the report row is locked with
+    SELECT ... FOR UPDATE before the UUID-keyed credential file is classified
+    and deleted. Doing the classification and the delete under the same lock
+    closes the window where a replacement attempt claims the report and
+    writes a fresh credential file between an unlocked ownership check and
+    the delete -- the file is keyed on the report UUID alone, so a stale
+    delete after that write would remove the replacement's live credentials.
+
     Args:
         report_uuid: UUID of the report
         expected_pid: PID to match against stored PID. Defaults to os.getpid().
+        cleanup_web_config: Delete the credential-bearing <uuid>_web.json while
+            the report row remains locked, unless a different execution token
+            now owns the report.
 
     Returns:
         True if ownership was cleared, False on a definitive PID/token mismatch,
@@ -1255,6 +1271,26 @@ def notify_report_stopped(
     try:
         with pooled_connection("primary") as conn:
             with conn.cursor() as cur:
+                if cleanup_web_config:
+                    cur.execute(
+                        "SELECT execution_token FROM reports WHERE uuid = %s FOR UPDATE",
+                        (report_uuid,),
+                    )
+                    row = cur.fetchone()
+                    current_token = row[0] if row is not None else None
+                    replaced = (
+                        current_token is not None
+                        and str(current_token) != str(execution_token)
+                    )
+
+                    if replaced:
+                        logger.warning(
+                            f"Leaving credential config for {report_uuid} in place: "
+                            "another execution attempt owns this report and may be using it"
+                        )
+                    else:
+                        (CONFIG_PATH / f"{report_uuid}_web.json").unlink(missing_ok=True)
+
                 cur.execute(
                     """
                     UPDATE reports

--- a/script/db_notifier.py
+++ b/script/db_notifier.py
@@ -1230,6 +1230,18 @@ def notify_report_running(report_uuid: str, pid: int, execution_token: str) -> b
         return False
 
 
+def _delete_web_config(report_uuid: str) -> None:
+    """Delete the credential-bearing <uuid>_web.json, logging (not raising) on
+    failure so a delete error never blocks the caller's ownership release."""
+    try:
+        (CONFIG_PATH / f"{report_uuid}_web.json").unlink(missing_ok=True)
+    except OSError as delete_error:
+        logger.error(
+            f"SECURITY: failed to delete credential web config file for "
+            f"{report_uuid}: {delete_error}"
+        )
+
+
 def notify_report_stopped(
     report_uuid: str,
     expected_pid: int = None,
@@ -1287,37 +1299,49 @@ def notify_report_stopped(
                     # just the SELECT that acquires it -- see the autocommit note
                     # in the docstring.
                     conn.autocommit = False
-                    cur.execute(
-                        "SELECT execution_token FROM reports WHERE uuid = %s FOR UPDATE",
-                        (report_uuid,),
-                    )
-                    row = cur.fetchone()
-                    current_token = row[0] if row is not None else None
-                    replaced = (
-                        current_token is not None
-                        and str(current_token) != str(execution_token)
-                    )
-
-                    if replaced:
-                        logger.warning(
-                            f"Leaving credential config for {report_uuid} in place: "
-                            "another execution attempt owns this report and may be using it"
+                    # Bound how long this waits to acquire the row lock. Without a
+                    # timeout, a slow/hung storage/config mount or a concurrent
+                    # writer already holding this row would block indefinitely --
+                    # Rails writes to the same row queue up behind it, and on the
+                    # SIGTERM path this process can be SIGKILLed while still
+                    # holding the lock, leaving both the file and the stale
+                    # pid/token behind.
+                    cur.execute("SET LOCAL lock_timeout = '5s'")
+                    try:
+                        cur.execute(
+                            "SELECT execution_token FROM reports WHERE uuid = %s FOR UPDATE",
+                            (report_uuid,),
                         )
+                    except OperationalError as lock_error:
+                        if getattr(lock_error, "pgcode", None) != "55P03":  # lock_not_available
+                            raise
+                        # The failed statement aborted the transaction; roll back
+                        # before this connection runs anything else, then fall back
+                        # to the pre-lock behaviour: delete unconditionally, without
+                        # the ownership classification the lock exists to protect,
+                        # rather than risk losing the release too.
+                        conn.rollback()
+                        conn.autocommit = True
+                        logger.warning(
+                            f"Report {report_uuid} row lock not available within "
+                            "timeout; falling back to an unlocked credential delete"
+                        )
+                        _delete_web_config(report_uuid)
                     else:
-                        # A delete failure (EACCES on the config dir, EROFS, a file
-                        # owned by another uid, ...) must not prevent the UPDATE below
-                        # from running: an unguarded unlink() would propagate to the
-                        # outer except and skip it entirely, leaving the report
-                        # running/starting with a stale PID and a live token until
-                        # CheckStaleReportsJob times it out and burns a retry for a
-                        # process that had already exited cleanly.
-                        try:
-                            (CONFIG_PATH / f"{report_uuid}_web.json").unlink(missing_ok=True)
-                        except OSError as delete_error:
-                            logger.error(
-                                "SECURITY: failed to delete credential web config "
-                                f"file for {report_uuid}: {delete_error}"
+                        row = cur.fetchone()
+                        current_token = row[0] if row is not None else None
+                        replaced = (
+                            current_token is not None
+                            and str(current_token) != str(execution_token)
+                        )
+
+                        if replaced:
+                            logger.warning(
+                                f"Leaving credential config for {report_uuid} in place: "
+                                "another execution attempt owns this report and may be using it"
                             )
+                        else:
+                            _delete_web_config(report_uuid)
 
                 cur.execute(
                     """

--- a/script/db_notifier.py
+++ b/script/db_notifier.py
@@ -1253,6 +1253,17 @@ def notify_report_stopped(
     the delete -- the file is keyed on the report UUID alone, so a stale
     delete after that write would remove the replacement's live credentials.
 
+    Pooled connections come back from the pool with autocommit enabled (see
+    ConnectionPoolManager.get_connection's reset-on-checkout), under which every
+    statement is its own implicit transaction -- a bare FOR UPDATE releases its
+    row lock the instant that one SELECT finishes, before the delete or the
+    UPDATE that follow it. autocommit is explicitly disabled for the duration of
+    the cleanup_web_config path so the SELECT, the delete, and the UPDATE share
+    one real transaction held until commit(); the pooled_connection wrapper
+    resets autocommit back to True (and rolls back on any exception) when the
+    connection is returned to the pool, so this does not leak into the next use
+    of the connection.
+
     Args:
         report_uuid: UUID of the report
         expected_pid: PID to match against stored PID. Defaults to os.getpid().
@@ -1272,6 +1283,10 @@ def notify_report_stopped(
         with pooled_connection("primary") as conn:
             with conn.cursor() as cur:
                 if cleanup_web_config:
+                    # Hold the row lock across the delete and the UPDATE below, not
+                    # just the SELECT that acquires it -- see the autocommit note
+                    # in the docstring.
+                    conn.autocommit = False
                     cur.execute(
                         "SELECT execution_token FROM reports WHERE uuid = %s FOR UPDATE",
                         (report_uuid,),

--- a/script/run_garak.py
+++ b/script/run_garak.py
@@ -40,7 +40,6 @@ from pathlib import Path
 
 from garak_plugin_cache_guard import install_plugin_cache_guard
 from db_notifier import (
-    execution_attempt_replaced as db_execution_attempt_replaced,
     notify_report_running as db_notify_running,
     notify_report_ready as db_notify_ready,
     notify_report_ready_from_synced as db_notify_ready_from_synced,
@@ -225,15 +224,6 @@ def notify_report_stopped(report_uuid, execution_token, cleanup_web_config=False
         return result
     except Exception as e:
         print(f"Error notifying report stopped: {e}", file=sys.stderr)
-        return None
-
-def execution_attempt_replaced(report_uuid, execution_token):
-    """True when a different attempt owns the report, False when it does not, None
-    when that could not be determined."""
-    try:
-        return db_execution_attempt_replaced(report_uuid, execution_token)
-    except Exception as e:
-        print(f"Error checking execution ownership: {e}", file=sys.stderr)
         return None
 
 

--- a/script/run_garak.py
+++ b/script/run_garak.py
@@ -206,14 +206,18 @@ def notify_report_ready_from_synced(report_uuid, exit_code=None, *, execution_to
         return False
 
 
-def notify_report_stopped(report_uuid, execution_token):
+def notify_report_stopped(report_uuid, execution_token, cleanup_web_config=False):
     """Release this execution attempt in the database.
 
     Returns True when ownership was cleared, False on a definitive mismatch (another
     attempt owns the report), and None when it could not be determined.
     """
     try:
-        result = db_notify_stopped(report_uuid, execution_token=execution_token)
+        result = db_notify_stopped(
+            report_uuid,
+            execution_token=execution_token,
+            cleanup_web_config=cleanup_web_config,
+        )
         if result:
             print(f"Report {report_uuid} PID cleared")
         else:
@@ -236,27 +240,22 @@ def execution_attempt_replaced(report_uuid, execution_token):
 def release_attempt_and_cleanup_web_config(report_uuid, execution_token):
     """Release this attempt and remove its credential file unless superseded.
 
-    A definitive ownership mismatch means the UUID-keyed file belongs to a newer
-    attempt and must be left alone. Unknown ownership still deletes it, so
-    credentials are not left behind when the database is unavailable.
+    The ownership check and the file deletion happen inside the same row lock
+    (notify_report_stopped's cleanup_web_config path), so a replacement attempt
+    cannot claim the report and write a fresh credential file between the check
+    and the delete. A None result means the release could not be determined (the
+    database was unavailable, say) -- fail closed and delete locally, since there
+    is no way to confirm no replacement exists.
     """
     if not execution_token:
         remove_web_config_file(report_uuid)
         return None
 
-    released = notify_report_stopped(report_uuid, execution_token)
+    released = notify_report_stopped(report_uuid, execution_token, cleanup_web_config=True)
 
-    # Ask who owns the report rather than inferring it from the release result: that
-    # is also False on an ordinary PID mismatch, which the recovery path produces
-    # routinely, and nothing else would ever remove the file in that case.
-    if execution_attempt_replaced(report_uuid, execution_token) is True:
-        logger.warning(
-            f"Leaving credential config for {report_uuid} in place: another "
-            f"execution attempt owns this report and may be using it"
-        )
-        return False
+    if released is None:
+        remove_web_config_file(report_uuid)
 
-    remove_web_config_file(report_uuid)
     return released
 
 
@@ -414,8 +413,17 @@ def main():
             heartbeat.stop()
             current_heartbeat = None
         if not is_validation:
-            notify_report_stopped(report_uuid, execution_token)
-        remove_web_config_file(report_uuid)
+            # Route through release_attempt_and_cleanup_web_config rather than
+            # notify_report_stopped + remove_web_config_file as two separate
+            # unlocked steps: a replacement attempt (e.g. this process was
+            # interrupted and retried elsewhere while it was still unwinding)
+            # could otherwise claim the report and write a fresh credential
+            # file that this exit then deletes.
+            release_attempt_and_cleanup_web_config(report_uuid, execution_token)
+        else:
+            # Validation runs have no report row to own or lock -- nothing to
+            # check ownership against, so delete unconditionally as before.
+            remove_web_config_file(report_uuid)
 
     sys.exit(exit_code)
 

--- a/script/tests/javascript_controller_tests.mjs
+++ b/script/tests/javascript_controller_tests.mjs
@@ -1501,6 +1501,66 @@ function testGaugeChartConfigTooltipFormatter() {
   assert.equal(tooltipFormatter({ name: "Success Rate", value: 83.24 }), "Success Rate: 83.24%")
 }
 
+function loadDashboardController() {
+  const source = readFileSync(
+    new URL("../../app/javascript/controllers/dashboard_controller.js", import.meta.url),
+    "utf8"
+  )
+
+  // dashboard_controller.js has several import lines (echarts helpers, chart config);
+  // loadControllerSource only strips the first one, so strip them all here instead.
+  const transformed = source
+    .replace(/^import .*?\n/gm, "")
+    .replace(
+      "export default class extends Controller",
+      "class DashboardController extends Controller"
+    )
+
+  const context = {
+    Controller: class {},
+    fetch: null // set per call by the test below
+  }
+
+  const ControllerClass = vm.runInNewContext(
+    `${transformed}\nDashboardController`,
+    context
+  )
+
+  return { ControllerClass, context }
+}
+
+async function testDashboardControllerAvgAsrScoreRendering() {
+  const { ControllerClass, context } = loadDashboardController()
+  // Isolate the score-text rendering from echarts, which initAvgAsrScores also drives
+  // and which is not available in this harness.
+  ControllerClass.prototype.upsertSparklineChart = function () {}
+
+  async function renderedScoreText(score) {
+    context.fetch = async () => ({
+      json: async () => ({ score, data: { rates: [] } })
+    })
+
+    const instance = new ControllerClass()
+    instance.totalHits3Target = { innerText: "" }
+
+    instance.initAvgAsrScores({})
+    // initAvgAsrScores does not return its fetch().then() chain, so flush the
+    // microtask queue (fetch resolution, then response.json(), then the render
+    // callback) past a macrotask boundary before reading the rendered text.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    return instance.totalHits3Target.innerText
+  }
+
+  // A company whose only reports failed with no probe results has nothing to
+  // average -- the endpoint returns score: null, and that must read N/A rather
+  // than the literal "null%", matching the neighboring Last Five Scans card.
+  assert.equal(await renderedScoreText(null), "N/A")
+  // A company where every measured attack was blocked is a genuine, measured 0%.
+  assert.equal(await renderedScoreText(0), "0%")
+  assert.equal(await renderedScoreText(42.5), "42.5%")
+}
+
 await testDebugStreamLeaseController()
 testActivityStreamController()
 testDebugTabsController()
@@ -1517,4 +1577,5 @@ testProbeCategoryToggleCategory()
 testGaugeChartConfigDetailFormatter()
 testGaugeChartConfigPointer()
 testGaugeChartConfigTooltipFormatter()
+await testDashboardControllerAvgAsrScoreRendering()
 console.log("JavaScript controller tests passed")

--- a/script/tests/test_db_notifier_pid_guard.py
+++ b/script/tests/test_db_notifier_pid_guard.py
@@ -343,11 +343,40 @@ class TestNotifyReportStoppedCleanupWebConfig(unittest.TestCase):
             self.assertFalse(web_config.exists(), "credential web config left on disk")
 
         mock_conn.rollback.assert_called_once()
-        self.assertIs(
-            mock_conn.autocommit,
-            True,
-            "connection must not be handed back to the pool still non-autocommit",
+
+    @patch("db_notifier.pooled_connection")
+    def test_bounds_the_fallback_update_after_a_lock_timeout(self, mock_pooled):
+        """lock_timeout only bounds the SELECT ... FOR UPDATE. The fallback still
+        writes the same contended row via the UPDATE below -- without its own bound,
+        that write can block indefinitely (and be SIGKILLed while blocked, on the
+        SIGTERM path), defeating the point of bounding the SELECT at all."""
+        mock_conn, mock_cur = self._make_mock_conn(rowcount=1)
+        mock_pooled.return_value = mock_conn
+
+        lock_timeout_error = db_notifier.OperationalError(
+            "canceling statement due to lock timeout"
         )
+        lock_timeout_error.pgcode = "55P03"  # lock_not_available
+
+        def execute_side_effect(sql, params=None):
+            if "FOR UPDATE" in sql:
+                raise lock_timeout_error
+
+        mock_cur.execute.side_effect = execute_side_effect
+
+        with patch.object(db_notifier, "CONFIG_PATH", Path(tempfile.mkdtemp())):
+            db_notifier.notify_report_stopped(
+                "lock-timeout-update", execution_token=TOKEN, cleanup_web_config=True
+            )
+
+        executed_sql = [call.args[0] for call in mock_cur.execute.call_args_list]
+        update_index = next(
+            i for i, sql in enumerate(executed_sql) if "UPDATE reports" in sql
+        )
+        # A statement_timeout must be set in the same transaction as the UPDATE that
+        # immediately follows it -- SET LOCAL only applies within one transaction, so
+        # this has to be the last statement issued before it.
+        self.assertIn("statement_timeout", executed_sql[update_index - 1])
 
     @patch("db_notifier.pooled_connection")
     def test_reraises_a_lock_error_that_is_not_a_timeout(self, mock_pooled):

--- a/script/tests/test_db_notifier_pid_guard.py
+++ b/script/tests/test_db_notifier_pid_guard.py
@@ -193,7 +193,9 @@ class TestNotifyReportStoppedCleanupWebConfig(unittest.TestCase):
             self.assertTrue(result)
             self.assertFalse(web_config.exists(), "credential web config left on disk")
 
-        select_sql = mock_cur.execute.call_args_list[0].args[0]
+        select_sql = next(
+            call.args[0] for call in mock_cur.execute.call_args_list if "FOR UPDATE" in call.args[0]
+        )
         self.assertIn("FOR UPDATE", select_sql)
 
     @patch("db_notifier.pooled_connection")
@@ -256,10 +258,18 @@ class TestNotifyReportStoppedCleanupWebConfig(unittest.TestCase):
                 "cleanup-lock", execution_token=TOKEN, cleanup_web_config=True
             )
 
-        select_sql, select_params = mock_cur.execute.call_args_list[0].args
-        self.assertIn("SELECT", select_sql)
+        select_sql, select_params = next(
+            (call.args[0], call.args[1])
+            for call in mock_cur.execute.call_args_list
+            if "SELECT" in call.args[0]
+        )
         self.assertIn("FOR UPDATE", select_sql)
         self.assertEqual(select_params, ("cleanup-lock",))
+        # ...and the wait to acquire it is bounded, so a hung mount or a concurrent
+        # writer can't stall this cleanup indefinitely.
+        self.assertTrue(
+            any("lock_timeout" in call.args[0] for call in mock_cur.execute.call_args_list)
+        )
 
     @patch("db_notifier.pooled_connection")
     def test_holds_an_explicit_transaction_across_the_lock_delete_and_update(self, mock_pooled):
@@ -295,6 +305,73 @@ class TestNotifyReportStoppedCleanupWebConfig(unittest.TestCase):
         # to protect.
         self.assertTrue(all(value is False for value in autocommit_during_execute))
         mock_conn.commit.assert_called_once()
+
+    @patch("db_notifier.pooled_connection")
+    def test_falls_back_to_an_unlocked_delete_when_the_row_lock_times_out(self, mock_pooled):
+        """A slow/hung storage/config mount, or Rails already writing to this same
+        row, must not make this cleanup block indefinitely on FOR UPDATE: on the
+        SIGTERM path a process blocked here can be SIGKILLed mid-lock, leaving both
+        the credential file and the stale pid/token behind. lock_timeout bounds the
+        wait; on a lock-not-available error, fall back to the pre-lock behaviour
+        (delete unconditionally, without the classification the lock protects) and
+        still clear the pid rather than lose the release entirely."""
+        mock_conn, mock_cur = self._make_mock_conn(rowcount=1)
+        mock_pooled.return_value = mock_conn
+
+        lock_timeout_error = db_notifier.OperationalError(
+            "canceling statement due to lock timeout"
+        )
+        lock_timeout_error.pgcode = "55P03"  # lock_not_available
+
+        def execute_side_effect(sql, params=None):
+            if "FOR UPDATE" in sql:
+                raise lock_timeout_error
+
+        mock_cur.execute.side_effect = execute_side_effect
+
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp)
+            web_config = config_path / "lock-timeout_web.json"
+            web_config.write_text('{"cookies": [{"value": "secret"}]}')
+
+            with patch.object(db_notifier, "CONFIG_PATH", config_path):
+                result = db_notifier.notify_report_stopped(
+                    "lock-timeout", execution_token=TOKEN, cleanup_web_config=True
+                )
+
+            self.assertTrue(result)
+            self.assertFalse(web_config.exists(), "credential web config left on disk")
+
+        mock_conn.rollback.assert_called_once()
+        self.assertIs(
+            mock_conn.autocommit,
+            True,
+            "connection must not be handed back to the pool still non-autocommit",
+        )
+
+    @patch("db_notifier.pooled_connection")
+    def test_reraises_a_lock_error_that_is_not_a_timeout(self, mock_pooled):
+        """Only lock_not_available (55P03, the lock_timeout expiry) gets the
+        unlocked-delete fallback. Any other OperationalError is a genuine,
+        undiagnosed failure and must still surface as an indeterminate result."""
+        mock_conn, mock_cur = self._make_mock_conn(rowcount=1)
+        mock_pooled.return_value = mock_conn
+
+        other_error = db_notifier.OperationalError("connection reset by peer")
+        other_error.pgcode = None
+
+        def execute_side_effect(sql, params=None):
+            if "FOR UPDATE" in sql:
+                raise other_error
+
+        mock_cur.execute.side_effect = execute_side_effect
+
+        with patch.object(db_notifier, "CONFIG_PATH", Path(tempfile.mkdtemp())):
+            result = db_notifier.notify_report_stopped(
+                "other-lock-error", execution_token=TOKEN, cleanup_web_config=True
+            )
+
+        self.assertIsNone(result)
 
     @patch("db_notifier.pooled_connection")
     def test_skips_the_lock_and_delete_when_cleanup_not_requested(self, mock_pooled):

--- a/script/tests/test_db_notifier_pid_guard.py
+++ b/script/tests/test_db_notifier_pid_guard.py
@@ -308,21 +308,33 @@ class TestNotifyReportStoppedCleanupWebConfig(unittest.TestCase):
         self.assertEqual(mock_cur.execute.call_count, 1)
 
     @patch("db_notifier.pooled_connection")
-    def test_cleanup_failure_is_indeterminate(self, mock_pooled):
-        """A failed credential deletion must not be reported as a clean release."""
+    def test_cleanup_failure_does_not_block_the_ownership_release(self, mock_pooled):
+        """A failed credential deletion (EACCES on the config dir, EROFS, a file
+        owned by another uid, ...) must not prevent the report from being released.
+        An unguarded unlink() would propagate past the UPDATE that clears
+        pid/execution_token, leaving the report running/starting with a stale PID
+        and a live token until CheckStaleReportsJob times it out two minutes later
+        and burns an interrupt retry for a process that had already exited cleanly.
+        The failure is still logged with the SECURITY-prefixed signal
+        remove_web_config_file uses elsewhere, just without aborting the release."""
         mock_conn, mock_cur = self._make_mock_conn(rowcount=1, fetchone=(TOKEN,))
         mock_pooled.return_value = mock_conn
 
         with tempfile.TemporaryDirectory() as tmp:
             config_path = Path(tmp)
             with patch.object(db_notifier, "CONFIG_PATH", config_path), \
-                 patch.object(Path, "unlink", side_effect=PermissionError("denied")):
+                 patch.object(Path, "unlink", side_effect=PermissionError("denied")), \
+                 self.assertLogs(db_notifier.logger, level="ERROR") as logs:
                 result = db_notifier.notify_report_stopped(
                     "cleanup-error", execution_token=TOKEN, cleanup_web_config=True
                 )
 
-        self.assertIsNone(result)
-        mock_conn.commit.assert_not_called()
+        self.assertTrue(result)
+        mock_conn.commit.assert_called_once()
+        self.assertTrue(
+            any("SECURITY" in message for message in logs.output),
+            "expected the SECURITY-prefixed delete-failure signal to be preserved",
+        )
 
 
 if __name__ == "__main__":

--- a/script/tests/test_db_notifier_pid_guard.py
+++ b/script/tests/test_db_notifier_pid_guard.py
@@ -262,6 +262,41 @@ class TestNotifyReportStoppedCleanupWebConfig(unittest.TestCase):
         self.assertEqual(select_params, ("cleanup-lock",))
 
     @patch("db_notifier.pooled_connection")
+    def test_holds_an_explicit_transaction_across_the_lock_delete_and_update(self, mock_pooled):
+        """Pooled connections come back with autocommit=True (see
+        ConnectionPoolManager.get_connection's reset-on-checkout), which means a bare
+        FOR UPDATE SELECT commits -- and releases its row lock -- the instant that one
+        statement finishes, before the delete or the UPDATE that follow it even run.
+        The lock protects nothing unless autocommit is turned off before the SELECT
+        and held through commit(), so every statement in the cleanup_web_config path
+        shares one real transaction."""
+        mock_conn, mock_cur = self._make_mock_conn(rowcount=1, fetchone=(TOKEN,))
+        mock_pooled.return_value = mock_conn
+
+        autocommit_during_execute = []
+        mock_cur.execute.side_effect = lambda *a, **k: autocommit_during_execute.append(
+            mock_conn.autocommit
+        )
+
+        with patch.object(db_notifier, "CONFIG_PATH", Path(tempfile.mkdtemp())):
+            db_notifier.notify_report_stopped(
+                "lock-scope", execution_token=TOKEN, cleanup_web_config=True
+            )
+
+        # autocommit must already be disabled by the time the locking SELECT runs...
+        self.assertTrue(
+            len(autocommit_during_execute) >= 2,
+            "expected both the SELECT and the UPDATE to execute",
+        )
+        self.assertIs(autocommit_during_execute[0], False)
+        # ...and still disabled for every later statement in the same call (the
+        # UPDATE) -- the connection must never revert to one-statement-per-transaction
+        # mid-sequence, or the lock is released before the delete/update it was meant
+        # to protect.
+        self.assertTrue(all(value is False for value in autocommit_during_execute))
+        mock_conn.commit.assert_called_once()
+
+    @patch("db_notifier.pooled_connection")
     def test_skips_the_lock_and_delete_when_cleanup_not_requested(self, mock_pooled):
         """Existing callers that don't ask for cleanup keep the original
         single-statement behaviour: no SELECT, no file classification."""

--- a/script/tests/test_db_notifier_pid_guard.py
+++ b/script/tests/test_db_notifier_pid_guard.py
@@ -10,7 +10,9 @@ WHERE clause won't match and the PID remains intact.
 
 import os
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock, patch, call
 
@@ -148,6 +150,144 @@ class TestNotifyReportStoppedPidGuard(unittest.TestCase):
         executed_params = mock_cur.execute.call_args[0][1]
         self.assertIn("AND pid = %s", executed_sql)
         self.assertEqual(executed_params, ("test-uuid-fork", child_pid, TOKEN))
+
+
+class TestNotifyReportStoppedCleanupWebConfig(unittest.TestCase):
+    """cleanup_web_config=True classifies ownership and deletes the UUID-keyed
+    credential file inside the same locked transaction, instead of as a second,
+    separately-racing step. Between an unlocked check and an unlocked delete, a
+    replacement attempt could claim the report and write a fresh credential file
+    that this process then deletes out from under it.
+    """
+
+    def _make_mock_conn(self, rowcount=1, fetchone=None):
+        mock_cur = MagicMock()
+        mock_cur.rowcount = rowcount
+        mock_cur.fetchone.return_value = fetchone
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        return mock_conn, mock_cur
+
+    @patch("db_notifier.pooled_connection")
+    def test_deletes_the_credential_file_under_the_row_lock(self, mock_pooled):
+        """No other execution token owns the report: delete under the lock."""
+        mock_conn, mock_cur = self._make_mock_conn(rowcount=1, fetchone=(TOKEN,))
+        mock_pooled.return_value = mock_conn
+
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp)
+            web_config = config_path / "cleanup-owner_web.json"
+            web_config.write_text('{"cookies": [{"value": "secret"}]}')
+
+            with patch.object(db_notifier, "CONFIG_PATH", config_path):
+                result = db_notifier.notify_report_stopped(
+                    "cleanup-owner", execution_token=TOKEN, cleanup_web_config=True
+                )
+
+            self.assertTrue(result)
+            self.assertFalse(web_config.exists(), "credential web config left on disk")
+
+        select_sql = mock_cur.execute.call_args_list[0].args[0]
+        self.assertIn("FOR UPDATE", select_sql)
+
+    @patch("db_notifier.pooled_connection")
+    def test_preserves_the_file_when_a_different_token_owns_the_report(self, mock_pooled):
+        """A different, non-null execution token means a replacement attempt owns
+        the report -- and therefore the UUID-keyed file this process was about to
+        delete. Leave it in place."""
+        replacement_token = "99999999-9999-4999-8999-999999999999"
+        mock_conn, mock_cur = self._make_mock_conn(rowcount=0, fetchone=(replacement_token,))
+        mock_pooled.return_value = mock_conn
+
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp)
+            web_config = config_path / "cleanup-replaced_web.json"
+            web_config.write_text('{"cookies": [{"value": "secret"}]}')
+
+            with patch.object(db_notifier, "CONFIG_PATH", config_path):
+                result = db_notifier.notify_report_stopped(
+                    "cleanup-replaced", execution_token=TOKEN, cleanup_web_config=True
+                )
+
+            self.assertFalse(result)
+            self.assertTrue(
+                web_config.exists(),
+                "a superseded process deleted the replacement's live credential file",
+            )
+
+    @patch("db_notifier.pooled_connection")
+    def test_deletes_the_file_when_ownership_was_already_released(self, mock_pooled):
+        """A NULL stored token (Rails revoked it, nobody has replaced it yet) is not
+        a replacement -- this is the ordinary "PID no longer matches" case, and
+        nothing else will ever remove the file."""
+        mock_conn, mock_cur = self._make_mock_conn(rowcount=0, fetchone=(None,))
+        mock_pooled.return_value = mock_conn
+
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp)
+            web_config = config_path / "cleanup-released_web.json"
+            web_config.write_text("{}")
+
+            with patch.object(db_notifier, "CONFIG_PATH", config_path):
+                result = db_notifier.notify_report_stopped(
+                    "cleanup-released", execution_token=TOKEN, cleanup_web_config=True
+                )
+
+            self.assertFalse(result)
+            self.assertFalse(web_config.exists(), "credential web config left on disk")
+
+    @patch("db_notifier.pooled_connection")
+    def test_locks_the_row_before_classifying_ownership(self, mock_pooled):
+        """The SELECT that decides keep-vs-delete takes FOR UPDATE on the report's
+        own row, closing the window a replacement could otherwise use to claim the
+        report and write a fresh credential file between an unlocked check and the
+        delete."""
+        mock_conn, mock_cur = self._make_mock_conn(rowcount=1, fetchone=(TOKEN,))
+        mock_pooled.return_value = mock_conn
+
+        with patch.object(db_notifier, "CONFIG_PATH", Path(tempfile.mkdtemp())):
+            db_notifier.notify_report_stopped(
+                "cleanup-lock", execution_token=TOKEN, cleanup_web_config=True
+            )
+
+        select_sql, select_params = mock_cur.execute.call_args_list[0].args
+        self.assertIn("SELECT", select_sql)
+        self.assertIn("FOR UPDATE", select_sql)
+        self.assertEqual(select_params, ("cleanup-lock",))
+
+    @patch("db_notifier.pooled_connection")
+    def test_skips_the_lock_and_delete_when_cleanup_not_requested(self, mock_pooled):
+        """Existing callers that don't ask for cleanup keep the original
+        single-statement behaviour: no SELECT, no file classification."""
+        mock_conn, mock_cur = self._make_mock_conn(rowcount=1)
+        mock_pooled.return_value = mock_conn
+
+        db_notifier.notify_report_stopped("no-cleanup", execution_token=TOKEN)
+
+        self.assertEqual(mock_cur.execute.call_count, 1)
+
+    @patch("db_notifier.pooled_connection")
+    def test_cleanup_failure_is_indeterminate(self, mock_pooled):
+        """A failed credential deletion must not be reported as a clean release."""
+        mock_conn, mock_cur = self._make_mock_conn(rowcount=1, fetchone=(TOKEN,))
+        mock_pooled.return_value = mock_conn
+
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp)
+            with patch.object(db_notifier, "CONFIG_PATH", config_path), \
+                 patch.object(Path, "unlink", side_effect=PermissionError("denied")):
+                result = db_notifier.notify_report_stopped(
+                    "cleanup-error", execution_token=TOKEN, cleanup_web_config=True
+                )
+
+        self.assertIsNone(result)
+        mock_conn.commit.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/script/tests/test_remove_web_config_file.py
+++ b/script/tests/test_remove_web_config_file.py
@@ -58,13 +58,16 @@ class TestSignalHandlerCleanup(unittest.TestCase):
     def test_keeps_the_web_config_when_another_attempt_owns_the_report(self):
         # On SIGTERM a superseded process must not delete <uuid>_web.json: it is keyed
         # on the report uuid alone, so it belongs to the attempt that replaced us.
+        # notify_report_stopped(cleanup_web_config=True) classifies ownership and
+        # deletes the file under the same lock, so False (replaced) means the file
+        # was already left alone -- release_attempt_and_cleanup_web_config must not
+        # make a second, separate delete call on top of that.
         with patch.object(run_garak, "_main_pid", os.getpid()), \
              patch.object(run_garak, "current_report_uuid", "uuid-xyz"), \
              patch.object(run_garak, "current_execution_token", TOKEN), \
              patch.object(run_garak, "current_journal_sync", None), \
              patch.object(run_garak, "current_heartbeat", None), \
              patch.object(run_garak, "notify_report_stopped", return_value=False), \
-             patch.object(run_garak, "execution_attempt_replaced", return_value=True), \
              patch.object(run_garak, "remove_web_config_file") as m_rm:
             with self.assertRaises(SystemExit):
                 run_garak.signal_handler(15, None)
@@ -73,17 +76,20 @@ class TestSignalHandlerCleanup(unittest.TestCase):
 
     def test_main_process_removes_web_config_on_signal(self):
         # An early SIGTERM (before the main try/finally) must still delete the
-        # credential file from the parent signal handler.
+        # credential file from the parent signal handler. The deletion happens
+        # inside notify_report_stopped's row lock (cleanup_web_config=True); a
+        # None result means the release was indeterminate (e.g. the database was
+        # unreachable), so remove_web_config_file is the fail-closed fallback.
         with patch.object(run_garak, "_main_pid", os.getpid()), \
              patch.object(run_garak, "current_report_uuid", "uuid-xyz"), \
              patch.object(run_garak, "current_execution_token", TOKEN), \
              patch.object(run_garak, "current_journal_sync", None), \
              patch.object(run_garak, "current_heartbeat", None), \
-             patch.object(run_garak, "notify_report_stopped") as m_stop, \
+             patch.object(run_garak, "notify_report_stopped", return_value=None) as m_stop, \
              patch.object(run_garak, "remove_web_config_file") as m_rm:
             with self.assertRaises(SystemExit):
                 run_garak.signal_handler(15, None)
-        m_stop.assert_called_once_with("uuid-xyz", TOKEN)
+        m_stop.assert_called_once_with("uuid-xyz", TOKEN, cleanup_web_config=True)
         m_rm.assert_called_once_with("uuid-xyz")
 
 

--- a/script/tests/test_run_garak_log_path.py
+++ b/script/tests/test_run_garak_log_path.py
@@ -16,7 +16,6 @@ _mock_db.notify_report_running = MagicMock(return_value=True)
 _mock_db.notify_report_ready = MagicMock(return_value=True)
 _mock_db.notify_report_ready_from_synced = MagicMock(return_value=True)
 _mock_db.notify_report_stopped = MagicMock(return_value=True)
-_mock_db.execution_attempt_replaced = MagicMock(return_value=False)
 _mock_db.load_existing_jsonl_prefix = MagicMock(return_value="")
 _mock_db.get_log_file_path = MagicMock(return_value=Path("/tmp/fake_reports/report.log"))
 _mock_db.HeartbeatThread = MagicMock

--- a/script/tests/test_run_garak_plugin_cache_guard.py
+++ b/script/tests/test_run_garak_plugin_cache_guard.py
@@ -14,7 +14,6 @@ _mock_db.notify_report_running = MagicMock(return_value=True)
 _mock_db.notify_report_ready = MagicMock(return_value=True)
 _mock_db.notify_report_ready_from_synced = MagicMock(return_value=True)
 _mock_db.notify_report_stopped = MagicMock(return_value=True)
-_mock_db.execution_attempt_replaced = MagicMock(return_value=False)
 _mock_db.load_existing_jsonl_prefix = MagicMock(return_value="")
 _mock_db.get_log_file_path = MagicMock(return_value=Path("/tmp/fake_reports/report.log"))
 _mock_db.HeartbeatThread = MagicMock

--- a/script/tests/test_run_garak_running_notification.py
+++ b/script/tests/test_run_garak_running_notification.py
@@ -63,7 +63,7 @@ TOKEN = "11111111-2222-3333-4444-555555555555"
 
 class TestRunningNotificationFailureIsFatal(unittest.TestCase):
     def _run_main(self, running_result, uuid="report-uuid-123", config_dir=None, token=TOKEN,
-                  stopped_result=True, replaced_result=False):
+                  stopped_result=True):
         # run_garak is imported once per process, so whichever test module imports it
         # first supplies these module-level constants. Pin them here (as Path, since
         # run_garak builds paths with `/`) so this test does not depend on that order.
@@ -79,7 +79,7 @@ class TestRunningNotificationFailureIsFatal(unittest.TestCase):
              patch.object(run_garak, "notify_report_ready", return_value=True), \
              patch.object(run_garak, "notify_report_ready_from_synced", return_value=True), \
              patch.object(run_garak, "notify_report_stopped", return_value=stopped_result) as mock_stopped, \
-             patch.object(run_garak, "execution_attempt_replaced", return_value=replaced_result), \
+             patch.object(run_garak, "remove_web_config_file") as mock_remove, \
              patch.object(run_garak, "load_existing_jsonl_prefix", return_value=""), \
              patch.object(run_garak, "get_log_file_path", return_value=tmp / "report.log"), \
              patch.object(sys, "argv", ["run_garak.py", uuid]), \
@@ -90,105 +90,66 @@ class TestRunningNotificationFailureIsFatal(unittest.TestCase):
                 os.environ.pop("SCAN_EXECUTION_TOKEN", None)
             with self.assertRaises(SystemExit) as ctx:
                 run_garak.main()
-        return ctx.exception.code, mock_scan, mock_heartbeat, mock_stopped
+        return ctx.exception.code, mock_scan, mock_heartbeat, mock_stopped, mock_remove
 
     def test_exits_nonzero_and_skips_the_scan_when_the_running_write_fails(self):
-        code, mock_scan, mock_heartbeat, _stopped = self._run_main(running_result=False)
+        code, mock_scan, mock_heartbeat, _stopped, _remove = self._run_main(running_result=False)
 
         self.assertEqual(code, 1)
         # Starting the scan would guarantee a SIGTERM from the heartbeat ~30s later.
         mock_scan.assert_not_called()
         mock_heartbeat.assert_not_called()
 
-    def test_removes_the_credential_web_config_on_the_abort_path(self):
-        """The abort returns before main()'s try/finally, so it must delete the
-        credential-bearing <uuid>_web.json itself. Rails writes that file before
-        launching this process, and once the process is accepted as started its own
-        startup rescue no longer removes it."""
-        config_dir = Path(tempfile.mkdtemp())
-        web_config = config_dir / "report-uuid-123_web.json"
-        web_config.write_text('{"cookies": [{"name": "session", "value": "secret"}]}')
-
-        code, _scan, _hb, _stopped = self._run_main(running_result=False, config_dir=config_dir)
-
-        self.assertEqual(code, 1)
-        self.assertFalse(web_config.exists(), "credential web config left on disk")
-
     def test_clears_the_recorded_pid_on_the_abort_path(self):
         """notify_report_running() can return False after the reports row is already
         committed: the pool hands out autocommit connections, so the status/pid UPDATE
         lands before the report_debug_logs statement that follows can fail. Without
         this, a dead process stays recorded as running until the reaper notices.
-        The call is PID-safe, so it is a no-op when nothing was recorded."""
-        code, _scan, _hb, mock_stopped = self._run_main(running_result=False)
+        The call is PID-safe, so it is a no-op when nothing was recorded. It also
+        requests the atomic cleanup path (cleanup_web_config=True), so ownership is
+        classified and the credential file is deleted under the same row lock rather
+        than as a second, separately-racing step."""
+        code, _scan, _hb, mock_stopped, _remove = self._run_main(running_result=False)
 
         self.assertEqual(code, 1)
-        mock_stopped.assert_called_once_with("report-uuid-123", TOKEN)
+        mock_stopped.assert_called_once_with("report-uuid-123", TOKEN, cleanup_web_config=True)
 
     def test_still_runs_the_scan_when_the_running_write_succeeds(self):
-        code, mock_scan, _mock_heartbeat, _stopped = self._run_main(running_result=True)
+        code, mock_scan, _mock_heartbeat, _stopped, _remove = self._run_main(running_result=True)
 
         self.assertEqual(code, 0)
         mock_scan.assert_called_once()
 
-    def test_keeps_the_credential_config_when_another_attempt_owns_the_report(self):
-        # <uuid>_web.json is keyed on the report UUID alone, so it is the same file a
-        # replacement attempt is already using. notify_report_stopped declining is how
-        # this process learns it is no longer the owner.
-        config_dir = Path(tempfile.mkdtemp()) / "config"
-        config_dir.mkdir(parents=True)
-        web_config = config_dir / "report-uuid-123_web.json"
-        web_config.write_text("{}")
-
-        self._run_main(
-            running_result=False,
-            config_dir=config_dir,
-            stopped_result=False,
-            replaced_result=True,
-        )
-
-        self.assertTrue(
-            web_config.exists(),
-            "a superseded process deleted the live attempt's credential file",
-        )
+    def test_does_not_double_delete_the_credential_config_when_release_is_determinate(self):
+        # Whether the report was released (True) or another attempt already owns it
+        # (False), notify_report_stopped(cleanup_web_config=True) has already made the
+        # keep-or-delete decision under the report row's lock. A second, unlocked
+        # remove_web_config_file call here would reopen exactly the race this closes:
+        # a replacement attempt could write a fresh credential file in between.
+        # (The keep-vs-delete decision itself is covered where it now lives --
+        # db_notifier's notify_report_stopped tests.)
+        for stopped_result in (True, False):
+            with self.subTest(stopped_result=stopped_result):
+                _code, _scan, _hb, _stopped, mock_remove = self._run_main(
+                    running_result=False, stopped_result=stopped_result
+                )
+                mock_remove.assert_not_called()
 
     def test_removes_the_credential_config_when_ownership_cleanup_errors(self):
         # A None result means the release could not be determined -- a database outage,
-        # say -- not that another attempt owns the report. Only a definitive mismatch
-        # may keep credentials on disk; nothing else runs after this exit.
-        config_dir = Path(tempfile.mkdtemp()) / "config"
-        config_dir.mkdir(parents=True)
-        web_config = config_dir / "report-uuid-123_web.json"
-        web_config.write_text('{"cookies": [{"name": "session", "value": "secret"}]}')
+        # say -- not that another attempt owns the report. The atomic classify-and-delete
+        # never got to run, so this is the fail-closed fallback: only a definitive
+        # mismatch may keep credentials on disk, and nothing else runs after this exit.
+        code, _scan, _hb, _stopped, mock_remove = self._run_main(running_result=False, stopped_result=None)
 
-        self._run_main(running_result=False, config_dir=config_dir, stopped_result=None)
-
-        self.assertFalse(web_config.exists(), "credential web config left on disk")
-
-    def test_removes_the_credential_config_when_only_the_pid_no_longer_matches(self):
-        # notify_report_stopped also returns False when the stored PID no longer
-        # matches -- RetryInterruptedReportsJob clears both the PID and the token
-        # before the old process reaches this cleanup. Nobody else owns the file then,
-        # and nothing else will ever remove it.
-        config_dir = Path(tempfile.mkdtemp()) / "config"
-        config_dir.mkdir(parents=True)
-        web_config = config_dir / "report-uuid-123_web.json"
-        web_config.write_text('{"cookies": [{"name": "session", "value": "secret"}]}')
-
-        self._run_main(
-            running_result=False,
-            config_dir=config_dir,
-            stopped_result=False,
-            replaced_result=False,
-        )
-
-        self.assertFalse(web_config.exists(), "credential web config left on disk")
+        self.assertEqual(code, 1)
+        mock_remove.assert_called_once_with("report-uuid-123")
 
     def test_refuses_to_start_without_an_execution_token(self):
         # Rails could only omit the token if the attempt was already revoked. Every
         # write this process makes would be rejected, so running the scan would burn
         # a full scan's work to produce nothing. Fail immediately, with a reason.
-        code, mock_scan, mock_heartbeat, _stopped = self._run_main(
+        code, mock_scan, mock_heartbeat, _stopped, _remove = self._run_main(
             running_result=True, token=None
         )
 
@@ -198,7 +159,7 @@ class TestRunningNotificationFailureIsFatal(unittest.TestCase):
 
     def test_validation_runs_do_not_need_an_execution_token(self):
         # Validation runs have no report row to own, so there is nothing to fence.
-        code, mock_scan, _hb, _stopped = self._run_main(
+        code, mock_scan, _hb, _stopped, _remove = self._run_main(
             running_result=True, uuid="validation_abc", token=None
         )
 
@@ -207,7 +168,7 @@ class TestRunningNotificationFailureIsFatal(unittest.TestCase):
 
     def test_validation_runs_do_not_require_the_running_write(self):
         # Validation runs have no database report record, so they never notify.
-        code, mock_scan, mock_heartbeat, _stopped = self._run_main(
+        code, mock_scan, mock_heartbeat, _stopped, _remove = self._run_main(
             running_result=False, uuid="validation_abc"
         )
 

--- a/script/tests/test_run_garak_signal_handler.py
+++ b/script/tests/test_run_garak_signal_handler.py
@@ -95,7 +95,7 @@ class TestParentSignalHandler(unittest.TestCase):
         with patch.object(run_garak, "notify_report_stopped", return_value=True) as mock_stopped:
             with self.assertRaises(SystemExit):
                 run_garak.signal_handler(signal.SIGTERM, None)
-            mock_stopped.assert_called_once_with("parent-test-uuid", TOKEN)
+            mock_stopped.assert_called_once_with("parent-test-uuid", TOKEN, cleanup_web_config=True)
 
     def test_parent_stops_heartbeat_and_journal_sync(self):
         """Parent process stops heartbeat and journal sync threads."""

--- a/script/tests/test_run_garak_traceback.py
+++ b/script/tests/test_run_garak_traceback.py
@@ -21,7 +21,6 @@ _mock_db.notify_report_running = MagicMock(return_value=True)
 _mock_db.notify_report_ready = MagicMock(return_value=True)
 _mock_db.notify_report_ready_from_synced = MagicMock(return_value=True)
 _mock_db.notify_report_stopped = MagicMock(return_value=True)
-_mock_db.execution_attempt_replaced = MagicMock(return_value=False)
 _mock_db.load_existing_jsonl_prefix = MagicMock(return_value="")
 _mock_db.get_log_file_path = MagicMock(return_value=Path("/tmp/fake_reports/report.log"))
 _mock_db.HeartbeatThread = MagicMock

--- a/spec/e2e/interrupted_reports_e2e_spec.rb
+++ b/spec/e2e/interrupted_reports_e2e_spec.rb
@@ -13,6 +13,22 @@ require "rails_helper"
 #
 # Run with: RAILS_ENV=test bundle exec rspec spec/e2e/interrupted_reports_e2e_spec.rb
 RSpec.describe "Interrupted Reports E2E", type: :feature do
+  # This suite builds fixtures from CheckStaleReportsJob.max_interrupt_retries and
+  # asserts against its default value (3) throughout. Isolate MAX_INTERRUPT_RETRIES
+  # so a container that actually sets it (e.g. for manual testing of a raised
+  # budget) can't change what "the" retry budget is for these examples.
+  around do |example|
+    original = ENV["MAX_INTERRUPT_RETRIES"]
+    ENV.delete("MAX_INTERRUPT_RETRIES")
+    example.run
+  ensure
+    if original.nil?
+      ENV.delete("MAX_INTERRUPT_RETRIES")
+    else
+      ENV["MAX_INTERRUPT_RETRIES"] = original
+    end
+  end
+
   # Use transactions for test isolation
   let(:target) { create(:target, :good) }
   let(:bad_target) { create(:target, :bad) }

--- a/spec/e2e/interrupted_reports_e2e_spec.rb
+++ b/spec/e2e/interrupted_reports_e2e_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "Interrupted Reports E2E", type: :feature do
         status: :running,
         pid: 12345,
         heartbeat_at: 5.minutes.ago,
-        retry_count: CheckStaleReportsJob::MAX_INTERRUPT_RETRIES, # 3
+        retry_count: CheckStaleReportsJob.max_interrupt_retries, # 3
         logs: "Previous retry attempts..."
       )
 
@@ -147,7 +147,7 @@ RSpec.describe "Interrupted Reports E2E", type: :feature do
         CheckStaleReportsJob.new.perform
       }.to change { report.reload.status }.from("running").to("failed")
 
-      expect(report.logs).to include("after #{CheckStaleReportsJob::MAX_INTERRUPT_RETRIES} retry attempts")
+      expect(report.logs).to include("after #{CheckStaleReportsJob.max_interrupt_retries} retry attempts")
     end
   end
 
@@ -393,7 +393,7 @@ RSpec.describe "Interrupted Reports E2E", type: :feature do
         pid: nil,
         heartbeat_at: 1.minute.ago,
         updated_at: 3.minutes.ago,
-        retry_count: CheckStaleReportsJob::MAX_INTERRUPT_RETRIES,
+        retry_count: CheckStaleReportsJob.max_interrupt_retries,
         logs: "Multiple retry attempts exhausted..."
       )
 
@@ -402,7 +402,7 @@ RSpec.describe "Interrupted Reports E2E", type: :feature do
       }.to change { report.reload.status }.from("running").to("failed")
 
       expect(report.logs).to include("orphaned")
-      expect(report.logs).to include("after #{CheckStaleReportsJob::MAX_INTERRUPT_RETRIES} retry attempts")
+      expect(report.logs).to include("after #{CheckStaleReportsJob.max_interrupt_retries} retry attempts")
     end
   end
 
@@ -436,7 +436,7 @@ RSpec.describe "Interrupted Reports E2E", type: :feature do
       expect(CheckStaleReportsJob::HEARTBEAT_TIMEOUT).to eq(2.minutes)
       expect(CheckStaleReportsJob::STARTING_TIMEOUT).to eq(2.minutes)
       expect(CheckStaleReportsJob::MAX_START_RETRIES).to eq(3)
-      expect(CheckStaleReportsJob::MAX_INTERRUPT_RETRIES).to eq(3)
+      expect(CheckStaleReportsJob.max_interrupt_retries).to eq(3)
       expect(RetryInterruptedReportsJob::STABILIZATION_DELAY).to eq(30.seconds)
     end
   end

--- a/spec/jobs/check_stale_reports_job_spec.rb
+++ b/spec/jobs/check_stale_reports_job_spec.rb
@@ -570,8 +570,80 @@ RSpec.describe CheckStaleReportsJob, type: :job do
       expect(described_class::MAX_START_RETRIES).to eq(3)
     end
 
-    it "has max 3 interrupt retries" do
-      expect(described_class::MAX_INTERRUPT_RETRIES).to eq(3)
+    it "defaults to 3 interrupt retries" do
+      expect(described_class::DEFAULT_MAX_INTERRUPT_RETRIES).to eq(3)
+    end
+  end
+
+  describe ".max_interrupt_retries" do
+    around do |example|
+      original = ENV["MAX_INTERRUPT_RETRIES"]
+      example.run
+    ensure
+      if original.nil?
+        ENV.delete("MAX_INTERRUPT_RETRIES")
+      else
+        ENV["MAX_INTERRUPT_RETRIES"] = original
+      end
+    end
+
+    it "defaults to 3 when unset" do
+      ENV.delete("MAX_INTERRUPT_RETRIES")
+      expect(described_class.max_interrupt_retries).to eq(3)
+    end
+
+    it "reads a positive integer from the environment" do
+      ENV["MAX_INTERRUPT_RETRIES"] = "6"
+      expect(described_class.max_interrupt_retries).to eq(6)
+    end
+
+    it "falls back to the default for a non-integer value" do
+      ENV["MAX_INTERRUPT_RETRIES"] = "abc"
+      expect(described_class.max_interrupt_retries).to eq(3)
+    end
+
+    it "falls back to the default for a non-positive value" do
+      ENV["MAX_INTERRUPT_RETRIES"] = "0"
+      expect(described_class.max_interrupt_retries).to eq(3)
+    end
+  end
+
+  describe "interrupt budget honours MAX_INTERRUPT_RETRIES" do
+    around do |example|
+      original = ENV["MAX_INTERRUPT_RETRIES"]
+      example.run
+    ensure
+      if original.nil?
+        ENV.delete("MAX_INTERRUPT_RETRIES")
+      else
+        ENV["MAX_INTERRUPT_RETRIES"] = original
+      end
+    end
+
+    it "keeps retrying past the default budget when raised via ENV" do
+      ENV["MAX_INTERRUPT_RETRIES"] = "5"
+      stale_time = 3.minutes.ago
+      # retry_count: 3 would exceed the hardcoded default and be failed outright.
+      report = create(:report, target: target, scan: scan, status: :running, pid: 12345,
+                      heartbeat_at: stale_time, retry_count: 3)
+
+      described_class.new.perform
+
+      report.reload
+      expect(report.status).to eq("interrupted")
+    end
+
+    it "still fails once the raised budget is exhausted" do
+      ENV["MAX_INTERRUPT_RETRIES"] = "5"
+      stale_time = 3.minutes.ago
+      report = create(:report, target: target, scan: scan, status: :running, pid: 12345,
+                      heartbeat_at: stale_time, retry_count: 5)
+
+      described_class.new.perform
+
+      report.reload
+      expect(report.status).to eq("failed")
+      expect(report.logs).to include("after 5 retry attempts")
     end
   end
 

--- a/spec/jobs/check_stale_reports_job_spec.rb
+++ b/spec/jobs/check_stale_reports_job_spec.rb
@@ -519,6 +519,47 @@ RSpec.describe CheckStaleReportsJob, type: :job do
         expect(running_report.reload.status).to eq("running")
         expect(pending_report.reload.status).to eq("pending")
       end
+
+      context "with a raised interrupt budget" do
+        around do |example|
+          original = ENV["MAX_INTERRUPT_RETRIES"]
+          example.run
+        ensure
+          if original.nil?
+            ENV.delete("MAX_INTERRUPT_RETRIES")
+          else
+            ENV["MAX_INTERRUPT_RETRIES"] = original
+          end
+        end
+
+        it "retries past the hardcoded MAX_START_RETRIES when the interrupt budget covers it" do
+          # retry_count 4 already exceeds MAX_START_RETRIES (3), but this report only
+          # got there by surviving several deploy-time interruptions under a raised
+          # budget -- a stuck start attempt right after must not undercut that budget.
+          ENV["MAX_INTERRUPT_RETRIES"] = "6"
+          stuck_time = 3.minutes.ago
+          report = create(:report, target: target, scan: scan, status: :starting, retry_count: 4, updated_at: stuck_time)
+
+          described_class.new.perform
+
+          report.reload
+          expect(report.status).to eq("pending")
+          expect(report.retry_count).to eq(5)
+          expect(report.logs).to include("Retry 5:")
+        end
+
+        it "still fails once the raised budget itself is exhausted" do
+          ENV["MAX_INTERRUPT_RETRIES"] = "6"
+          stuck_time = 3.minutes.ago
+          report = create(:report, target: target, scan: scan, status: :starting, retry_count: 6, updated_at: stuck_time)
+
+          described_class.new.perform
+
+          report.reload
+          expect(report.status).to eq("failed")
+          expect(report.logs).to include("Failed after 6 start attempts")
+        end
+      end
     end
 
     describe "multiple reports" do
@@ -629,6 +670,46 @@ RSpec.describe CheckStaleReportsJob, type: :job do
       # truncated budget the operator did not ask for.
       ENV["MAX_INTERRUPT_RETRIES"] = "1.5"
       expect(described_class.max_interrupt_retries).to eq(3)
+    end
+
+    it "warns when a malformed value is rejected" do
+      ENV["MAX_INTERRUPT_RETRIES"] = "5oops"
+      expect(Rails.logger).to receive(:warn).with(/MAX_INTERRUPT_RETRIES="5oops"/)
+      described_class.max_interrupt_retries
+    end
+
+    it "warns when a non-positive value is rejected" do
+      ENV["MAX_INTERRUPT_RETRIES"] = "0"
+      expect(Rails.logger).to receive(:warn).with(/MAX_INTERRUPT_RETRIES="0"/)
+      described_class.max_interrupt_retries
+    end
+  end
+
+  describe ".start_retry_ceiling" do
+    around do |example|
+      original = ENV["MAX_INTERRUPT_RETRIES"]
+      example.run
+    ensure
+      if original.nil?
+        ENV.delete("MAX_INTERRUPT_RETRIES")
+      else
+        ENV["MAX_INTERRUPT_RETRIES"] = original
+      end
+    end
+
+    it "equals MAX_START_RETRIES when the interrupt budget is not raised" do
+      ENV.delete("MAX_INTERRUPT_RETRIES")
+      expect(described_class.start_retry_ceiling).to eq(3)
+    end
+
+    it "tracks a raised interrupt budget" do
+      ENV["MAX_INTERRUPT_RETRIES"] = "6"
+      expect(described_class.start_retry_ceiling).to eq(6)
+    end
+
+    it "never drops below MAX_START_RETRIES even if the interrupt budget is lowered" do
+      ENV["MAX_INTERRUPT_RETRIES"] = "1"
+      expect(described_class.start_retry_ceiling).to eq(3)
     end
   end
 

--- a/spec/jobs/check_stale_reports_job_spec.rb
+++ b/spec/jobs/check_stale_reports_job_spec.rb
@@ -606,6 +606,30 @@ RSpec.describe CheckStaleReportsJob, type: :job do
       ENV["MAX_INTERRUPT_RETRIES"] = "0"
       expect(described_class.max_interrupt_retries).to eq(3)
     end
+
+    it "falls back to the default for a negative value" do
+      ENV["MAX_INTERRUPT_RETRIES"] = "-3"
+      expect(described_class.max_interrupt_retries).to eq(3)
+    end
+
+    it "falls back to the default for a blank value" do
+      ENV["MAX_INTERRUPT_RETRIES"] = ""
+      expect(described_class.max_interrupt_retries).to eq(3)
+    end
+
+    it "falls back to the default for a partially-numeric value instead of truncating it" do
+      # String#to_i silently reads "5oops" as 5 -- a configuration typo must not
+      # silently change the retry budget.
+      ENV["MAX_INTERRUPT_RETRIES"] = "5oops"
+      expect(described_class.max_interrupt_retries).to eq(3)
+    end
+
+    it "falls back to the default for a decimal value instead of truncating it" do
+      # String#to_i silently reads "1.5" as 1 -- reject it rather than accept a
+      # truncated budget the operator did not ask for.
+      ENV["MAX_INTERRUPT_RETRIES"] = "1.5"
+      expect(described_class.max_interrupt_retries).to eq(3)
+    end
   end
 
   describe "interrupt budget honours MAX_INTERRUPT_RETRIES" do

--- a/spec/jobs/retry_interrupted_reports_job_spec.rb
+++ b/spec/jobs/retry_interrupted_reports_job_spec.rb
@@ -136,6 +136,73 @@ RSpec.describe RetryInterruptedReportsJob, type: :job do
       end
     end
 
+    describe "interrupt budget" do
+      around do |example|
+        original = ENV["MAX_INTERRUPT_RETRIES"]
+        example.run
+      ensure
+        if original.nil?
+          ENV.delete("MAX_INTERRUPT_RETRIES")
+        else
+          ENV["MAX_INTERRUPT_RETRIES"] = original
+        end
+      end
+
+      it "fails instead of requeuing once retry_count has already reached the current budget" do
+        # The report was interrupted while the budget was higher (or unset); an
+        # operator has since lowered MAX_INTERRUPT_RETRIES. Requeuing it would retry
+        # past a budget that no longer allows it.
+        ENV["MAX_INTERRUPT_RETRIES"] = "3"
+        report = create(:report, target: target, scan: scan, status: :interrupted,
+                        retry_count: 3, updated_at: 1.minute.ago)
+
+        described_class.new.perform
+
+        report.reload
+        expect(report.status).to eq("failed")
+        expect(report.retry_count).to eq(3)
+        expect(report.logs).to include("exceeded 3 interrupt retries")
+      end
+
+      it "still requeues when retry_count is under the current budget" do
+        ENV["MAX_INTERRUPT_RETRIES"] = "3"
+        report = create(:report, target: target, scan: scan, status: :interrupted,
+                        retry_count: 2, updated_at: 1.minute.ago)
+
+        described_class.new.perform
+
+        report.reload
+        expect(report.status).to eq("pending")
+        expect(report.retry_count).to eq(3)
+      end
+
+      it "requeues past the hardcoded default of 3 when the budget is raised" do
+        ENV["MAX_INTERRUPT_RETRIES"] = "6"
+        report = create(:report, target: target, scan: scan, status: :interrupted,
+                        retry_count: 4, updated_at: 1.minute.ago)
+
+        described_class.new.perform
+
+        report.reload
+        expect(report.status).to eq("pending")
+        expect(report.retry_count).to eq(5)
+      end
+
+      it "fails a report already at the default budget even without an ENV override" do
+        # Guards the seam where only the log message consulted the live budget: a
+        # report already at retry_count 3 must not be silently requeued again just
+        # because nothing else in this job compared it to the budget at all.
+        ENV.delete("MAX_INTERRUPT_RETRIES")
+        report = create(:report, target: target, scan: scan, status: :interrupted,
+                        retry_count: 3, updated_at: 1.minute.ago)
+
+        described_class.new.perform
+
+        report.reload
+        expect(report.status).to eq("failed")
+      end
+    end
+
     describe "status filtering" do
       it "only processes interrupted reports" do
         pending_report = create(:report, target: target, scan: scan, status: :pending, updated_at: 1.minute.ago)

--- a/spec/models/target_spec.rb
+++ b/spec/models/target_spec.rb
@@ -121,6 +121,63 @@ RSpec.describe Target, type: :model do
         target = build(:target, target_type: :api, json_config: "")
         expect(target).to be_valid
       end
+
+      it "does not re-resolve an unchanged URI for a save that touches only an unrelated column" do
+        allow(UrlSafetyValidator).to receive(:safe_url?).and_return(
+          UrlSafetyValidator::Result.new("safe?": true, error: nil, resolved_ips: [ "93.184.216.34" ])
+        )
+        target = create(
+          :target,
+          target_type: :api,
+          json_config: { rest: { RestGenerator: { uri: "https://example.com/v1/generate" } } }.to_json
+        )
+
+        # The URI would now fail DNS resolution -- prove the validator is not
+        # even consulted for a save that never touched json_config.
+        allow(UrlSafetyValidator).to receive(:safe_url?).and_return(
+          UrlSafetyValidator::Result.new("safe?": false, error: "Could not resolve hostname")
+        )
+
+        expect(UrlSafetyValidator).not_to receive(:safe_url?)
+        target.update!(status: :good, validation_text: "Target validated successfully")
+        expect(target.reload).to be_good
+      end
+
+      it "still re-resolves a changed URI before persisting it" do
+        allow(UrlSafetyValidator).to receive(:safe_url?).and_return(
+          UrlSafetyValidator::Result.new("safe?": true, error: nil, resolved_ips: [ "93.184.216.34" ])
+        )
+        target = create(
+          :target,
+          target_type: :api,
+          json_config: { rest: { RestGenerator: { uri: "https://example.com/v1/generate" } } }.to_json
+        )
+
+        allow(UrlSafetyValidator).to receive(:safe_url?).and_return(
+          UrlSafetyValidator::Result.new("safe?": false, error: "Could not resolve hostname")
+        )
+
+        expect {
+          target.update!(
+            json_config: { rest: { RestGenerator: { uri: "https://unresolved.example/v1/generate" } } }.to_json
+          )
+        }.to raise_error(ActiveRecord::RecordInvalid, /Could not resolve hostname/)
+      end
+
+      it "re-validates a brand new record even though nothing has changed yet" do
+        allow(UrlSafetyValidator).to receive(:safe_url?).and_return(
+          UrlSafetyValidator::Result.new("safe?": false, error: "Could not resolve hostname")
+        )
+
+        target = build(
+          :target,
+          target_type: :api,
+          json_config: { rest: { RestGenerator: { uri: "https://unresolved.example/v1/generate" } } }.to_json
+        )
+
+        expect(target).not_to be_valid
+        expect(target.errors[:json_config]).to include(/Could not resolve hostname/)
+      end
     end
 
     context "for webchat targets" do

--- a/spec/services/stats/average_asr_score_security_spec.rb
+++ b/spec/services/stats/average_asr_score_security_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Stats::AverageAsrScore do
     end
   end
 
-  it "returns 0.0 (fails closed) when there is no current tenant" do
+  it "fails closed when there is no current tenant, matching no reports rather than leaking any" do
     company = create(:company)
     ActsAsTenant.with_tenant(company) do
       r = create(:report, company: company)
@@ -32,7 +32,10 @@ RSpec.describe Stats::AverageAsrScore do
     end
 
     ActsAsTenant.without_tenant do
-      expect(described_class.new.average_attack_success_rate).to eq(0.0)
+      # company_id: nil means the WHERE clause matches zero rows (company_id = NULL is
+      # never true in SQL) -- the same "nothing measurable" outcome as no reports at all,
+      # so it is nil rather than a false zero, not a leak of the tenant's real 50%.
+      expect(described_class.new.average_attack_success_rate).to be_nil
     end
   end
 

--- a/spec/services/stats/average_asr_score_spec.rb
+++ b/spec/services/stats/average_asr_score_spec.rb
@@ -112,12 +112,21 @@ RSpec.describe Stats::AverageAsrScore do
     end
 
     context 'when no reports exist' do
-      it 'returns zero score with empty data' do
+      it 'reports the score as unmeasurable rather than a false zero' do
         result = subject
 
-        expect(result[:score]).to eq(0)
+        expect(result[:score]).to be_nil
         expect(result[:data][:dates]).to be_present
         expect(result[:data][:rates]).to all eq(0.0)
+      end
+    end
+
+    context 'when every attack was blocked' do
+      it 'reports a genuine zero, not the unmeasurable nil' do
+        report = create(:report, company: company, target: target, scan: scan, created_at: Time.zone.today)
+        create(:probe_result, report: report, probe: probe, detector: detector, passed: 0, total: 10)
+
+        expect(subject[:score]).to eq(0.0)
       end
     end
 
@@ -184,10 +193,10 @@ RSpec.describe Stats::AverageAsrScore do
         create(:probe_result, report: report, probe: probe, detector: detector, passed: 0, total: 0)
       end
 
-      it 'excludes reports with zero totals from calculation' do
+      it 'excludes reports with zero totals from calculation, leaving nothing measurable' do
         result = subject
 
-        expect(result[:score]).to eq(0)
+        expect(result[:score]).to be_nil
       end
     end
   end
@@ -215,9 +224,9 @@ RSpec.describe Stats::AverageAsrScore do
     end
 
     context 'with no reports' do
-      it 'returns zero' do
+      it 'returns nil rather than a false zero' do
         ActsAsTenant.with_tenant(company) do
-          expect(subject.average_attack_success_rate(4.days.ago)).to eq(0)
+          expect(subject.average_attack_success_rate(4.days.ago)).to be_nil
         end
       end
     end


### PR DESCRIPTION
Six correctness fixes, plus the follow-on work two review passes turned up. Grouped by what they affect.

## A target re-validated its config on every save

`Target#json_config_should_be_validated?` gated the SSRF/URI validations on `json_config.present? && api?` with no dirty check, so **every** save of an API target re-resolved DNS — including saves that never touch the config. `ValidateTarget#call` marks a target good immediately after validating it, so that status write re-ran the same resolution and a transient DNS failure could fail the very update recording success.

The guard now also requires `new_record? || will_save_change_to_json_config? || will_save_change_to_target_type?`. `will_save_change_to_*` is reliable here even though the attribute is encrypted — `EncryptedAttributeType#changed_in_place?` decrypts before comparing, unlike `saved_change_to_*`, which this repo's CLAUDE.md warns is always true for non-deterministic encryption. Launch-time `scan_launch_url_safe?` still covers DNS rebinding between saves.

## The per-scan credential file could be deleted out from under a live scan

`notify_report_stopped` checked attempt ownership and deleted `<uuid>_web.json` as two unlocked steps, so a replacement attempt's fresh credential file could be deleted by the exiting process — leaving the new scan running without cookies or headers.

The check, the delete and the ownership release now share one transaction holding a `FOR UPDATE` row lock. Note this needed an explicit `autocommit = False`: pooled connections are handed out with autocommit enabled, under which a bare `FOR UPDATE` releases its lock the instant the SELECT completes — the first version of this fix looked right and protected nothing. The lock is bounded by `SET LOCAL lock_timeout = '5s'`, falling back to the unguarded delete rather than blocking Rails writes to that row behind a slow filesystem or being SIGKILLed mid-cleanup on the SIGTERM path.

A delete failure also no longer aborts the ownership release: the `unlink` is guarded, so a report can't be left `running` with a stale pid and live token until the stale-reaper times it out two minutes later.

## The interrupted-scan retry budget

`MAX_INTERRUPT_RETRIES` was hardcoded at 3, so a scan interrupted more than three times by rolling-deploy restarts was permanently failed even though its progress is DB-persisted and safe to resume. It is now configurable via env, with strict parsing (a malformed value like `5oops` falls back to the default and logs a warning rather than silently becoming `5`).

Making it configurable exposed that two budgets share one `retry_count` column, so the setting is now authoritative wherever that column is compared:
- the start-retry ceiling derives from `[MAX_START_RETRIES, max_interrupt_retries].max`, so raising the budget genuinely absorbs more interruptions instead of the report being failed by a hardcoded `3` with a message about start timeouts that never happened;
- `RetryInterruptedReportsJob` compares against the live budget before requeuing, so lowering it actually stops retries instead of logging "attempt 5/3".

## The dashboard's average ASR tile reported a false zero

`Stats::AverageAsrScore` coerced a NULL aggregate to `0`, and the dashboard rendered it as `0.0%`. A company whose only reports failed with no probe results saw "Avg ASR 0.0%" next to a "Last Five Scans" card correctly reading N/A. It now returns `nil` for unmeasurable and renders N/A, following the `Reports::AsrFigure` doctrine: `0.0` means measured and nothing succeeded, `nil` means nothing was measurable. A genuine measured zero still renders `0.0%`.

## Two CI-only E2E flakes

Cleanup no longer fails on an aborted request (matched by `err.name === 'AbortError'`, not engine-specific wording), and the environment-variables heading assertion is scoped to the page heading rather than matching the nav item too. Neither is verified by execution — Cypress doesn't run in this environment.

## Verification

Full RSpec 2981 examples with 2 pre-existing failures also present on `main` (unrelated `Target.count` DB-leak flakes); Python 124/124 on both interpreters; `npm run test:js` passing; RuboCop clean; Brakeman no warnings. Every behavioural change is pinned by a test watched failing first. The ENV-isolation fix was checked by actually running the affected suite with `MAX_INTERRUPT_RETRIES=6` set.

## Known limitations, stated deliberately

Two edges of the above were found in review and left unfixed on purpose:

- **Lowering `MAX_INTERRUPT_RETRIES` does not stop a report already queued for launch.** The budget is enforced when a report is requeued, but one already moved to `pending` under a higher budget will still be launched by `StartPendingScansJob`. Enforcing it at launch means expanding the check into a third job, and "an attempt already scheduled completes" is defensible semantics. The window only opens when an operator lowers the budget while a report is in backoff.
- **The credential-cleanup row lock is held across a filesystem `unlink`.** `lock_timeout` and `statement_timeout` bound SQL lock acquisition and statement execution, not filesystem I/O, so a hung mount can still block status updates for that one report row. There is no portable I/O deadline for this in Python, and the architectural fixes (deleting outside the lock, or a watchdog) would reopen the race this change exists to close.
