### PR TITLE
fix(reports): count bypassed probes for Vulnerabilities Found, and stop expiring idle sessions

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -537,12 +537,19 @@ class Report < ApplicationRecord
   # already shows successful attacks, so counting that probe agrees with the rest of the
   # page rather than fighting it.
   #
-  # Known, accepted under-report: a legacy multi-detector probe_result where an earlier
-  # detector was bypassed but the row's final stored detector defended -- passed is 0
-  # there, and no reconstruction path exists for those pre-max-merge rows. Left uncounted
-  # rather than patched: the rest of the page reads "0 / N attacks succeeded" and "ASR
-  # 0.0%" from that same passed column, so this count still agrees with everything else on
-  # the page. The affected population is historical and does not grow.
+  # Known, accepted under-report: 6e86cca -- the same commit that added any_detector_passed
+  # and its backfill -- also changed probe_result.passed from last-write-wins to max-wins
+  # across a probe's detectors. For a report processed before that commit, a probe bypassed
+  # by one detector but defended by a later-processed detector kept whichever detector wrote
+  # last, so passed can be corrupted to 0 even though an attack against that probe actually
+  # succeeded. The backfill keys any_detector_passed off passed > 0, so it reads that same
+  # already-corrupted value and cannot recover the row; the raw per-detector eval data is
+  # discarded after processing, so there is no reconstruction path either. Unlike the
+  # rolling-deploy case above, passed > 0 does not rescue this one -- both columns derive
+  # from the same corrupted write. Left uncounted rather than patched: the rest of the page
+  # reads "0 / N attacks succeeded" and "ASR 0.0%" from that same corrupted passed column,
+  # so this count still agrees with everything else on the page. The affected population is
+  # historical (reports processed before 6e86cca) and does not grow.
   def security_vulnerabilities_count
     probe_results.where(any_detector_passed: true)
       .or(probe_results.where("passed > 0"))

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -514,13 +514,14 @@ class Report < ApplicationRecord
     cached_total
   end
 
-  # Detectors that found something. `passed` is successful attacks -- the same column
-  # #total_successful_attacks sums -- so a detector identified a vulnerability when at
-  # least one attack against it succeeded. Counting `passed < total` inverted that: a
-  # report with 0/84 successful attacks claimed two vulnerabilities, and a detector
-  # bypassed on every attempt (80/80) was counted as clean.
+  # Distinct probes (attack techniques) where at least one attack succeeded. Counting
+  # detector_results undercounts: detector_results is unique per (detector, report), and
+  # most 0din probes declare the same shared detector, so a report where one probe was
+  # bypassed and one where twenty were both read "1" detector row. Counting probe_results
+  # via any_detector_passed matches Scans::StatsSerializer#top_vulnerabilities_info, which
+  # already counts probes the same way for the same page.
   def security_vulnerabilities_count
-    detector_results.where("passed > 0").count
+    probe_results.where(any_detector_passed: true).count
   end
 
   # Compute total input tokens from all probe results

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -527,17 +527,26 @@ class Report < ApplicationRecord
   # Ordinary reports have at most one probe_result per probe_id already (uniqueness
   # validation on [probe_id, threat_variant_id]), so this is a no-op for them.
   #
-  # Known under-report: a legacy multi-detector probe_result where an earlier detector was
-  # bypassed but the row's final stored detector defended has any_detector_passed=false --
-  # the backfill migration keys off passed > 0, and no reconstruction path exists for those
-  # pre-max-merge rows (see db/migrate/20260412044226). Accepted rather than patched:
-  # such a report already reads "0 / N attacks succeeded" and "ASR 0.0%" from the same
-  # passed column, so this count already agrees with everything else on the page. Reaching
-  # into detector_results to surface a nonzero count here would contradict those figures --
-  # exactly the inconsistency this method was corrected to remove. The affected population
-  # is historical and does not grow.
+  # any_detector_passed OR passed > 0, not the flag alone: a rolling deploy can finish a
+  # report with an old worker after the backfill migration (db/migrate/20260412044226) has
+  # already run. That worker's insert omits the new column, so it lands on the schema
+  # default -- false -- even when passed > 0 (db/schema.rb: default: false, null: false).
+  # The flag alone would then read "0 vulnerabilities" beside a nonzero successful-attack
+  # count. Falling back to passed > 0 cannot introduce a contradiction, because passed is
+  # the same column the ASR and attack totals are computed from: if it is nonzero the page
+  # already shows successful attacks, so counting that probe agrees with the rest of the
+  # page rather than fighting it.
+  #
+  # Known, accepted under-report: a legacy multi-detector probe_result where an earlier
+  # detector was bypassed but the row's final stored detector defended -- passed is 0
+  # there, and no reconstruction path exists for those pre-max-merge rows. Left uncounted
+  # rather than patched: the rest of the page reads "0 / N attacks succeeded" and "ASR
+  # 0.0%" from that same passed column, so this count still agrees with everything else on
+  # the page. The affected population is historical and does not grow.
   def security_vulnerabilities_count
-    probe_results.where(any_detector_passed: true).distinct.count(:probe_id)
+    probe_results.where(any_detector_passed: true)
+      .or(probe_results.where("passed > 0"))
+      .distinct.count(:probe_id)
   end
 
   # Compute total input tokens from all probe results

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -519,9 +519,15 @@ class Report < ApplicationRecord
   # most 0din probes declare the same shared detector, so a report where one probe was
   # bypassed and one where twenty were both read "1" detector row. Counting probe_results
   # via any_detector_passed matches Scans::StatsSerializer#top_vulnerabilities_info, which
-  # already counts probes the same way for the same page.
+  # already counts probes the same way (grouped by probes.id) for the same page.
+  #
+  # Distinct on probe_id rather than a plain row count: a variant child report stores one
+  # probe_result row per (probe, threat_variant) -- see VariantDefaults -- so a probe with
+  # two successful variants would otherwise read "2" vulnerabilities for one technique.
+  # Ordinary reports have at most one probe_result per probe_id already (uniqueness
+  # validation on [probe_id, threat_variant_id]), so this is a no-op for them.
   def security_vulnerabilities_count
-    probe_results.where(any_detector_passed: true).count
+    probe_results.where(any_detector_passed: true).distinct.count(:probe_id)
   end
 
   # Compute total input tokens from all probe results

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -526,6 +526,16 @@ class Report < ApplicationRecord
   # two successful variants would otherwise read "2" vulnerabilities for one technique.
   # Ordinary reports have at most one probe_result per probe_id already (uniqueness
   # validation on [probe_id, threat_variant_id]), so this is a no-op for them.
+  #
+  # Known under-report: a legacy multi-detector probe_result where an earlier detector was
+  # bypassed but the row's final stored detector defended has any_detector_passed=false --
+  # the backfill migration keys off passed > 0, and no reconstruction path exists for those
+  # pre-max-merge rows (see db/migrate/20260412044226). Accepted rather than patched:
+  # such a report already reads "0 / N attacks succeeded" and "ASR 0.0%" from the same
+  # passed column, so this count already agrees with everything else on the page. Reaching
+  # into detector_results to surface a nonzero count here would contradict those figures --
+  # exactly the inconsistency this method was corrected to remove. The affected population
+  # is historical and does not grow.
   def security_vulnerabilities_count
     probe_results.where(any_detector_passed: true).distinct.count(:probe_id)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
 
   # Devise modules (engine may add :omniauthable)
   devise :database_authenticatable, :recoverable, :rememberable,
-         :validatable, :lockable, :timeoutable
+         :validatable, :lockable
 
   # Super admin scopes and methods
   scope :super_admins, -> { where(super_admin: true) }

--- a/app/views/admin/glossary/show.html.erb
+++ b/app/views/admin/glossary/show.html.erb
@@ -39,7 +39,7 @@
         <%= render "admin/glossary/term", term: "Security Grade", definition: "An A+ through F letter grade for a scan, computed from the Attack Success Rate adjusted by a risk penalty. Probes with higher Social Impact Scores that succeed carry heavier penalties." %>
         <%= render "admin/glossary/term", term: "Max Score", definition: "The highest detector confidence score reached by a probe across all its attempts, shown as a percentage. Indicates how definitively the detector classified a response as vulnerable." %>
         <%= render "admin/glossary/term", term: "Successful Attacks / Passed", definition: "The number of probe attempts where the attack succeeded — meaning the target model responded in a way that the detector classified as vulnerable. Shown as a ratio (e.g., 3 / 40)." %>
-        <%= render "admin/glossary/term", term: "Vulnerabilities Found", definition: "The number of detectors that recorded at least one successful attack in a report — one count per detector that found something, not per attack attempt." %>
+        <%= render "admin/glossary/term", term: "Vulnerabilities Found", definition: "The number of distinct probes (attack techniques) where at least one attack succeeded — one count per bypassed probe, not per detector and not per attack attempt." %>
         <%= render "admin/glossary/term", term: "Token Usage", definition: "The number of LLM tokens consumed during a scan, broken down into input tokens (prompts sent) and output tokens (model responses). Used for cost estimation and monitoring." %>
       </dl>
     </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -186,7 +186,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 60.minutes
+  # config.timeout_in = 30.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1684,5 +1684,24 @@ RSpec.describe Report, type: :model do
 
       expect(report.security_vulnerabilities_count).to eq(1)
     end
+
+    # A variant child report records one probe_result row per (probe, threat_variant),
+    # so the same base probe can appear on several rows -- see the fixture in
+    # "a variant child report, whose rows are one per probe and variant"
+    # (spec/requests/report_metric_reconciliation_spec.rb). "Vulnerabilities Found" names
+    # a distinct attack technique (the glossary's "distinct probes"), not a variant, so
+    # two successful variants of the same probe must still read "1", not "2".
+    it 'counts one vulnerability for a probe with multiple successful threat variants' do
+      ActsAsTenant.with_tenant(company) do
+        shared_probe = create(:probe)
+        2.times do |i|
+          create(:probe_result, report: report, probe: shared_probe,
+                                 threat_variant: create(:threat_variant, probe: shared_probe, prompt: "Variant #{i}"),
+                                 passed: 1, total: 5, any_detector_passed: true)
+        end
+      end
+
+      expect(report.security_vulnerabilities_count).to eq(1)
+    end
   end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1627,37 +1627,59 @@ RSpec.describe Report, type: :model do
       end
     end
 
-    # `passed` is successful attacks (Report#total_successful_attacks sums the same column).
-    # Counting `passed < total` read it as "attempts resisted", so a report where nothing
-    # succeeded claimed vulnerabilities and the detector that found every one was ignored.
+    # "Vulnerabilities Found" names an attack technique that worked, not a detector row.
+    # `detector_results` is unique per (detector, report) -- most 0din probes declare the
+    # same shared detector (e.g. 0din.MitigationBypass), so a report where three distinct
+    # probes were each bypassed still has exactly one detector_result row for that
+    # detector. Counting detector_results therefore reads "1" next to a probe list that
+    # enumerates three bypassed techniques. Counting probe_results.any_detector_passed
+    # matches Scans::StatsSerializer#top_vulnerabilities_info, which already counts probes
+    # the same way for the same page.
     #
-    # Two fully-bypassed detectors (passed == total, both > 0) and one clean detector
-    # (passed == 0) make the old and new queries diverge: `passed < total` counts only
-    # the clean row (old = 1), `passed > 0` counts both bypassed rows (new = 2). A
-    # fixture with just one bypassed row and one clean row lands on the same integer
-    # under both queries and would not pin the regression.
-    it 'counts detectors where at least one attack succeeded' do
+    # Three probes sharing one detector, all bypassed: the old detector-row count and the
+    # new probe count diverge here (old = 1 detector_result row, new = 3 bypassed probes),
+    # so this fixture pins the regression -- a fixture where both queries land on the same
+    # integer would not.
+    it 'counts distinct probes where at least one attack succeeded, not detector rows' do
       ActsAsTenant.with_tenant(company) do
-        create(:detector_result, report: report, detector: create(:detector), passed: 4, total: 4)
-        create(:detector_result, report: report, detector: create(:detector), passed: 10, total: 10)
-        create(:detector_result, report: report, detector: create(:detector), passed: 0, total: 80)
+        shared_detector = create(:detector, name: "0din.MitigationBypass")
+        create(:detector_result, report: report, detector: shared_detector, passed: 14, total: 14)
+
+        create(:probe_result, report: report, probe: create(:probe), detector: shared_detector,
+                               passed: 4, total: 4, any_detector_passed: true)
+        create(:probe_result, report: report, probe: create(:probe), detector: shared_detector,
+                               passed: 10, total: 10, any_detector_passed: true)
+        create(:probe_result, report: report, probe: create(:probe), detector: shared_detector,
+                               passed: 0, total: 80, any_detector_passed: false)
       end
 
       expect(report.security_vulnerabilities_count).to eq(2)
     end
 
-    it 'counts nothing when every attack was blocked' do
+    it 'counts nothing when every probe was blocked' do
       ActsAsTenant.with_tenant(company) do
-        create(:detector_result, report: report, detector: create(:detector), passed: 0, total: 4)
-        create(:detector_result, report: report, detector: create(:detector), passed: 0, total: 80)
+        create(:probe_result, report: report, probe: create(:probe), passed: 0, total: 4,
+                               any_detector_passed: false)
+        create(:probe_result, report: report, probe: create(:probe), passed: 0, total: 80,
+                               any_detector_passed: false)
       end
 
       expect(report.security_vulnerabilities_count).to eq(0)
     end
 
-    it 'counts a detector that was fully bypassed' do
+    it 'counts a probe that was fully bypassed' do
       ActsAsTenant.with_tenant(company) do
-        create(:detector_result, report: report, detector: create(:detector), passed: 80, total: 80)
+        create(:probe_result, report: report, probe: create(:probe), passed: 80, total: 80,
+                               any_detector_passed: true)
+      end
+
+      expect(report.security_vulnerabilities_count).to eq(1)
+    end
+
+    it 'counts a multi-detector probe where any_detector_passed is true even though the stored passed is 0' do
+      ActsAsTenant.with_tenant(company) do
+        create(:probe_result, report: report, probe: create(:probe), passed: 0, total: 10,
+                               any_detector_passed: true)
       end
 
       expect(report.security_vulnerabilities_count).to eq(1)

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1685,6 +1685,20 @@ RSpec.describe Report, type: :model do
       expect(report.security_vulnerabilities_count).to eq(1)
     end
 
+    # A rolling deploy can finish a report with an old worker after the any_detector_passed
+    # backfill has already run: that worker's insert omits the column, so it lands on the
+    # schema default (false) even when passed > 0 (db/schema.rb: default: false, null: false).
+    # The flag alone would then read "0 vulnerabilities" beside a nonzero successful-attack
+    # count -- the same contradiction this method exists to avoid, from the other direction.
+    it 'counts a probe with successful attacks even when any_detector_passed was never set' do
+      ActsAsTenant.with_tenant(company) do
+        create(:probe_result, report: report, probe: create(:probe), passed: 3, total: 10,
+                               any_detector_passed: false)
+      end
+
+      expect(report.security_vulnerabilities_count).to eq(1)
+    end
+
     # A variant child report records one probe_result row per (probe, threat_variant),
     # so the same base probe can appear on several rows -- see the fixture in
     # "a variant child report, whose rows are one per probe and variant"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe User, type: :model do
       expect(User.devise_modules).to include(:rememberable)
       expect(User.devise_modules).to include(:validatable)
     end
+
+    it 'does not expire inactive sessions' do
+      expect(User.devise_modules).not_to include(:timeoutable)
+    end
   end
 
   describe 'associations' do


### PR DESCRIPTION
Two deliberate product changes.

## "Vulnerabilities Found" counts probes, not detector rows

The metric counted `detector_results` rows with at least one successful attack. In practice that is near-binary: most 0din probes declare the same `0din.MitigationBypass` detector, so a report where one probe was bypassed and one where twenty were bypassed both read **1**.

It also disagreed with the page it appears on — `Scans::StatsSerializer#top_vulnerabilities_info` already counts probes via `any_detector_passed`, so the headline could read 1 beside a list enumerating ten bypassed probes.

It now counts distinct probes where at least one attack succeeded, and the glossary defines that unit precisely. Three refinements came out of review:

- **Distinct `probe_id`, not rows.** A variant child report legitimately stores one row per `(probe_id, threat_variant_id)`, so two successful variants of one base probe would otherwise read 2. A no-op for ordinary reports, which have a uniqueness constraint on that pair.
- **`any_detector_passed` OR `passed > 0`.** The column is `default: false, null: false`, so a worker finishing after the backfill migration during a rolling deploy inserts a row omitting it — leaving the flag false while `passed` is intact and positive. Those reports showed real successful attacks and a real ASR beside "Vulnerabilities Found: 0". The fallback cannot reintroduce an inconsistency, because `passed` is the same column the ASR and attack totals are computed from.
- **One case remains unrecoverable, and is documented in the code.** `6e86cca` introduced `any_detector_passed` and changed `probe_result.passed` from last-write-wins to max-wins in the same change. For reports processed before it, a probe bypassed by one detector but defended by a later-processed one ended up with `passed = 0`. Both columns derive from that corrupted write and the raw eval data is discarded after processing, so no fallback can reach it. Those reports stay uncounted — and stay coherent, since their ASR and attack totals read 0 from the same column.

## Sessions no longer expire on inactivity

Devise's `:timeoutable` and `config.timeout_in = 60.minutes` are removed, so users are no longer silently logged out after an hour idle. A spec pins the removal so it cannot be reintroduced without a deliberate decision.

Note: `config/locales/devise.en.yml`'s `devise.failure.timeout` string ("Your session expired…") is now unreachable — nothing else sets `flash[:timedout]`. Left in place rather than pruned as part of this change.

## Verification

Full RSpec 2985 examples with the 2 pre-existing `Target.count` DB-leak failures also present on `main` (verified by running those files against `main` directly); RuboCop clean. Every behavioural change is pinned by a test watched failing first, including fixtures that give a different answer under the previous implementation.
