### PR TITLE
fix(deploy): make documented deployment settings actually reach the container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,11 +9,29 @@ RUBY_YJIT_ENABLE=1  # Enable YJIT for ~2x performance boost (Ruby 3.3+)
 
 # Application Port
 PORT=80  # Host port the scanner is accessible on (container always listens on 80)
+         # NOT forwarded into the container on purpose: Puma reads PORT, so forwarding it
+         # would bind the app to the host port while the mapping still targets 80.
 
-# SSL Configuration
-ASSUME_SSL=false  # Set to true in production
+# Deployment / reverse proxy
+# Every variable in this block is read by config/environments/production.rb AND
+# forwarded by both Compose files. A variable absent from the Compose `environment:`
+# block never reaches the container no matter what this file says, so keep the two
+# in step -- spec/deployment/environment_passthrough_spec.rb fails when they drift.
+ASSUME_SSL=false  # true behind a TLS-terminating proxy; also decides whether the session cookie is issued Secure
+# RAILS_ALLOWED_HOSTS=scanner.example.com,10.0.0.5   # Comma-separated. Rails rejects any Host header not listed; unset allows localhost only
+# SESSION_COOKIE_DOMAIN=.example.com                 # Share the session cookie across subdomains
+# ACTION_CABLE_URL=wss://ws.example.com/cable        # Only when websockets are served from a different origin
+# TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12           # Comma-separated CIDRs whose X-Forwarded-For may be believed
 
 # PostgreSQL Configuration
+#
+# POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER and POSTGRES_PASSWORD are set by the
+# Compose files already. The ADVANCED settings below -- pool sizing, TLS, per-database
+# names, and the DATABASE_URL section -- are NOT yet forwarded: they reach the app only
+# if you add them to the `scanner` service's `environment:` block yourself. They move as
+# one deferred change rather than piecemeal, because a half-configurable database is
+# worse than a consistently manual one. spec/deployment/environment_passthrough_spec.rb
+# records the list so it cannot grow silently.
 # PostgreSQL runs as a separate container service (docker-compose postgres service)
 # POSTGRES_PASSWORD is required for production compose (docker-compose.yml)
 # For managed PostgreSQL (AWS RDS, Azure, Google Cloud SQL), also set POSTGRES_HOST

--- a/app/services/retention/simple_strategy.rb
+++ b/app/services/retention/simple_strategy.rb
@@ -33,7 +33,12 @@ module Retention
     private
 
     def retention_days
-      days = ENV.fetch("RETENTION_DAYS", DEFAULT_RETENTION_DAYS).to_i
+      # Strict Integer(), not String#to_i. This setting decides what gets DELETED, and
+      # to_i reads a partially-numeric "5oops" as 5 and a decimal "1.5" as 1 -- so a
+      # typo would quietly shorten retention rather than being rejected. Blank,
+      # unparseable and non-positive values all fall back to the default.
+      days = Integer(ENV["RETENTION_DAYS"].to_s.strip, exception: false).to_i
+      days = DEFAULT_RETENTION_DAYS unless days.positive?
       [ days, 1 ].max
     end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,6 @@
 require "active_support/core_ext/integer/time"
 require "logging"
+require "trusted_proxies"
 
 require "dotenv"
 env_file = Rails.root.join("storage", ".env")
@@ -60,7 +61,12 @@ Rails.application.configure do
   # Trust reverse proxies to read X-Forwarded-For for real client IPs.
   # Set TRUSTED_PROXIES as a comma-separated list of CIDRs in .env.
   # Example: TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12
-  trusted = ENV.fetch("TRUSTED_PROXIES", "").split(",").map(&:strip).reject(&:empty?)
+  #
+  # Parsed rather than passed through: see lib/trusted_proxies.rb for why raw
+  # strings matched nothing, and why an invalid entry is fatal instead of dropped.
+  # It lives in lib/ and is required at the top of this file because environment
+  # configuration runs before autoloading is available -- the same reason Logging is.
+  trusted = TrustedProxies.parse(ENV["TRUSTED_PROXIES"])
   config.action_dispatch.trusted_proxies = trusted if trusted.any?
 
   # Configure SSL options with localhost exception
@@ -125,7 +131,11 @@ Rails.application.configure do
   config.log_formatter = Logging::JSONFormatter.new
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+  # `.presence`, not `fetch`'s default: an operator who writes RAILS_LOG_LEVEL= with
+  # no value, or a Compose passthrough that forwards the variable as an empty string
+  # when it is unset, both hand this an empty string -- which fetch happily returns
+  # and Logger rejects with "invalid log level", taking down boot.
+  config.log_level = ENV["RAILS_LOG_LEVEL"].presence || "info"
 
   # Prevent health checks from clogging up the logs.
   config.silence_healthcheck_path = "/up"

--- a/dist/docker-compose.yml
+++ b/dist/docker-compose.yml
@@ -23,15 +23,38 @@ services:
     container_name: scanner
     image: ghcr.io/0din-ai/scanner:latest
     environment:
-      PLAYWRIGHT_BROWSERS_PATH: /opt/playwright-browsers
-      SECRET_KEY_BASE: "${SECRET_KEY_BASE:?Set SECRET_KEY_BASE in .env}"
-      SOLID_QUEUE_IN_PUMA: "true"
-      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
-      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
-      POSTGRES_USER: ${POSTGRES_USER:-scanner}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in environment or .env file}
-      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
-      ADMIN_INITIAL_PASSWORD: ${ADMIN_INITIAL_PASSWORD:?ADMIN_INITIAL_PASSWORD must be set in environment or .env file}
+      # Deployment settings the app reads at runtime.
+      #
+      # A .env file is only an INTERPOLATION source for Compose: a variable that is not
+      # named here never reaches the container, however carefully an operator sets it.
+      # Every name below was read by the app and silently inert -- ASSUME_SSL among them,
+      # which also decides whether the session cookie is issued with Secure.
+      #
+      # Listed BARE, without a value. That is Compose's pass-through-if-set form: it reads
+      # the value from the environment or .env, and when the variable is unset it is not
+      # placed in the container AT ALL. The `${VAR:-}` map form cannot express that -- it
+      # forwards an empty string, which would make every reader's empty-value behaviour
+      # load-bearing, and an empty log level fails Rails' bootstrap outright.
+      - ASSUME_SSL
+      - RAILS_ALLOWED_HOSTS
+      - SESSION_COOKIE_DOMAIN
+      - ACTION_CABLE_URL
+      - TRUSTED_PROXIES
+      - RAILS_LOG_LEVEL
+      - CLARITY_PROJECT_ID
+      - RETENTION_DAYS
+      - MAX_INTERRUPT_RETRIES
+      - DEBUG_LOG_TAIL_BYTES
+      # Values this file sets or defaults, rather than passes through.
+      - "PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers"
+      - "SECRET_KEY_BASE=${SECRET_KEY_BASE:?Set SECRET_KEY_BASE in .env}"
+      - "SOLID_QUEUE_IN_PUMA=true"
+      - "POSTGRES_HOST=${POSTGRES_HOST:-postgres}"
+      - "POSTGRES_PORT=${POSTGRES_PORT:-5432}"
+      - "POSTGRES_USER=${POSTGRES_USER:-scanner}"
+      - "POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in environment or .env file}"
+      - "ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}"
+      - "ADMIN_INITIAL_PASSWORD=${ADMIN_INITIAL_PASSWORD:?ADMIN_INITIAL_PASSWORD must be set in environment or .env file}"
     working_dir: /rails
     restart: always
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,14 +25,37 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      SECRET_KEY_BASE: "${SECRET_KEY_BASE:?Set SECRET_KEY_BASE in .env}"
-      SOLID_QUEUE_IN_PUMA: "true"
-      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
-      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
-      POSTGRES_USER: ${POSTGRES_USER:-scanner}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in environment or .env file}
-      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
-      ADMIN_INITIAL_PASSWORD: ${ADMIN_INITIAL_PASSWORD:?ADMIN_INITIAL_PASSWORD must be set in environment or .env file}
+      # Deployment settings the app reads at runtime.
+      #
+      # A .env file is only an INTERPOLATION source for Compose: a variable that is not
+      # named here never reaches the container, however carefully an operator sets it.
+      # Every name below was read by the app and silently inert -- ASSUME_SSL among them,
+      # which also decides whether the session cookie is issued with Secure.
+      #
+      # Listed BARE, without a value. That is Compose's pass-through-if-set form: it reads
+      # the value from the environment or .env, and when the variable is unset it is not
+      # placed in the container AT ALL. The `${VAR:-}` map form cannot express that -- it
+      # forwards an empty string, which would make every reader's empty-value behaviour
+      # load-bearing, and an empty log level fails Rails' bootstrap outright.
+      - ASSUME_SSL
+      - RAILS_ALLOWED_HOSTS
+      - SESSION_COOKIE_DOMAIN
+      - ACTION_CABLE_URL
+      - TRUSTED_PROXIES
+      - RAILS_LOG_LEVEL
+      - CLARITY_PROJECT_ID
+      - RETENTION_DAYS
+      - MAX_INTERRUPT_RETRIES
+      - DEBUG_LOG_TAIL_BYTES
+      # Values this file sets or defaults, rather than passes through.
+      - "SECRET_KEY_BASE=${SECRET_KEY_BASE:?Set SECRET_KEY_BASE in .env}"
+      - "SOLID_QUEUE_IN_PUMA=true"
+      - "POSTGRES_HOST=${POSTGRES_HOST:-postgres}"
+      - "POSTGRES_PORT=${POSTGRES_PORT:-5432}"
+      - "POSTGRES_USER=${POSTGRES_USER:-scanner}"
+      - "POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in environment or .env file}"
+      - "ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}"
+      - "ADMIN_INITIAL_PASSWORD=${ADMIN_INITIAL_PASSWORD:?ADMIN_INITIAL_PASSWORD must be set in environment or .env file}"
     working_dir: /rails
     restart: always
     stdin_open: true

--- a/lib/trusted_proxies.rb
+++ b/lib/trusted_proxies.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "ipaddr"
+
+# Parses the TRUSTED_PROXIES setting into the objects Rails actually matches against.
+#
+# ActionDispatch::RemoteIp matches with `proxy === ip`. String#=== is equality, so a
+# list of raw strings meant the documented CIDR form ("10.0.0.0/8") matched no address
+# at all -- and because a custom list REPLACES Rails' RFC1918 defaults, an operator who
+# set this ended up trusting fewer proxies than one who never did, losing real client
+# IPs rather than resolving them.
+module TrustedProxies
+  class InvalidEntry < StandardError; end
+
+  module_function
+
+  # Returns [] for a blank setting, so the caller leaves Rails' defaults in place.
+  #
+  # Any unparseable entry raises. This is a security control read once at boot: an
+  # operator who mistypes one CIDR should find out immediately, not months later from
+  # wrong client IPs in an audit trail. Dropping the bad entry instead would leave the
+  # control silently half-applied, and dropping ALL of them would fall back to Rails'
+  # broader defaults -- trusting MORE than the operator asked for, which is the one
+  # direction a proxy allowlist must never fail in.
+  def parse(raw)
+    entries = raw.to_s.split(",").map(&:strip).reject(&:empty?)
+
+    entries.map do |entry|
+      IPAddr.new(entry)
+    rescue IPAddr::Error => e
+      raise InvalidEntry, "TRUSTED_PROXIES entry #{entry.inspect} is not a valid IP or CIDR: #{e.message}"
+    end
+  end
+end

--- a/spec/deployment/environment_passthrough_spec.rb
+++ b/spec/deployment/environment_passthrough_spec.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "yaml"
+
+# A .env file is only an INTERPOLATION source for Compose. A variable that is not named
+# in a service's `environment:` block never reaches the container, however carefully an
+# operator sets it -- so a setting can be documented, read by the app, and still be inert
+# in every deployment. ASSUME_SSL was exactly that, and it decides whether the session
+# cookie is issued with Secure.
+#
+# The contract this pins: a variable .env.example advertises AND the app reads is either
+# forwarded by BOTH Compose files, or listed below as deliberately not forwarded with a
+# reason. Nothing may sit in the gap silently.
+RSpec.describe "deployment environment passthrough" do
+  COMPOSE_FILES = %w[docker-compose.yml dist/docker-compose.yml].freeze
+
+  FORWARDED_VARIABLES = %w[
+    ASSUME_SSL
+    RAILS_ALLOWED_HOSTS
+    SESSION_COOKIE_DOMAIN
+    ACTION_CABLE_URL
+    TRUSTED_PROXIES
+    RAILS_LOG_LEVEL
+    CLARITY_PROJECT_ID
+    RETENTION_DAYS
+    MAX_INTERRUPT_RETRIES
+    DEBUG_LOG_TAIL_BYTES
+  ].freeze
+
+  # Advertised and read, but deliberately NOT forwarded. Each entry is a decision, not an
+  # oversight, and .env.example says so where an operator will see it.
+  NOT_FORWARDED = {
+    # Puma reads PORT. Forwarding it would bind the app to the HOST port while the
+    # published mapping still targets container port 80, making the app unreachable.
+    "PORT" => "host-side port mapping",
+    # Database configuration is deferred as ONE cohesive change rather than because
+    # every member is individually blocked. Some are empty-safe today and could be
+    # forwarded now; the per-database URL overrides are not (`ENV["DATABASE_QUEUE_URL"]
+    # || ...` lets an empty value suppress the automatic suffix), and the database
+    # names and pool settings need defaults decided. Splitting the group across two
+    # releases would leave a half-configurable database, so it moves together.
+    "DATABASE_URL" => "database configuration, deferred as a group",
+    "DATABASE_QUEUE_URL" => "database configuration, deferred as a group",
+    "DATABASE_CACHE_URL" => "database configuration, deferred as a group",
+    "DATABASE_CABLE_URL" => "database configuration, deferred as a group",
+    "POSTGRES_PRIMARY_DB" => "database configuration, deferred as a group",
+    "POSTGRES_CACHE_DB" => "database configuration, deferred as a group",
+    "POSTGRES_QUEUE_DB" => "database configuration, deferred as a group",
+    "POSTGRES_CABLE_DB" => "database configuration, deferred as a group",
+    "POSTGRES_POOL_SIZE" => "database configuration, deferred as a group",
+    "POSTGRES_POOL_TIMEOUT" => "database configuration, deferred as a group",
+    "POSTGRES_SSL_MODE" => "database configuration, deferred as a group",
+    "POSTGRES_SSL_CERT" => "database configuration, deferred as a group",
+    "POSTGRES_SSL_KEY" => "database configuration, deferred as a group",
+    "POSTGRES_SSL_ROOT_CERT" => "database configuration, deferred as a group"
+  }.freeze
+
+  # The raw `environment:` entries for the scanner service, as written. List form is
+  # what makes pass-through-if-set possible, so the shape matters and is not normalised
+  # away here.
+  def scanner_environment(path)
+    entries = YAML.load_file(Rails.root.join(path), aliases: true)
+                  .fetch("services").fetch("scanner").fetch("environment")
+    raise "#{path} must use list form for environment, found #{entries.class}" unless entries.is_a?(Array)
+
+    entries
+  end
+
+  def passthrough_names(path)
+    scanner_environment(path).reject { |entry| entry.to_s.include?("=") }
+  end
+
+  def assigned_names(path)
+    scanner_environment(path).select { |entry| entry.to_s.include?("=") }
+                             .map { |entry| entry.split("=", 2).first }
+  end
+
+  def all_names(path)
+    passthrough_names(path) + assigned_names(path)
+  end
+
+  def env_example
+    @env_example ||= Rails.root.join(".env.example").read
+  end
+
+  # Variables .env.example presents as settings, whether live or commented out.
+  def advertised_variables
+    env_example.scan(/^\s*#?\s*([A-Z][A-Z0-9_]{2,})=/).flatten.uniq
+  end
+
+  # Ruby, Python and ERB/YAML all read the environment differently, and a scan that
+  # knows only Ruby's spelling reports a variable as unread when db_notifier.py or
+  # database.yml is the thing consuming it.
+  ENV_READ_PATTERNS = [
+    /ENV(?:\.fetch\(|\[)["']([A-Z0-9_]+)["']/,          # Ruby, including inside ERB
+    /os\.environ(?:\.get\(|\[)["']([A-Z0-9_]+)["']/,     # Python
+    /os\.getenv\(["']([A-Z0-9_]+)["']/                    # Python
+  ].freeze
+
+  def variables_read_by_app
+    Dir.glob(Rails.root.join("{app,config,db,lib,script}/**/*.{rb,erb,py,yml,yaml}"))
+       .flat_map { |file| ENV_READ_PATTERNS.flat_map { |pattern| File.read(file).scan(pattern) } }
+       .flatten.uniq
+  end
+
+  COMPOSE_FILES.each do |path|
+    context path do
+      FORWARDED_VARIABLES.each do |name|
+        it "passes #{name} through only when it is set" do
+          # A bare name, not `NAME=${NAME:-}`. The assigned form would place an EMPTY
+          # STRING in the container for an unset variable, which makes every reader's
+          # empty-value behaviour load-bearing -- an empty log level fails Rails'
+          # bootstrap outright. A hardcoded value would also satisfy a presence check
+          # while pinning every deployment to a constant.
+          expect(passthrough_names(path)).to include(name),
+            "#{name} must appear as a bare `- #{name}` in #{path}; found " \
+            "#{scanner_environment(path).grep(/\A#{name}[=\z]/).inspect}"
+        end
+      end
+
+      NOT_FORWARDED.each_key do |name|
+        it "does not forward #{name}" do
+          expect(all_names(path)).not_to include(name),
+            "#{name} is listed as deliberately not forwarded; remove it from NOT_FORWARDED " \
+            "if that decision has changed"
+        end
+      end
+    end
+  end
+
+  it "documents every forwarded variable in .env.example" do
+    undocumented = FORWARDED_VARIABLES.reject { |name| env_example.match?(/^\s*#?\s*#{name}=/) }
+
+    expect(undocumented).to be_empty,
+      "reaches the container but nothing tells an operator it exists: #{undocumented.join(', ')}"
+  end
+
+  it "leaves no advertised, app-read variable unaccounted for" do
+    # The rule that keeps the gap from growing back: anything an operator can read about
+    # in .env.example and that the app actually consumes is either forwarded or a
+    # recorded decision not to forward.
+    # Subtracted per file, so a name present in only ONE Compose file cannot hide the
+    # drift in the other.
+    accounted = FORWARDED_VARIABLES + NOT_FORWARDED.keys +
+                COMPOSE_FILES.map { |path| all_names(path) }.reduce(:&)
+    read = variables_read_by_app
+    unaccounted = advertised_variables.select { |name| read.include?(name) } - accounted
+
+    expect(unaccounted).to be_empty,
+      "advertised in .env.example and read by the app, but neither forwarded nor listed " \
+      "as deliberately excluded: #{unaccounted.join(', ')}"
+  end
+
+  describe "a variable an operator sets to nothing" do
+    # Pass-through-if-set keeps an UNSET variable out of the container entirely, but an
+    # operator can still write `RETENTION_DAYS=` in .env, which forwards an empty string.
+    # Readers of forwarded values have to survive that.
+    it "leaves the log level valid rather than failing boot" do
+      # ENV.fetch's default does NOT apply to an empty string, and an empty level fails
+      # Rails' bootstrap with `wrong constant name` -- the app does not start at all.
+      expect(Rails.root.join("config/environments/production.rb").read)
+        .to include('ENV["RAILS_LOG_LEVEL"].presence || "info"')
+      expect { Logger.new(IO::NULL).level = "" }.to raise_error(ArgumentError, /invalid log level/)
+    end
+  end
+
+  describe Retention::SimpleStrategy, "RETENTION_DAYS parsing" do
+    # This setting decides what gets DELETED, so every malformed value must fall back to
+    # the default rather than be partially believed.
+    def resolved_days(value)
+      ClimateControl.modify(RETENTION_DAYS: value) do
+        described_class.new.send(:retention_days)
+      end
+    rescue NameError, NoMethodError
+      # No ClimateControl in this suite; drive ENV directly and restore.
+      previous = ENV["RETENTION_DAYS"]
+      value.nil? ? ENV.delete("RETENTION_DAYS") : ENV["RETENTION_DAYS"] = value
+      begin
+        described_class.new.send(:retention_days)
+      ensure
+        previous.nil? ? ENV.delete("RETENTION_DAYS") : ENV["RETENTION_DAYS"] = previous
+      end
+    end
+
+    {
+      nil => "unset",
+      "" => "empty",
+      "   " => "whitespace",
+      "abc" => "non-numeric",
+      "5oops" => "partially numeric",
+      "1.5" => "decimal",
+      "0" => "zero",
+      "-7" => "negative"
+    }.each do |value, description|
+      it "falls back to the default for a #{description} value" do
+        expect(resolved_days(value)).to eq(described_class::DEFAULT_RETENTION_DAYS)
+      end
+    end
+
+    it "honours a valid positive value" do
+      expect(resolved_days("30")).to eq(30)
+    end
+  end
+
+  describe TrustedProxies do
+    # RemoteIp matches with `proxy === ip`. String#=== is equality, so a list of raw
+    # strings matched no address -- and since a custom list REPLACES Rails' RFC1918
+    # defaults, setting it left an operator trusting FEWER proxies than not setting it.
+    it "parses CIDRs into objects that actually match addresses" do
+      expect("10.0.0.0/8" === "10.1.2.3").to be(false)
+
+      parsed = described_class.parse("10.0.0.0/8,172.16.0.0/12")
+
+      expect(parsed.map(&:class)).to all(eq(IPAddr))
+      expect(parsed.any? { |proxy| proxy === "10.1.2.3" }).to be(true)
+      expect(parsed.any? { |proxy| proxy === "192.0.2.1" }).to be(false)
+    end
+
+    it "returns nothing for a blank setting, leaving Rails' defaults alone" do
+      expect(described_class.parse(nil)).to eq([])
+      expect(described_class.parse("")).to eq([])
+      expect(described_class.parse("  , ")).to eq([])
+    end
+
+    it "rejects a list containing an invalid entry" do
+      # Not dropped: half-applying a proxy allowlist leaves the control silently wrong.
+      expect { described_class.parse("10.0.0.0/8,nonsense") }
+        .to raise_error(TrustedProxies::InvalidEntry, /nonsense/)
+    end
+
+    it "rejects a wholly invalid list rather than falling back to broader defaults" do
+      # Skipping assignment here would restore Rails' RFC1918 defaults -- trusting MORE
+      # than the operator asked for, the one direction an allowlist must never fail in.
+      expect { described_class.parse("nonsense") }.to raise_error(TrustedProxies::InvalidEntry)
+    end
+  end
+end


### PR DESCRIPTION
A `.env` file is only an interpolation source for Compose. A variable not named in a service's `environment:` block never reaches the container, however carefully an operator sets it — so a setting can be documented, read by the app, and inert in every deployment.

**`ASSUME_SSL` was exactly that.** `.env.example` tells operators to set it in production, `production.rb` reads it in three places, and neither Compose file passed it through. Behind a TLS-terminating proxy that means `config.assume_ssl` stayed false and the session cookie was issued **without `Secure`**, while the documentation said otherwise.

`RAILS_ALLOWED_HOSTS`, `SESSION_COOKIE_DOMAIN`, `ACTION_CABLE_URL` and `TRUSTED_PROXIES` were worse off again — read by the app, forwarded by neither file, documented nowhere. `RAILS_LOG_LEVEL`, `CLARITY_PROJECT_ID`, `RETENTION_DAYS`, `MAX_INTERRUPT_RETRIES` and `DEBUG_LOG_TAIL_BYTES` were documented but not forwarded.

All ten now reach the container from both Compose files, as **bare names in list form** — Compose's pass-through-if-set spelling, where an unset variable is left out of the container entirely. The `NAME: ${NAME:-}` alternative forwards an empty string instead, which would make every reader's empty-value handling load-bearing; an empty log level fails Rails' bootstrap outright, so the app would not start at all.

### Two readers were wrong independently of how the value arrives

**`TRUSTED_PROXIES` never worked as documented.** The value was split into strings and handed to Rails, but `RemoteIp` matches with `proxy === ip` and `String#===` is equality, so `"10.0.0.0/8"` matched no address. Because a custom list *replaces* Rails' RFC1918 defaults, an operator who set it trusted **fewer** proxies than one who never did. Entries are now parsed as `IPAddr`, and an invalid one stops boot — half-applying a proxy allowlist leaves the control silently wrong, and dropping every entry of a non-blank list would fall back to those broader defaults, trusting *more* than was asked for.

**`RETENTION_DAYS` parsed with `String#to_i`**, which reads `"5oops"` as 5 and `"1.5"` as 1. This setting decides what gets deleted and was previously inert, so making it effective without strict parsing would let a typo quietly shorten retention.

### Deliberately not included

`PORT` stays unforwarded — Puma reads it, so forwarding would bind the app to the host port while the published mapping still targets 80. The advanced database group (pool sizing, TLS, per-database names, `DATABASE_URL`) moves as one later change. Both are marked in `.env.example` where an operator will see them, rather than reading as supported.

### Verification

Verified in a production-mode boot with the settings a `.env` would supply: `assume_ssl=true`, `cookie_secure=true`, trusted proxies parsed to `IPAddr` and matching, `RAILS_ALLOWED_HOSTS` applied, retention honoured, and an unset variable falling back to its default rather than arriving empty. An invalid proxy entry stops boot naming the entry.