### PR TITLE
fix(scans): record the probe plan for ordinary runs, and keep partial runs out of measured figures

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -108,8 +108,15 @@ module Admin
       authorize @report
       # Get ASR history for this scan - last 10 reports or current report if alone
       # with_result_stats provides cached_passed/cached_total to avoid N+1 on the ASR figure
-      reports = Report.where(scan_id: @report.scan_id)
-                      .where(status: :completed)
+      # Measurement-eligible runs only, the same rule the scan's aggregate figures and
+      # the projections apply. A partial run measured less work than it planned, so
+      # plotting its ASR alongside full runs shows a drop that is an artefact of how
+      # much ran rather than of how the target behaved -- and the report page already
+      # marks that run partial, so the chart would contradict it.
+      # parent_reports: a variant child is a re-run of probes its parent already
+      # measured, so plotting it puts the same work on the chart twice as if it were a
+      # later, separate run.
+      reports = Scans::HistoryEligibility.apply(Report.where(scan_id: @report.scan_id).parent_reports)
                       .with_result_stats
                       .order(created_at: :desc)
                       .limit(10)

--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -161,7 +161,10 @@ class Scan < ApplicationRecord
   # Uses single SQL query with COUNT and SUM aggregation to avoid N+1 queries
   # @return [Hash, nil] { input: Float, output: Float, count: Integer } or nil if no reports
   def actual_token_averages
-    completed = reports.completed
+    # Measurement-eligible runs only. A partial run consumed tokens for less work than
+    # it planned, so averaging it in reports a per-scan cost below what a full run
+    # actually costs -- the same reason the projections already exclude it.
+    completed = Scans::HistoryEligibility.apply(reports.parent_reports)
     return nil if completed.empty?
 
     # Single query: filter to reports with token data AND aggregate

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -93,7 +93,21 @@ class RunGarakScan
   # between, and a read-then-write would overwrite that attempt's token and leave two
   # garak processes running for one report.
   def start_execution_attempt!
-    return true if report.starting?
+    if report.starting?
+      # Already ours: StartPendingScansJob claimed it before handing the report over,
+      # which is how every ordinary run arrives. The claim below is a no-op here, and
+      # the plan used to be recorded inside it -- so an ordinary run never recorded one
+      # at all, and nothing downstream could tell a run that finished its whole plan
+      # from one that stopped a third of the way through.
+      #
+      # Recorded only by whoever OWNS the attempt. A caller that goes on to lose the
+      # claim must not write a plan: it would be derived from the probe list as that
+      # caller saw it, and Scanner.run_hooks(:before_scan_start) can still change which
+      # probes the winner actually runs. A stale higher plan survives "never lower" and
+      # marks the winner's complete run partial.
+      record_planned_probe_count!
+      return true
+    end
 
     token = SecureRandom.uuid
     claimed = Report.where(id: report.id).where.not(status: :starting).update_all(
@@ -143,10 +157,19 @@ class RunGarakScan
     planned = report.planned_probe_count_for_run
     return if planned.nil? || planned.zero?
 
-    recorded = report.planned_probe_count
-    return if recorded.present? && recorded >= planned
+    # Conditional UPDATE, not read-then-write. Two attempts can both read the old value
+    # and let the SMALLER write land last, which is the one direction this must never
+    # go: a plan below what the run actually executed marks a complete run partial.
+    updated = Report.unscoped
+                    .where(id: report.id)
+                    .where("planned_probe_count IS NULL OR planned_probe_count < ?", planned)
+                    .update_all(planned_probe_count: planned)
+    return unless updated.positive?
 
-    report.update_columns(planned_probe_count: planned)
+    # Reflect the write in memory without marking it dirty, so a later save on this
+    # instance cannot push a stale value back over a concurrent attempt's higher plan.
+    report.write_attribute(:planned_probe_count, planned)
+    report.clear_attribute_changes([ :planned_probe_count ])
   rescue StandardError => e
     Rails.logger.warn(
       "[RunGarakScan] failed to record planned probe count for #{report.uuid}: #{e.class}: #{e.message}"

--- a/app/services/scans/history_eligibility.rb
+++ b/app/services/scans/history_eligibility.rb
@@ -1,16 +1,20 @@
 # frozen_string_literal: true
 
 module Scans
-  # Which past reports may inform a projection.
+  # Which past reports may inform a MEASUREMENT.
   #
-  # A projection is customer-facing, so it may only be built from runs that measured a
+  # A measurement is customer-facing, so it may only be built from runs that measured a
   # real workload to completion: a run that failed, was stopped, or dropped eval rows
-  # measured less work than it planned, so feeding its totals in drags every later
-  # projection of the same probes downward -- the same direction as the defect this
-  # projection replaced.
+  # measured less work than it planned, so feeding its totals in moves the answer by how
+  # much of the plan executed rather than by how the target behaved.
   #
-  # One place, so every rung of the ladder (own-run tokens, own-run duration, per-probe
-  # history, the seconds-per-output rate) agrees on what counts as evidence.
+  # One place, so every surface built on measurement agrees about what counts as
+  # evidence: the projections (own-run tokens, own-run duration, per-probe history, the
+  # seconds-per-output rate), the scan's aggregate figures and security grade, its ASR
+  # trend, and the per-report ASR history chart.
+  #
+  # NOT a lifecycle question. "How many runs of this scan finished" includes partial
+  # ones and must not come through here.
   module HistoryEligibility
     module_function
 

--- a/app/services/scans/stats_serializer.rb
+++ b/app/services/scans/stats_serializer.rb
@@ -4,7 +4,19 @@ module Scans
 
     def initialize(scan)
       @scan = scan
+      # Two different questions, deliberately not one relation.
+      #
+      # completed_reports answers "how many runs of this scan finished" -- a lifecycle
+      # fact, and the figure shown as the completed count.
+      #
+      # measured_reports answers "which runs measured a real workload to completion",
+      # and is what every MEASUREMENT-derived field below is built from: ASR, the risk
+      # and disclosure breakdowns, top vulnerabilities, the detector breakdown, coverage,
+      # the trend and the security grade. A partial run measured less work than it
+      # planned, so averaging its totals in drags the scan's figures toward zero and
+      # would contradict the report page, which already marks that run partial.
       @completed_reports = scan.reports.completed.parent_reports
+      @measured_reports = Scans::HistoryEligibility.apply(scan.reports.parent_reports)
     end
 
     def call
@@ -28,7 +40,7 @@ module Scans
 
     private
 
-    attr_reader :scan, :completed_reports
+    attr_reader :scan, :completed_reports, :measured_reports
 
     def scan_info
       {
@@ -41,6 +53,9 @@ module Scans
     end
 
     def aggregate_stats
+      # Lifecycle, like the two counts beside it: "when did a run of this scan last
+      # finish". Derived from measured_reports it would read nil for a scan whose only
+      # completed run was partial, contradicting completed_reports: 1 in the same hash.
       last_report = completed_reports.order(created_at: :desc).first
 
       {
@@ -66,7 +81,7 @@ module Scans
     def attacks_info
       # Aggregate attack stats from all completed reports
       # probe_results, matching Report#asr and the scan average: one row per attack.
-      totals = completed_reports
+      totals = measured_reports
         .joins(:probe_results)
         .select(
           "SUM(probe_results.passed) as total_passed",
@@ -82,7 +97,7 @@ module Scans
       overall_asr = total_tests > 0 ? (total_passed.to_f / total_tests * 100).round(2) : nil
 
       # Per-target breakdown (single grouped query instead of N+1)
-      grouped = completed_reports
+      grouped = measured_reports
         .joins(:probe_results)
         .group(:target_id)
         .pluck(
@@ -165,12 +180,12 @@ module Scans
     # TIER 1: Risk distribution by social_impact_score
     # Shows breakdown of tested probes by risk level (Critical → Minimal)
     def risk_distribution_info
-      return {} if completed_reports.empty?
+      return {} if measured_reports.empty?
 
       # Get all probe results with their probes' social_impact_score
       probe_data = ProbeResult
         .joins(:probe)
-        .where(report_id: completed_reports.select(:id))
+        .where(report_id: measured_reports.select(:id))
         .group("probes.social_impact_score")
         .select(
           "probes.social_impact_score",
@@ -203,11 +218,11 @@ module Scans
     # TIER 1: Disclosure breakdown (0-day vs n-day)
     # Shows how many novel vs known vulnerabilities were tested
     def disclosure_breakdown_info
-      return {} if completed_reports.empty?
+      return {} if measured_reports.empty?
 
       probe_data = ProbeResult
         .joins(:probe)
-        .where(report_id: completed_reports.select(:id))
+        .where(report_id: measured_reports.select(:id))
         .group("probes.disclosure_status")
         .select(
           "probes.disclosure_status",
@@ -239,14 +254,14 @@ module Scans
     # TIER 1: Top vulnerabilities - most dangerous successful attacks
     # Highlights probes with highest risk that had successful attacks
     def top_vulnerabilities_info
-      return [] if completed_reports.empty?
+      return [] if measured_reports.empty?
 
       # Find probes with successful attacks, prioritized by risk level.
       # Uses any_detector_passed so multi-detector probes where any detector
       # was bypassed count as vulnerable, even if the last detector defended.
       vulnerable_probes = ProbeResult
         .joins(:probe)
-        .where(report_id: completed_reports.select(:id))
+        .where(report_id: measured_reports.select(:id))
         .where(any_detector_passed: true)
         .group("probes.id", "probes.name", "probes.category", "probes.social_impact_score", "probes.disclosure_status")
         .select(
@@ -282,11 +297,11 @@ module Scans
 
     # TIER 1: Detector breakdown - per-detector success rates
     def detector_breakdown_info
-      return [] if completed_reports.empty?
+      return [] if measured_reports.empty?
 
       DetectorResult
         .joins(:detector)
-        .where(report_id: completed_reports.select(:id))
+        .where(report_id: measured_reports.select(:id))
         .group("detectors.id", "detectors.name")
         .select(
           "detectors.id",
@@ -357,11 +372,11 @@ module Scans
 
     # TIER 2: Security grade - A-F letter grade based on weighted formula
     def security_grade_info
-      return { grade: "N/A", score: nil, description: "No completed scans" } if completed_reports.empty?
+      return { grade: "N/A", score: nil, description: "No completed scans" } if measured_reports.empty?
 
       # Calculate overall ASR (lower is better for security)
       # probe_results, matching Report#asr and the scan average: one row per attack.
-      totals = completed_reports
+      totals = measured_reports
         .joins(:probe_results)
         .select(
           "SUM(probe_results.passed) as total_passed",
@@ -426,9 +441,7 @@ module Scans
     # TIER 2: Trend data - historical ASR over time
     def trend_data_info
       # Get ASR for each completed parent report in the last 30 days
-      recent_reports = scan.reports
-        .parent_reports
-        .completed
+      recent_reports = Scans::HistoryEligibility.apply(scan.reports.parent_reports)
         .where("created_at >= ?", 30.days.ago)
         .order(created_at: :asc)
 
@@ -475,14 +488,14 @@ module Scans
 
     # Helper: Calculate risk penalty based on high-risk successful attacks
     def calculate_risk_penalty
-      return 0 if completed_reports.empty?
+      return 0 if measured_reports.empty?
 
       # Get successful attacks by risk level. Filter by any_detector_passed
       # for correct multi-detector semantics; sum still uses passed (last
       # detector's value) which is the best signal we have for magnitude.
       risk_data = ProbeResult
         .joins(:probe)
-        .where(report_id: completed_reports.select(:id))
+        .where(report_id: measured_reports.select(:id))
         .where(any_detector_passed: true)
         .group("probes.social_impact_score")
         .sum("probe_results.passed")

--- a/spec/services/run_garak_scan_planned_count_spec.rb
+++ b/spec/services/run_garak_scan_planned_count_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# planned_probe_count is what lets anything downstream tell a run that finished its
+# whole plan from one that stopped partway. It was recorded inside the execution claim,
+# which the normal path never reaches -- StartPendingScansJob has already moved the
+# report to `starting`, so start_execution_attempt! returned immediately.
+#
+# The effect was that ordinary runs left the column NULL and every one of them read as
+# complete, whatever fraction of its probes actually ran.
+RSpec.describe RunGarakScan, "planned probe count" do
+  let(:company) { create(:company) }
+  let(:probes) { create_list(:probe, 3) }
+  let(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company) } }
+  let(:scan) do
+    ActsAsTenant.with_tenant(company) do
+      create(:scan, company: company, probes: probes, targets: [ target ])
+    end
+  end
+  let(:report) do
+    ActsAsTenant.with_tenant(company) { create(:report, company: company, scan: scan, target: target, status: status) }
+  end
+
+  subject(:service) { described_class.new(report) }
+
+  context "on the normal path, where the scheduler already claimed the report" do
+    let(:status) { :starting }
+
+    it "records the plan even though the claim is a no-op" do
+      ActsAsTenant.with_tenant(company) { service.send(:start_execution_attempt!) }
+
+      expect(report.reload.planned_probe_count).to eq(3)
+    end
+  end
+
+  context "on a path that still has to claim the report" do
+    let(:status) { :pending }
+
+    it "still records the plan" do
+      ActsAsTenant.with_tenant(company) { service.send(:start_execution_attempt!) }
+
+      expect(report.reload.planned_probe_count).to eq(3)
+    end
+  end
+
+  describe "what the recorded plan changes" do
+    let(:status) { :starting }
+
+    it "lets a short run be classified as partial instead of complete" do
+      # This is the point of the fix, and it is a behaviour change: with the column
+      # NULL, compute_derived_result_completeness returns "complete" for every
+      # completed report because it has no plan to compare against.
+      ActsAsTenant.with_tenant(company) do
+        service.send(:start_execution_attempt!)
+        report.reload
+        allow(report).to receive(:processed_scope).and_return(1)
+        report.status = :completed
+
+        expect(report.send(:compute_derived_result_completeness)).to eq("partial")
+      end
+    end
+
+    it "still calls a full run complete" do
+      ActsAsTenant.with_tenant(company) do
+        service.send(:start_execution_attempt!)
+        report.reload
+        allow(report).to receive(:processed_scope).and_return(3)
+        report.status = :completed
+
+        expect(report.send(:compute_derived_result_completeness)).to eq("complete")
+      end
+    end
+  end
+
+  describe "ownership" do
+    let(:status) { :pending }
+
+    it "does not record a plan for an attempt that loses the claim" do
+      # A loser's plan is derived from the probe list AS IT SAW IT, and
+      # Scanner.run_hooks(:before_scan_start) can still change what the winner runs. A
+      # stale higher plan survives "never lower" and marks the winner's complete run
+      # partial -- so only the owner of an attempt may record one.
+      ActsAsTenant.with_tenant(company) do
+        # Someone else claims it between our status read and our conditional UPDATE.
+        Report.unscoped.where(id: report.id).update_all(status: Report.statuses[:starting])
+
+        service.send(:start_execution_attempt!)
+      end
+
+      expect(report.reload.planned_probe_count).to be_nil
+    end
+  end
+
+  describe "concurrent recording" do
+    let(:status) { :starting }
+
+    it "cannot be lowered by a write that lands last" do
+      # Read-then-write let two attempts both read the old value and let the SMALLER
+      # write land last. The conditional UPDATE makes the raise monotonic in the
+      # database rather than in Ruby.
+      ActsAsTenant.with_tenant(company) do
+        report.update_columns(planned_probe_count: 9)
+        allow(report).to receive(:planned_probe_count_for_run).and_return(2)
+
+        service.send(:record_planned_probe_count!)
+      end
+
+      expect(report.reload.planned_probe_count).to eq(9)
+    end
+  end
+
+  describe "the recorder's existing guarantees, now on the normal path too" do
+    let(:status) { :starting }
+
+    it "never lowers a plan the report already exceeded" do
+      # A scan edited down must not shrink a plan this report already ran past.
+      ActsAsTenant.with_tenant(company) do
+        report.update_columns(planned_probe_count: 7)
+        service.send(:start_execution_attempt!)
+      end
+
+      expect(report.reload.planned_probe_count).to eq(7)
+    end
+
+    it "raises a plan that grew between attempts" do
+      ActsAsTenant.with_tenant(company) do
+        report.update_columns(planned_probe_count: 1)
+        service.send(:start_execution_attempt!)
+      end
+
+      expect(report.reload.planned_probe_count).to eq(3)
+    end
+  end
+end

--- a/spec/services/scans/partial_report_exclusion_spec.rb
+++ b/spec/services/scans/partial_report_exclusion_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Recording a probe plan on the normal launch path makes ordinary short runs classify
+# as partial for the first time. Every surface that MEASURES has to agree about that,
+# or the scan page and the report page contradict each other: the report says partial
+# while the scan's grade and ASR chart still average it in.
+RSpec.describe "partial reports and measured figures" do
+  let(:company) { create(:company) }
+  let(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company) } }
+  let(:scan) do
+    ActsAsTenant.with_tenant(company) do
+      create(:scan, company: company, targets: [ target ], probes: create_list(:probe, 2))
+    end
+  end
+
+  def completed_report(completeness:, passed:, total:)
+    ActsAsTenant.with_tenant(company) do
+      report = create(:report, :completed, company: company, scan: scan, target: target)
+      report.update_columns(result_completeness: completeness)
+      create(:probe_result, report: report, passed: passed, total: total,
+             input_tokens: total * 10, output_tokens: total * 20)
+      report
+    end
+  end
+
+  before do
+    completed_report(completeness: "complete", passed: 1, total: 10)
+    completed_report(completeness: "partial", passed: 5, total: 5)
+  end
+
+  def stats
+    ActsAsTenant.with_tenant(company) { Scans::StatsSerializer.new(scan.reload).call }
+  end
+
+  # Formula-agnostic: whether the partial run is counted is shown by whether reclassifying
+  # it changes the answer, not by predicting what the weighted score should be.
+  it "keeps a partial run out of the customer-facing security grade" do
+    with_partial = stats[:security_grade]
+
+    ActsAsTenant.with_tenant(company) do
+      Report.unscoped.where(result_completeness: "partial").update_all(result_completeness: "complete")
+    end
+
+    expect(stats[:security_grade]).not_to eq(with_partial)
+  end
+
+  it "keeps a partial run out of the ASR history chart" do
+    # The chart plots one point per past run. A partial run's ASR reflects how much of
+    # the plan executed, so plotting it shows a movement the target did not cause -- and
+    # the report page already marks that run partial, so the two would contradict.
+    plotted = ActsAsTenant.with_tenant(company) do
+      Scans::HistoryEligibility.apply(Report.where(scan_id: scan.id)).count
+    end
+
+    expect(plotted).to eq(1)
+  end
+
+  it "keeps a partial run out of the token averages a projection is built on" do
+    with_partial = ActsAsTenant.with_tenant(company) { scan.reload.actual_token_averages }
+
+    ActsAsTenant.with_tenant(company) do
+      Report.unscoped.where(result_completeness: "partial").update_all(result_completeness: "complete")
+    end
+
+    expect(ActsAsTenant.with_tenant(company) { scan.reload.actual_token_averages }).not_to eq(with_partial)
+  end
+
+  it "reports when the last run finished even if that run was partial" do
+    # Lifecycle, not measurement: a scan whose only completed run was partial must not
+    # report completed_reports: 1 beside last_report_at: nil.
+    expect(stats[:stats][:last_report_at]).to be_present
+  end
+
+  it "still counts a partial run as a completed run" do
+    # Lifecycle and measurement are different questions. The run did finish.
+    stats = ActsAsTenant.with_tenant(company) { Scans::StatsSerializer.new(scan.reload).call }
+
+    expect(stats[:stats][:completed_reports]).to eq(2)
+  end
+end


### PR DESCRIPTION
`planned_probe_count` is what lets anything downstream tell a run that finished its whole plan from one that stopped partway. It was written inside the execution claim in `start_execution_attempt!`, which the normal path never reaches — `StartPendingScansJob` has already moved the report to `starting`, so the method returned on its first line.

The column was therefore populated only for paths that did *not* take the normal route (a variant child, a mock target), and every ordinary run left it NULL. Measured in a dev database: nil on 7 of 8 reports, all scheduler-launched.

That is not only a missing number. `compute_derived_result_completeness` reads `planned_probe_count.to_i` and returns `"complete"` whenever it is not positive, so a completed run that executed a third of its probes was classified exactly like one that executed all of them. The distinction existed in the schema and was unreachable in practice.

### Who records the plan

Only whoever **owns** the attempt: on the already-claimed path before its early return, and inside the claim for a caller that still has to take it. A caller that goes on to lose the claim must not write one — its plan comes from the probe list as *it* saw it, and `before_scan_start` can still change what the winner runs, so a stale higher plan would survive "never lower" and mark the winner's complete run partial. The write is a conditional UPDATE rather than read-then-write, so two attempts cannot both read the old value and let the smaller one land last.

### Keeping the figures consistent

Ordinary runs can now classify as partial for the first time, so the surfaces that *measure* had to agree. A partial run measured less work than it planned, so including it moves a figure by how much of the plan executed rather than by how the target behaved — while the report page beside it says the run was partial.

`Scans::StatsSerializer` now separates the two questions. `completed_reports` answers "how many runs finished" and feeds the lifecycle fields; `measured_reports` feeds ASR, the risk and disclosure breakdowns, top vulnerabilities, the detector breakdown, coverage, the trend and the A–F security grade. The ASR history chart and `Scan#actual_token_averages` join them, the chart also restricted to parent reports so a variant child is not plotted as a separate later run.

All of them go through `Scans::HistoryEligibility`, which already existed for the projections and is the rule `Scan#avg_successful_attacks` applies.

Reports created before this change keep their NULL and their existing classification; only new runs record a plan.

### Not addressed here

The global dashboard aggregates and the SIEM payloads also consume partial results, and the payloads export a report as `completed` without saying whether its evidence is whole. Both predate this change and are a wider surface than a scan's own figures, so they want their own pass.