### PR TITLE
security(browser): re-screen every browser request against the URL blocklist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,6 +173,7 @@ COPY --from=build /rails/RELEASE_NOTES.md* /rails/
 # Install custom garak plugins (OpenRouter + WebChatbot generators, 0din probes & detectors)
 COPY --from=build /rails/script/garak_plugins/openrouter.py /opt/venv/lib/python3.13/site-packages/garak/generators/openrouter.py
 COPY --from=build /rails/script/garak_plugins/web_chatbot.py /opt/venv/lib/python3.13/site-packages/garak/generators/web_chatbot.py
+COPY --from=build /rails/script/garak_plugins/_network_guard.py /opt/venv/lib/python3.13/site-packages/garak/generators/_network_guard.py
 COPY --from=build /rails/script/garak_plugins/probes/0din.py /opt/venv/lib/python3.13/site-packages/garak/probes/0din.py
 COPY --from=build /rails/script/garak_plugins/probes/0din_variants.py /opt/venv/lib/python3.13/site-packages/garak/probes/0din_variants.py
 COPY --from=build /rails/script/garak_plugins/detectors/0din.py /opt/venv/lib/python3.13/site-packages/garak/detectors/0din.py

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -89,6 +89,7 @@ RUN GARAK_SITE=$(/opt/venv/bin/python -c "import site; print([p for p in site.ge
     mkdir -p "$GARAK_SITE/garak/generators" "$GARAK_SITE/garak/probes" "$GARAK_SITE/garak/detectors" && \
     cp script/garak_plugins/openrouter.py "$GARAK_SITE/garak/generators/openrouter.py" && \
     cp script/garak_plugins/web_chatbot.py "$GARAK_SITE/garak/generators/web_chatbot.py" && \
+    cp script/garak_plugins/_network_guard.py "$GARAK_SITE/garak/generators/_network_guard.py" && \
     cp script/garak_plugins/probes/0din.py "$GARAK_SITE/garak/probes/0din.py" && \
     cp script/garak_plugins/probes/0din_variants.py "$GARAK_SITE/garak/probes/0din_variants.py" && \
     cp script/garak_plugins/detectors/0din.py "$GARAK_SITE/garak/detectors/0din.py" && \

--- a/app/services/browser_automation/network_guard.rb
+++ b/app/services/browser_automation/network_guard.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+module BrowserAutomation
+  # Keeps UrlSafetyValidator's blocklist in force for a browser's whole navigation
+  # lifetime, not just the URL we hand to page.goto().
+  #
+  # PlaywrightService validates the initial URL, but nothing re-checks where the
+  # browser ends up afterwards: an HTTP redirect from the target, or JavaScript on
+  # the target's own page (fetch/XHR/window.location/iframes/sub-resources), can
+  # steer it to a destination that was never screened. Since the browser runs in
+  # the same container as Rails, that reaches whatever the container can reach.
+  #
+  # This module emits a `context.route()` handler that re-resolves and re-screens
+  # the host of every request the browser makes, against the CIDR list that
+  # UrlSafetyValidator already owns. Requests to a blocked address are aborted.
+  #
+  # Screening the request URL alone is NOT enough: Chromium follows 3xx responses
+  # internally and does not re-invoke route handlers for the redirected hop, for
+  # navigations and sub-resources alike. So the handler also walks the redirect
+  # chain itself (route.fetch with maxRedirects: 0), screens every hop, and only
+  # then hands the final response to the browser.
+  #
+  # Known limits, deliberately not papered over:
+  #   * TOCTOU remains. The guard resolves the host and Chromium resolves it
+  #     again for the connection it actually opens; a DNS record that flips
+  #     between the two can still slip past. This narrows the window from
+  #     "once per scan" to "once per request", which is the most an app-layer
+  #     check can do. Network-level egress control is the real fix.
+  #   * WebSocket handshakes are not intercepted by route(), so ws:// and wss://
+  #     are not covered here.
+  #   * Server-Sent Events are host-screened but not redirect-screened: buffering
+  #     them through route.fetch() would hold the stream open forever and hang
+  #     any chat target that streams tokens.
+  module NetworkGuard
+    module_function
+
+    # Payload consumed by GUARD_JS. Passed through the data file rather than
+    # interpolated into the script, like every other value in these scripts.
+    def payload(allow_localhost: nil)
+      allow = allow_localhost.nil? ? UrlSafetyValidator.allow_localhost? : allow_localhost
+      {
+        "blocked_cidrs" => UrlSafetyValidator.blocked_cidrs,
+        "allow_loopback" => !!allow
+      }
+    end
+
+    # Defines __installNetworkGuard(context, guard). Returns a handle whose
+    # .blocked() lists what was aborted, for the caller to report back to Rails.
+    #
+    # Fails closed: a missing, empty, or unparsable blocklist raises before any
+    # navigation happens, rather than silently running an unguarded browser.
+    GUARD_JS = <<~JS
+      const __dnsPromises = require('dns').promises;
+
+      const MAX_REDIRECTS = 20;
+
+      const __netGuard = {
+        parseIp(input) {
+          let s = String(input == null ? '' : input).trim();
+          if (s.startsWith('[') && s.endsWith(']')) s = s.slice(1, -1);
+          const zone = s.indexOf('%');
+          if (zone !== -1) s = s.slice(0, zone);
+          if (s.length === 0) return null;
+          return s.includes(':') ? __netGuard.parseIpv6(s) : __netGuard.parseIpv4(s);
+        },
+
+        parseIpv4(s) {
+          const parts = s.split('.');
+          if (parts.length !== 4) return null;
+          let n = 0n;
+          for (const part of parts) {
+            if (!/^[0-9]{1,3}$/.test(part)) return null;
+            const value = Number(part);
+            if (value > 255) return null;
+            n = (n << 8n) | BigInt(value);
+          }
+          return { version: 4, value: n };
+        },
+
+        parseIpv6(s) {
+          // Split an embedded IPv4 tail (::ffff:127.0.0.1) into two more groups.
+          let tail = [];
+          const lastColon = s.lastIndexOf(':');
+          const suffix = s.slice(lastColon + 1);
+          if (suffix.includes('.')) {
+            const v4 = __netGuard.parseIpv4(suffix);
+            if (!v4) return null;
+            tail = [ Number((v4.value >> 16n) & 0xffffn), Number(v4.value & 0xffffn) ];
+            s = s.slice(0, lastColon + 1) + '0:0';
+          }
+
+          const halves = s.split('::');
+          if (halves.length > 2) return null;
+
+          const toGroups = (text) => {
+            if (text === '') return [];
+            const out = [];
+            for (const group of text.split(':')) {
+              if (!/^[0-9a-fA-F]{1,4}$/.test(group)) return null;
+              out.push(parseInt(group, 16));
+            }
+            return out;
+          };
+
+          let head = toGroups(halves[0]);
+          let rest = halves.length === 2 ? toGroups(halves[1]) : [];
+          if (head === null || rest === null) return null;
+          if (tail.length) {
+            // The '0:0' placeholder stood in for the IPv4 tail; drop it and append.
+            const target = halves.length === 2 ? rest : head;
+            target.splice(target.length - 2, 2, tail[0], tail[1]);
+          }
+
+          let groups;
+          if (halves.length === 2) {
+            const fill = 8 - head.length - rest.length;
+            if (fill < 0) return null;
+            groups = head.concat(new Array(fill).fill(0), rest);
+          } else {
+            groups = head;
+          }
+          if (groups.length !== 8) return null;
+
+          let n = 0n;
+          for (const group of groups) n = (n << 16n) | BigInt(group);
+
+          // Normalize IPv4-mapped/compatible to v4 so ::ffff:10.0.0.1 is screened
+          // against the IPv4 ranges rather than sailing past them.
+          const high = n >> 32n;
+          const low = n & 0xffffffffn;
+          // ::ffff:a.b.c.d is always a mapped v4. ::a.b.c.d is the deprecated
+          // compat form, but :: and ::1 are v6 addresses in their own right.
+          if (high === 0xffffn) return { version: 4, value: low };
+          if (high === 0n && low !== 0n && low !== 1n) return { version: 4, value: low };
+          return { version: 6, value: n };
+        },
+
+        parseCidr(text) {
+          const slash = String(text).lastIndexOf('/');
+          if (slash === -1) return null;
+          const base = __netGuard.parseIp(String(text).slice(0, slash));
+          const prefix = Number(String(text).slice(slash + 1));
+          if (!base || !Number.isInteger(prefix) || prefix < 0) return null;
+          const width = base.version === 4 ? 32 : 128;
+          if (prefix > width) return null;
+          const shift = BigInt(width - prefix);
+          return { version: base.version, network: base.value >> shift, shift };
+        },
+
+        contains(range, ip) {
+          if (range.version !== ip.version) return false;
+          return (ip.value >> range.shift) === range.network;
+        }
+      };
+
+      async function __installNetworkGuard(context, guard) {
+        const cidrs = (guard && guard.blocked_cidrs) || [];
+        if (!Array.isArray(cidrs) || cidrs.length === 0) {
+          throw new Error('network guard: blocklist missing - refusing to browse unguarded');
+        }
+        const ranges = cidrs.map(__netGuard.parseCidr);
+        const badIndex = ranges.findIndex((range) => range === null);
+        if (badIndex !== -1) {
+          throw new Error('network guard: unparsable CIDR ' + cidrs[badIndex]);
+        }
+
+        const loopback = [ '127.0.0.0/8', '::1/128' ].map(__netGuard.parseCidr);
+        const allowLoopback = guard.allow_loopback === true;
+        const blocked = [];
+        const decisions = new Map();
+
+        const hostAllowed = async (host) => {
+          if (decisions.has(host)) return decisions.get(host);
+
+          const verdict = await (async () => {
+            let addresses;
+            const literal = __netGuard.parseIp(host);
+            if (literal) {
+              addresses = [ literal ];
+            } else {
+              let looked;
+              try {
+                looked = await __dnsPromises.lookup(host, { all: true, verbatim: true });
+              } catch (error) {
+                return { allowed: false, reason: 'could not resolve ' + host };
+              }
+              addresses = looked.map((entry) => __netGuard.parseIp(entry.address)).filter(Boolean);
+            }
+            // No usable address is a fail-closed case, same as the Ruby validator.
+            if (!addresses.length) return { allowed: false, reason: 'could not resolve ' + host };
+
+            for (const address of addresses) {
+              for (const range of ranges) {
+                if (!__netGuard.contains(range, address)) continue;
+                if (allowLoopback && loopback.some((lo) => __netGuard.contains(lo, address))) continue;
+                return { allowed: false, reason: 'blocked internal address' };
+              }
+            }
+            return { allowed: true };
+          })();
+
+          decisions.set(host, verdict);
+          return verdict;
+        };
+
+        // Screen one URL. Returns null when allowed, or a rejection reason.
+        const screen = async (url) => {
+          let parsed;
+          try {
+            parsed = new URL(url);
+          } catch (error) {
+            return 'unparsable URL';
+          }
+          if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            return 'scheme ' + parsed.protocol;
+          }
+          const verdict = await hostAllowed(parsed.hostname);
+          return verdict.allowed ? null : verdict.reason;
+        };
+
+        const deny = (route, url, reason) => {
+          blocked.push({ url: String(url).slice(0, 200), reason });
+          return route.abort('blockedbyclient');
+        };
+
+        await context.route('**/*', async (route) => {
+          const request = route.request();
+          const url = request.url();
+
+          // data:/blob:/about: never leave the renderer, so they need no screening.
+          if (/^(data|blob|about):/.test(url)) return route.continue();
+
+          const reason = await screen(url);
+          if (reason) return deny(route, url, reason);
+
+          // Server-Sent Events must stay streaming; route.fetch() would buffer the
+          // response and hang the connection open forever. Host-screened only.
+          const accept = (request.headers()['accept'] || '').toLowerCase();
+          if (accept.includes('text/event-stream')) return route.continue();
+
+          // Chromium follows 3xx internally and does NOT re-invoke route handlers
+          // for the redirected hop (verified on Playwright 1.59 for both navigation
+          // and sub-resource requests), so screening only the request URL leaves the
+          // redirect pivot wide open. Walk the chain here instead, screening every
+          // hop, and hand the browser the final response.
+          let current = url;
+          let response;
+          try {
+            response = await route.fetch({ maxRedirects: 0 });
+            for (let hop = 0; hop < MAX_REDIRECTS; hop++) {
+              const status = response.status();
+              if (status < 300 || status > 399) break;
+
+              const location = response.headers()['location'];
+              if (!location) break;
+
+              const next = new URL(location, current).toString();
+              const nextReason = await screen(next);
+              if (nextReason) return deny(route, next, 'redirect to ' + nextReason);
+
+              current = next;
+              response = await route.fetch({ url: next, maxRedirects: 0 });
+              if (hop === MAX_REDIRECTS - 1) return deny(route, next, 'too many redirects');
+            }
+          } catch (error) {
+            return route.abort('failed');
+          }
+
+          return route.fulfill({ response });
+        });
+
+        return { blocked: () => blocked };
+      }
+    JS
+  end
+end

--- a/app/services/browser_automation/playwright_service.rb
+++ b/app/services/browser_automation/playwright_service.rb
@@ -32,13 +32,14 @@ module BrowserAutomation
         url: url,
         output_path: output_path.to_s,
         wait_until: options[:wait_until] || "networkidle",
-        type: options[:type] || "png"
+        type: options[:type] || "png",
+        network_guard: NetworkGuard.payload
       }
 
       script = <<~JS
         const { chromium } = require('playwright');
         const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
-
+        #{NetworkGuard::GUARD_JS}
         (async () => {
           const browser = await chromium.launch({
             headless: true,
@@ -49,6 +50,7 @@ module BrowserAutomation
             const context = await browser.newContext({
               viewport: { width: #{(options[:width] || 1920).to_i}, height: #{(options[:height] || 1080).to_i} }
             });
+            const __guard = await __installNetworkGuard(context, __data.network_guard);
             const page = await context.newPage();
 
             await page.goto(__data.url, {
@@ -62,7 +64,7 @@ module BrowserAutomation
               type: __data.type
             });
 
-            console.log(JSON.stringify({ success: true, path: __data.output_path }));
+            console.log(JSON.stringify({ success: true, path: __data.output_path, blocked_requests: __guard.blocked() }));
           } catch (error) {
             console.error(JSON.stringify({ error: error.message }));
             process.exitCode = 1;
@@ -81,6 +83,10 @@ module BrowserAutomation
       end
     end
 
+    # No NetworkGuard here on purpose: this renders Scanner's own report URL, not a
+    # tenant-supplied one, and the app is routinely reachable only on a container
+    # address that the blocklist covers (RFC1918). Guarding it would block Scanner
+    # from rendering its own pages. The tenant-driven surfaces are guarded instead.
     def generate_pdf(url, output_path = nil, options = {})
       validate_url_safety!(url, allow_localhost: options[:allow_localhost])
       output_path ||= generate_pdf_path
@@ -163,13 +169,14 @@ module BrowserAutomation
         container_selector: container_selector,
         send_selector: (send_selector.present? && send_selector != "null") ? send_selector : nil,
         test_message: test_message,
-        auth: auth_payload(config[:auth] || config["auth"])
+        auth: auth_payload(config[:auth] || config["auth"]),
+        network_guard: NetworkGuard.payload
       }
 
       script = <<~JS
         const { chromium } = require('playwright');
         const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
-
+        #{NetworkGuard::GUARD_JS}
         (async () => {
           const browser = await chromium.launch({
             headless: true,
@@ -183,6 +190,7 @@ module BrowserAutomation
               ...(__auth.storage_state ? { storageState: __auth.storage_state } : {}),
               extraHTTPHeaders: Object.assign({}, __auth.headers || {})
             });
+            const __guard = await __installNetworkGuard(context, __data.network_guard);
             if (Array.isArray(__auth.cookies) && __auth.cookies.length) {
               await context.addCookies(__auth.cookies);
             }
@@ -248,7 +256,8 @@ module BrowserAutomation
               console.log(JSON.stringify({
                 success: false,
                 errors: errors,
-                response_detected: false
+                response_detected: false,
+                blocked_requests: __guard.blocked()
               }));
               await browser.close();
               return;
@@ -287,7 +296,8 @@ module BrowserAutomation
               console.log(JSON.stringify({
                 success: false,
                 errors: errors,
-                response_detected: false
+                response_detected: false,
+                blocked_requests: __guard.blocked()
               }));
               await browser.close();
               return;
@@ -305,7 +315,8 @@ module BrowserAutomation
               response_detected: contentChanged,
               test_message_found: testMessagePresent,
               baseline_length: baselineHistory.length,
-              new_length: newHistory.length
+              new_length: newHistory.length,
+              blocked_requests: __guard.blocked()
             }));
 
           } catch (error) {
@@ -345,13 +356,14 @@ module BrowserAutomation
       data = {
         url: url,
         user_agent: options[:user_agent] || "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-        auth: auth_payload(options[:auth])
+        auth: auth_payload(options[:auth]),
+        network_guard: NetworkGuard.payload
       }
 
       script = <<~JS
         const { chromium } = require('playwright');
         const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
-
+        #{NetworkGuard::GUARD_JS}
         (async () => {
           const browser = await chromium.launch({
             headless: true,
@@ -366,6 +378,7 @@ module BrowserAutomation
               ...(__auth.storage_state ? { storageState: __auth.storage_state } : {}),
               extraHTTPHeaders: Object.assign({}, __auth.headers || {})
             });
+            const __guard = await __installNetworkGuard(context, __data.network_guard);
             if (Array.isArray(__auth.cookies) && __auth.cookies.length) {
               await context.addCookies(__auth.cookies);
             }
@@ -531,7 +544,7 @@ module BrowserAutomation
               screenshot: screenshotBase64
             };
 
-            console.log(JSON.stringify({ success: true, data: result }));
+            console.log(JSON.stringify({ success: true, data: result, blocked_requests: __guard.blocked() }));
           } catch (error) {
             console.error(JSON.stringify({ error: error.message }));
             process.exitCode = 1;
@@ -574,6 +587,19 @@ module BrowserAutomation
     end
 
     private
+
+    # Surface what the in-browser guard aborted. These are requests the target tried
+    # to make to an internal address after its URL had already passed validation, so
+    # they are worth seeing even when the overall operation succeeded.
+    def log_blocked_requests(result)
+      blocked = result.is_a?(Hash) ? result["blocked_requests"] : nil
+      return if blocked.blank?
+
+      Rails.logger.warn(
+        "PlaywrightService: network guard blocked #{blocked.size} request(s): " \
+        "#{blocked.map { |b| "#{b['reason']} #{b['url']}" }.join('; ')}"
+      )
+    end
 
     def validate_url_safety!(url, allow_localhost: nil)
       allow = allow_localhost.nil? ? UrlSafetyValidator.allow_localhost? : allow_localhost
@@ -657,6 +683,7 @@ module BrowserAutomation
           if status.success?
             result = extract_json.call(output)
             if result
+              log_blocked_requests(result)
               result
             else
               Rails.logger.error "No JSON found in Playwright output: #{redact_for_log(output)}"
@@ -683,13 +710,14 @@ module BrowserAutomation
     def build_page_script(url, options)
       data = {
         url: url,
-        wait_until: options[:wait_until] || "networkidle"
+        wait_until: options[:wait_until] || "networkidle",
+        network_guard: NetworkGuard.payload
       }
 
       script = <<~JS
         const { chromium } = require('playwright');
         const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
-
+        #{NetworkGuard::GUARD_JS}
         (async () => {
           const browser = await chromium.launch({
             headless: #{options[:headless] != false}
@@ -699,13 +727,14 @@ module BrowserAutomation
             const context = await browser.newContext({
               viewport: { width: #{(options[:width] || 1920).to_i}, height: #{(options[:height] || 1080).to_i} }
             });
+            const __guard = await __installNetworkGuard(context, __data.network_guard);
             const page = await context.newPage();
 
             if (__data.url) {
               await page.goto(__data.url, { waitUntil: __data.wait_until });
             }
 
-            console.log(JSON.stringify({ success: true }));
+            console.log(JSON.stringify({ success: true, blocked_requests: __guard.blocked() }));
           } catch (error) {
             console.error(JSON.stringify({ error: error.message }));
             process.exitCode = 1;

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -484,10 +484,16 @@ class RunGarakScan
 
     web_config = target.web_config.is_a?(String) ? JSON.parse(target.web_config) : target.web_config
 
-    # Wrap web_config in garak's expected structure
+    # Hand the browser driver the same blocklist UrlSafetyValidator enforces, so the
+    # webchat URL stays screened for the whole scan rather than only at launch: a
+    # redirect from the target, or JS on its page, can otherwise steer the browser to
+    # an internal address that was never checked. WebChatbotGenerator refuses to
+    # launch without this key.
     garak_config = {
       "web_chatbot" => {
-        "WebChatbotGenerator" => web_config
+        "WebChatbotGenerator" => (web_config.is_a?(Hash) ? web_config : {}).merge(
+          "network_guard" => BrowserAutomation::NetworkGuard.payload
+        )
       }
     }
 

--- a/app/validators/url_safety_validator.rb
+++ b/app/validators/url_safety_validator.rb
@@ -24,6 +24,14 @@ class UrlSafetyValidator
 
   Result = Struct.new(:safe?, :error, :resolved_ips, keyword_init: true)
 
+  # BLOCKED_RANGES as CIDR strings, for the out-of-process browser drivers
+  # (the Node Playwright scripts and the Python WebChatbotGenerator) that
+  # re-check every request the browser makes. They receive the list instead of
+  # redeclaring it so there is exactly one blocklist in the codebase.
+  def self.blocked_cidrs
+    @blocked_cidrs ||= BLOCKED_RANGES.map { |range| "#{range.to_string}/#{range.prefix}" }.freeze
+  end
+
   def self.safe_url?(url, allow_localhost: false)
     new(url, allow_localhost: allow_localhost).validate
   end

--- a/script/garak_plugins/_network_guard.py
+++ b/script/garak_plugins/_network_guard.py
@@ -1,0 +1,185 @@
+"""Network guard for the vendored Chromium WebChatbotGenerator.
+
+Standalone so it can be unit-tested without garak or playwright installed; the
+Dockerfiles copy it next to web_chatbot.py inside garak/generators/.
+"""
+
+import asyncio
+import ipaddress
+import logging
+import socket
+from urllib.parse import urljoin, urlsplit
+
+
+MAX_REDIRECTS = 20
+INERT_SCHEMES = ("data", "blob", "about")
+
+
+class NetworkGuardError(Exception):
+    """Raised when the guard cannot be configured. Never downgraded to a warning:
+    an unguarded browser is the bug this class exists to prevent."""
+
+
+class NetworkGuard:
+    """Keeps Scanner's URL blocklist in force for the browser's whole navigation
+    lifetime, not just the URL passed to page.goto().
+
+    Rails validates the webchat URL before the scan launches, but nothing re-checks
+    where the browser ends up afterwards: an HTTP redirect from the target, or
+    JavaScript on the target's own page, can steer it to an address that was never
+    screened. The browser runs in the same container as Rails, so that reaches
+    whatever the container can reach.
+
+    Screening the request URL alone is not enough. Chromium follows 3xx responses
+    internally and does not re-invoke route handlers for the redirected hop, so this
+    walks the redirect chain itself and screens every hop.
+
+    `blocked_cidrs` is supplied by Rails from UrlSafetyValidator::BLOCKED_RANGES so
+    there is one blocklist in the product rather than a Python copy that drifts.
+
+    Known limits: DNS may still flip between this lookup and Chromium's own (TOCTOU),
+    WebSocket handshakes are not intercepted by route(), and Server-Sent Events are
+    host-screened but not redirect-screened because buffering them would hold the
+    stream open forever.
+    """
+
+    LOOPBACK = (ipaddress.ip_network("127.0.0.0/8"), ipaddress.ip_network("::1/128"))
+
+    def __init__(self, config):
+        if not isinstance(config, dict):
+            raise NetworkGuardError("network_guard config missing - refusing to browse unguarded")
+        cidrs = config.get("blocked_cidrs") or []
+        if not isinstance(cidrs, list) or not cidrs:
+            raise NetworkGuardError("network_guard.blocked_cidrs missing - refusing to browse unguarded")
+        try:
+            self.ranges = [ipaddress.ip_network(c, strict=False) for c in cidrs]
+        except ValueError as exc:
+            raise NetworkGuardError(f"network_guard.blocked_cidrs unparsable: {exc}") from exc
+        self.allow_loopback = config.get("allow_loopback") is True
+        self.blocked = []
+        self._decisions = {}
+
+    @staticmethod
+    def _parse_ip(host):
+        """Return an ip_address for a literal host, or None when it is a name.
+        IPv4-mapped/compatible v6 is normalized so ::ffff:10.0.0.1 is screened
+        against the IPv4 ranges instead of sailing past them."""
+        candidate = host.strip()
+        if candidate.startswith("[") and candidate.endswith("]"):
+            candidate = candidate[1:-1]
+        candidate = candidate.split("%", 1)[0]
+        try:
+            ip = ipaddress.ip_address(candidate)
+        except ValueError:
+            return None
+        if isinstance(ip, ipaddress.IPv6Address):
+            if ip.ipv4_mapped:
+                return ip.ipv4_mapped
+        return ip
+
+    async def _resolve(self, host):
+        literal = self._parse_ip(host)
+        if literal is not None:
+            return [literal]
+        loop = asyncio.get_event_loop()
+        try:
+            infos = await loop.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+        except (socket.gaierror, OSError):
+            return []
+        addresses = []
+        for info in infos:
+            parsed = self._parse_ip(info[4][0])
+            if parsed is not None:
+                addresses.append(parsed)
+        return addresses
+
+    async def _host_allowed(self, host):
+        if host in self._decisions:
+            return self._decisions[host]
+
+        addresses = await self._resolve(host)
+        # No usable address is fail-closed, matching the Ruby validator.
+        if not addresses:
+            verdict = (False, f"could not resolve {host}")
+        else:
+            verdict = (True, None)
+            for address in addresses:
+                for network in self.ranges:
+                    if address.version != network.version or address not in network:
+                        continue
+                    if self.allow_loopback and any(
+                        address.version == lo.version and address in lo for lo in self.LOOPBACK
+                    ):
+                        continue
+                    verdict = (False, "blocked internal address")
+                    break
+                if not verdict[0]:
+                    break
+
+        self._decisions[host] = verdict
+        return verdict
+
+    async def screen(self, url):
+        """Return None when the URL may be fetched, else a rejection reason."""
+        parts = urlsplit(url)
+        if parts.scheme not in ("http", "https"):
+            return f"scheme {parts.scheme}"
+        if not parts.hostname:
+            return "no host"
+        allowed, reason = await self._host_allowed(parts.hostname)
+        return None if allowed else reason
+
+    def _deny(self, url, reason):
+        self.blocked.append({"url": url[:200], "reason": reason})
+        logging.warning("WebChatbotGenerator network guard blocked %s (%s)", url[:200], reason)
+
+    async def handle(self, route):
+        request = route.request
+        url = request.url
+
+        if urlsplit(url).scheme in INERT_SCHEMES:
+            await route.continue_()
+            return
+
+        reason = await self.screen(url)
+        if reason:
+            self._deny(url, reason)
+            await route.abort("blockedbyclient")
+            return
+
+        accept = (request.headers.get("accept") or "").lower()
+        if "text/event-stream" in accept:
+            # Streaming responses must not be buffered through route.fetch(); doing so
+            # holds the connection open and hangs any target that streams tokens.
+            await route.continue_()
+            return
+
+        current = url
+        try:
+            response = await route.fetch(max_redirects=0)
+            for hop in range(MAX_REDIRECTS):
+                if not 300 <= response.status <= 399:
+                    break
+                location = response.headers.get("location")
+                if not location:
+                    break
+
+                nxt = urljoin(current, location)
+                nxt_reason = await self.screen(nxt)
+                if nxt_reason:
+                    self._deny(nxt, f"redirect to {nxt_reason}")
+                    await route.abort("blockedbyclient")
+                    return
+
+                current = nxt
+                response = await route.fetch(url=nxt, max_redirects=0)
+                if hop == MAX_REDIRECTS - 1:
+                    self._deny(nxt, "too many redirects")
+                    await route.abort("blockedbyclient")
+                    return
+        except Exception as exc:  # network failure mid-chain - fail closed
+            logging.debug("WebChatbotGenerator network guard aborting %s: %s", url[:200], exc)
+            await route.abort("failed")
+            return
+
+        await route.fulfill(response=response)

--- a/script/garak_plugins/web_chatbot.py
+++ b/script/garak_plugins/web_chatbot.py
@@ -14,8 +14,10 @@ import json
 from playwright.async_api import async_playwright, Page, Browser, TimeoutError as PlaywrightTimeoutError
 
 from garak.generators.base import Generator
+from garak.generators._network_guard import NetworkGuard
 from garak import _config
 from garak.attempt import Conversation, Message
+
 
 class WebChatbotGenerator(Generator):
     """Web-based chatbot interface using browser automation
@@ -71,6 +73,9 @@ class WebChatbotGenerator(Generator):
             "headers": {},          # extra_http_headers
             "storage_state": None,  # Playwright storage_state object
         },
+        # Supplied by Rails from UrlSafetyValidator::BLOCKED_RANGES. Required:
+        # _init_browser refuses to launch without it rather than browsing unguarded.
+        "network_guard": None,      # {"blocked_cidrs": [...], "allow_loopback": bool}
     }
 
     generator_family_name = "WebChatbot"
@@ -83,6 +88,7 @@ class WebChatbotGenerator(Generator):
         self._context = None
         self._page = None
         self._playwright = None
+        self._network_guard = None
 
         # Call parent to load configuration
         super().__init__(name=name, config_root=config_root)
@@ -161,6 +167,13 @@ class WebChatbotGenerator(Generator):
             self._context = await self._browser.new_context(
                 **self._build_context_kwargs(getattr(self, "auth", None), self.browser_options)
             )
+
+            # Before the first navigation: Rails validated self.url at scan launch,
+            # but a redirect or in-page JS can move the browser somewhere it never
+            # checked. The guard re-screens every request for the life of the context.
+            self._network_guard = NetworkGuard(getattr(self, "network_guard", None))
+            await self._context.route("**/*", self._network_guard.handle)
+
             cookies = self._normalize_cookies((getattr(self, "auth", None) or {}).get("cookies") or [])
             if cookies:
                 await self._context.add_cookies(cookies)

--- a/script/tests/test_web_chatbot_network_guard.py
+++ b/script/tests/test_web_chatbot_network_guard.py
@@ -1,0 +1,106 @@
+"""Unit tests for the WebChatbotGenerator network guard.
+
+The guard keeps Scanner's URL blocklist in force for the browser's whole navigation
+lifetime. Its two jobs are screening a host against the blocklist Rails supplies, and
+refusing to run at all when that blocklist is absent - browsing unguarded must never
+be the fallback. Both are asserted here without a browser so the suite stays runnable
+anywhere; the redirect interception itself needs Chromium and is
+recorded in the PR that introduced this.
+"""
+import asyncio
+import importlib.util
+import unittest
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parents[2] / "script" / "garak_plugins"
+
+
+def _load(module_name, relative_path):
+    spec = importlib.util.spec_from_file_location(module_name, PLUGIN_DIR / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_guard = _load("local_network_guard", "_network_guard.py")
+NetworkGuard = _guard.NetworkGuard
+NetworkGuardError = _guard.NetworkGuardError
+
+# Mirrors UrlSafetyValidator::BLOCKED_RANGES. Rails passes the real list at runtime;
+# this copy exists only so the test can run without Rails.
+BLOCKED_CIDRS = [
+    "127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16",
+    "0.0.0.0/8", "::1/128", "fc00::/7", "fe80::/10", "100.64.0.0/10", "240.0.0.0/4",
+    "224.0.0.0/4", "255.255.255.255/32", "::/128", "ff00::/8",
+]
+
+
+class TestNetworkGuardScreening(unittest.TestCase):
+    def screen(self, url, allow_loopback=False):
+        guard = NetworkGuard({"blocked_cidrs": BLOCKED_CIDRS, "allow_loopback": allow_loopback})
+        return asyncio.run(guard.screen(url))
+
+    def assert_blocked(self, url, **kwargs):
+        self.assertIsNotNone(self.screen(url, **kwargs), f"expected {url} to be blocked")
+
+    def assert_allowed(self, url, **kwargs):
+        self.assertIsNone(self.screen(url, **kwargs), f"expected {url} to be allowed")
+
+    def test_blocks_loopback_rfc1918_and_metadata(self):
+        for host in ("127.0.0.1", "10.1.2.3", "172.16.5.5", "192.168.1.1", "169.254.169.254"):
+            self.assert_blocked(f"http://{host}/x")
+
+    def test_blocks_carrier_grade_nat_and_reserved_ranges(self):
+        for host in ("100.64.0.1", "240.0.0.1", "224.0.0.1", "255.255.255.255", "0.0.0.0"):
+            self.assert_blocked(f"http://{host}/x")
+
+    def test_blocks_ipv6_internal_ranges(self):
+        for host in ("[::1]", "[fc00::1]", "[fd00::1]", "[fe80::1]", "[ff02::1]"):
+            self.assert_blocked(f"http://{host}/x")
+
+    def test_blocks_ipv4_mapped_ipv6_that_would_otherwise_slip_past(self):
+        # ::ffff:10.0.0.1 is 10.0.0.1 wearing a v6 costume - it must be screened
+        # against the v4 ranges, not waved through for failing to match a v6 one.
+        for host in ("[::ffff:10.0.0.1]", "[::ffff:127.0.0.1]", "[::ffff:169.254.169.254]"):
+            self.assert_blocked(f"http://{host}/x")
+
+    def test_allows_public_addresses(self):
+        for host in ("8.8.8.8", "1.1.1.1", "172.32.0.1", "100.128.0.1", "[2001:4860:4860::8888]"):
+            self.assert_allowed(f"http://{host}/x")
+
+    def test_rejects_non_http_schemes(self):
+        for url in ("file:///etc/passwd", "ftp://8.8.8.8/x", "gopher://8.8.8.8/x"):
+            self.assertIsNotNone(self.screen(url), f"expected {url} to be refused")
+
+    def test_rejects_unresolvable_host(self):
+        self.assert_blocked("http://this-host-does-not-exist.invalid/x")
+
+    def test_allow_loopback_permits_loopback_only(self):
+        # Matches UrlSafetyValidator.allow_localhost? in dev/test: loopback is fine,
+        # everything else internal is still refused.
+        self.assert_allowed("http://127.0.0.1/x", allow_loopback=True)
+        self.assert_allowed("http://[::1]/x", allow_loopback=True)
+        self.assert_blocked("http://10.1.2.3/x", allow_loopback=True)
+        self.assert_blocked("http://169.254.169.254/x", allow_loopback=True)
+
+
+class TestNetworkGuardFailsClosed(unittest.TestCase):
+    def test_missing_or_empty_config_refuses_to_construct(self):
+        for config in (None, {}, {"blocked_cidrs": []}, {"blocked_cidrs": None}, "nope"):
+            with self.assertRaises(NetworkGuardError, msg=f"config {config!r} was accepted"):
+                NetworkGuard(config)
+
+    def test_unparsable_cidr_refuses_to_construct(self):
+        with self.assertRaises(NetworkGuardError):
+            NetworkGuard({"blocked_cidrs": ["10.0.0.0/8", "not-a-cidr"]})
+
+    def test_allow_loopback_defaults_to_false(self):
+        guard = NetworkGuard({"blocked_cidrs": BLOCKED_CIDRS})
+        self.assertFalse(guard.allow_loopback)
+        # Truthy-but-not-True values must not enable it either.
+        guard = NetworkGuard({"blocked_cidrs": BLOCKED_CIDRS, "allow_loopback": "yes"})
+        self.assertFalse(guard.allow_loopback)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/services/browser_automation/network_guard_spec.rb
+++ b/spec/services/browser_automation/network_guard_spec.rb
@@ -1,0 +1,151 @@
+require "rails_helper"
+require "open3"
+
+# The guard is what keeps UrlSafetyValidator's blocklist in force for the browser's
+# whole navigation lifetime. These specs cover the Ruby half: that the blocklist
+# handed to the browser is UrlSafetyValidator's own, that every tenant-driven
+# Playwright entry point installs the guard, and that a blocked request is surfaced
+# rather than swallowed. The interception behaviour itself lives in the JS the guard
+# emits and is covered by driving a real browser, not from here.
+RSpec.describe BrowserAutomation::NetworkGuard do
+  describe ".payload" do
+    it "hands over UrlSafetyValidator's blocklist rather than a second copy" do
+      expect(described_class.payload["blocked_cidrs"]).to eq(UrlSafetyValidator.blocked_cidrs)
+    end
+
+    it "covers the ranges an SSRF would aim at" do
+      cidrs = described_class.payload["blocked_cidrs"]
+      expect(cidrs).to include("127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12",
+                               "192.168.0.0/16", "169.254.0.0/16")
+    end
+
+    it "follows UrlSafetyValidator's localhost policy by default" do
+      allow(UrlSafetyValidator).to receive(:allow_localhost?).and_return(false)
+      expect(described_class.payload["allow_loopback"]).to be(false)
+
+      allow(UrlSafetyValidator).to receive(:allow_localhost?).and_return(true)
+      expect(described_class.payload["allow_loopback"]).to be(true)
+    end
+
+    it "coerces an explicit override to a strict boolean" do
+      expect(described_class.payload(allow_localhost: "yes")["allow_loopback"]).to be(true)
+      expect(described_class.payload(allow_localhost: false)["allow_loopback"]).to be(false)
+    end
+  end
+
+  describe "GUARD_JS" do
+    it "screens every request through the context, not just the page" do
+      # context.route covers popups and every page in the context; page.route would
+      # miss a window the target opens.
+      expect(described_class::GUARD_JS).to include("context.route('**/*'")
+    end
+
+    it "walks the redirect chain itself" do
+      # Chromium follows 3xx internally without re-invoking route handlers, so a
+      # guard that only screens route.request().url() misses the redirect pivot -
+      # which is the exact bug being fixed.
+      expect(described_class::GUARD_JS).to include("maxRedirects: 0")
+      expect(described_class::GUARD_JS).to include("redirect to ")
+    end
+
+    it "refuses to run without a blocklist instead of browsing unguarded" do
+      expect(described_class::GUARD_JS).to include("refusing to browse unguarded")
+    end
+  end
+end
+
+RSpec.describe BrowserAutomation::PlaywrightService, "network guard wiring" do
+  let(:service) { described_class.instance }
+  let(:url) { "https://example.com" }
+
+  # Capture the script and data file each entry point hands to node.
+  def capture(result: { "success" => true })
+    script = nil
+    data = nil
+    allow(Open3).to receive(:capture3) do |env, _cmd, script_path|
+      script = File.read(script_path)
+      data = JSON.parse(File.read(env["PLAYWRIGHT_DATA_PATH"]))
+      [ result.to_json, "", double(success?: true) ]
+    end
+    yield
+    [ script, data ]
+  end
+
+  # Every entry point that navigates to a TENANT-supplied URL must install the guard.
+  {
+    "screenshot" => ->(s) { s.screenshot("https://example.com", "/tmp/x.png") },
+    "with_page" => ->(s) { s.with_page("https://example.com") },
+    "extract_page_structure" => ->(s) { s.extract_page_structure("https://example.com") },
+    "validate_webchat_config" => lambda do |s|
+      s.validate_webchat_config(
+        "https://example.com",
+        { "selectors" => { "input_field" => "#i", "response_container" => "#r" } }
+      )
+    end
+  }.each do |name, invoke|
+    context "##{name}" do
+      it "installs the network guard on the browser context" do
+        script, data = capture(result: { "success" => true, "path" => "/tmp/x.png", "data" => {}, "errors" => [] }) do
+          invoke.call(service)
+        end
+
+        expect(script).to include("__installNetworkGuard(context, __data.network_guard)")
+        expect(data["network_guard"]["blocked_cidrs"]).to eq(UrlSafetyValidator.blocked_cidrs)
+      end
+
+      it "passes the blocklist through the data file, never interpolated into the script" do
+        script, = capture(result: { "success" => true, "path" => "/tmp/x.png", "data" => {}, "errors" => [] }) do
+          invoke.call(service)
+        end
+
+        # The blocklist arriving as script text would mean a value could reach the
+        # script string; every other value in these scripts goes via the data file.
+        expect(script).not_to include('"169.254.0.0/16"')
+      end
+    end
+  end
+
+  describe "#generate_pdf" do
+    it "is deliberately left unguarded because it renders Scanner's own report URL" do
+      script, data = capture(result: { "success" => true, "path" => "/tmp/x.pdf" }) do
+        service.generate_pdf("http://localhost:3000/reports/1.pdf", "/tmp/x.pdf", allow_localhost: true)
+      end
+
+      # Guarding this would block Scanner from rendering its own pages whenever the
+      # app is reachable only on a container address the blocklist covers.
+      expect(script).not_to include("__installNetworkGuard")
+      expect(data).not_to have_key("network_guard")
+    end
+  end
+
+  describe "blocked request reporting" do
+    it "warns with what the guard aborted so a silent block is not invisible" do
+      allow(Rails.logger).to receive(:warn)
+      result = {
+        "success" => true,
+        "path" => "/tmp/x.png",
+        "blocked_requests" => [
+          { "url" => "http://169.254.169.254/latest/meta-data/", "reason" => "redirect to blocked internal address" }
+        ]
+      }
+      allow(Open3).to receive(:capture3).and_return([ result.to_json, "", double(success?: true) ])
+
+      service.screenshot(url, "/tmp/x.png")
+
+      expect(Rails.logger).to have_received(:warn)
+        .with(/network guard blocked 1 request.*169\.254\.169\.254/)
+    end
+
+    it "stays quiet when nothing was blocked" do
+      allow(Rails.logger).to receive(:warn)
+      allow(Open3).to receive(:capture3).and_return([
+        { "success" => true, "path" => "/tmp/x.png", "blocked_requests" => [] }.to_json,
+        "", double(success?: true)
+      ])
+
+      service.screenshot(url, "/tmp/x.png")
+
+      expect(Rails.logger).not_to have_received(:warn).with(/network guard/)
+    end
+  end
+end

--- a/spec/validators/url_safety_validator_spec.rb
+++ b/spec/validators/url_safety_validator_spec.rb
@@ -352,4 +352,26 @@ RSpec.describe UrlSafetyValidator do
       expect(result.safe?).to be true
     end
   end
+
+  # The out-of-process browser drivers (the Node Playwright scripts and the Python
+  # WebChatbotGenerator) re-screen every request the browser makes. They read this
+  # list rather than redeclaring the ranges, so a range added here reaches them too.
+  describe ".blocked_cidrs" do
+    it "serializes every blocked range" do
+      expect(described_class.blocked_cidrs.size).to eq(described_class::BLOCKED_RANGES.size)
+    end
+
+    it "emits parsable CIDR strings that round-trip to the same ranges" do
+      described_class.blocked_cidrs.zip(described_class::BLOCKED_RANGES).each do |cidr, range|
+        expect(IPAddr.new(cidr)).to eq(range)
+        expect(IPAddr.new(cidr).prefix).to eq(range.prefix)
+      end
+    end
+
+    it "includes the RFC1918 and cloud-metadata ranges an SSRF aims at" do
+      expect(described_class.blocked_cidrs).to include(
+        "127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16"
+      )
+    end
+  end
 end


### PR DESCRIPTION
Closes #130.

## What was wrong

`UrlSafetyValidator` screens the webchat URL before the browser starts, and nothing checks where the browser goes after that. @annatchijova's report is accurate and reproduces exactly as written.

While verifying it I found the gap is **wider than reported**, and that the suggested fix does not close it on its own:

| # | Pivot | In the report | Reaches internal service on `main` |
|---|---|---|---|
| A | Target responds `302` to an internal address | yes | yes |
| B | In-page JS `fetch()` to an internal address | yes | yes |
| C | In-page `fetch()` to an **allowed** host that `302`s to an internal one | no | **yes** |

Case C matters because it defeats the obvious fix. A `route()` handler that screens `route.request().url()` — the direction suggested in the issue — blocks A and B but **not C**: Chromium follows `3xx` internally and does not re-invoke route handlers for the redirected hop. Verified on Playwright 1.59, for navigations and sub-resources alike, and it still holds with `route.fetch({maxRedirects: 0})` + `fulfill({response})`:

```
routed requests for goto(/r) -> 302 -> internal:
   http://127.0.0.1:19732/r          <- handler fires
   (nothing)                          <- redirect hop never routed
final url: http://127.0.0.1:19731/landed
```

## What this does

Adds `NetworkGuard` on **both** browser drivers, holding the invariant the issue names for the browser's whole navigation lifetime:

- **`BrowserAutomation::NetworkGuard`** (Ruby, emits the JS) for `PlaywrightService` — `screenshot`, `with_page`, `validate_webchat_config`, `extract_page_structure`.
- **`garak.generators._network_guard`** (Python) for `WebChatbotGenerator` — the driver that runs during an actual scan, which has the same gap and which the report did not cover.

Both re-resolve and re-screen the host of every request, and both **walk the redirect chain themselves**, screening each hop before the browser sees a response. Neither declares its own blocklist: `UrlSafetyValidator.blocked_cidrs` is passed to the Node scripts through the existing data file and to the Python generator through the garak web config, so a range added to `BLOCKED_RANGES` reaches all three enforcement points. Both fail closed — a missing or unparsable blocklist raises before any navigation rather than browsing unguarded.

**`generate_pdf` is deliberately left unguarded.** It renders Scanner's own report URL with `allow_localhost: true`, and the app is routinely reachable only on a container address the blocklist covers — guarding it would stop Scanner rendering its own pages. Asserted as intentional in the specs so it is not mistaken for an oversight.

## Verification

Reproduced the report against real Chromium, then re-ran with the guard. Not a mock: two local HTTP servers, the pivot destination on a genuinely blocked address.

```
BASELINE (main)
PASS  Case A: redirect reaches internal service
PASS  Case B: in-page fetch reaches internal service
PASS  Case C: sub-resource redirect reaches internal service

GUARDED
PASS  prod policy: blocked target never reaches internal service
PASS  benign webchat target still loads
PASS  loopback still allowed when policy allows it (no over-blocking)
PASS  Case A redirect to 169.254.169.254 aborted by guard
PASS  multi-hop redirect chain aborted at the internal hop
PASS  Case C sub-resource redirect bypass closed
```

Run again against the script `PlaywrightService` actually generates (not the extracted guard), and against the Python guard driving a real browser — the metadata pivot is refused while a permitted request on the same page still completes.

Committed checks: `3042 examples, 0 failures` · `207 python tests, OK` · Brakeman `0 security warnings` · RuboCop clean. New coverage in `spec/services/browser_automation/network_guard_spec.rb` (18) and `script/tests/test_web_chatbot_network_guard.py` (11, no browser or garak needed).

## Limits — deliberately not papered over

The report's second suggestion, network-level isolation, is still the real fix. This is an app-layer control and has app-layer holes, all documented in the source:

- **TOCTOU remains.** The guard resolves the host and Chromium resolves it again for the connection it opens. This narrows the window from once per scan to once per request; it does not close it.
- **WebSockets are not covered.** `route()` does not intercept the handshake, as @annatchijova anticipated.
- **Server-Sent Events are host-screened but not redirect-screened.** Buffering them through `route.fetch()` would hold the stream open forever and hang any target that streams tokens, so SSE requests are screened and passed through.

## Reviewer notes

- Every non-SSE request now goes through Playwright's Node/Python network stack rather than straight from the browser. Correct, and a real behaviour change — worth a look if any target is latency-sensitive.
- `WebChatbotGenerator` now **requires** `network_guard` in its config. Rails always supplies it, but a config written by an older Rails will fail the scan loudly instead of running unguarded. Intentional; flag it if you would rather it degrade.
- `_network_guard.py` is a new vendored plugin file, so both Dockerfiles copy it (`test_plugin_install_paths.py` enforces this).
