### PR TITLE
feat(reports): show meaningful progress while a scan is running

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class ReportsController < Admin::BaseController
     # probes_tab and attempt_content load @report with custom includes — excluded intentionally
-    before_action :set_report, only: [ :show, :destroy, :stop, :asr_history, :top_probes ]
+    before_action :set_report, only: [ :show, :destroy, :stop, :asr_history, :top_probes, :progress ]
     before_action :set_debug_lease_report, only: [ :refresh_debug_lease ]
 
     include TargetsHelper
@@ -161,6 +161,25 @@ module Admin
       authorize @report
       @probe_results = @report.probe_results.for_report_probe_cards.to_a
       render layout: false
+    end
+
+    # Live progress for a run that has not finished, polled from the report page.
+    #
+    # Conditional on the DERIVED representation rather than on updated_at. A run
+    # crossing the stall threshold writes nothing to the database, so an updated_at
+    # etag would serve the same card indefinitely while the answer changed underneath
+    # it -- and a matching etag lets this skip the journal read entirely, which is the
+    # expensive half.
+    def progress
+      authorize @report
+
+      @progress = Reports::Progress.new(@report)
+
+      return unless stale?(etag: @progress.representation_key, public: false)
+
+      render partial: "admin/reports/progress_card_body",
+             locals: { report: @report, progress: @progress },
+             layout: false
     end
 
     # Probe attempt rows loaded on demand from each probe card.

--- a/app/javascript/controllers/report_progress_controller.js
+++ b/app/javascript/controllers/report_progress_controller.js
@@ -1,0 +1,105 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Polls the progress endpoint while a run is in flight and swaps the rendered body in.
+//
+// HTTP rather than a socket on purpose: the answer changes on the order of seconds, a
+// missed update costs nothing, and the endpoint is conditional -- an unchanged
+// representation returns 304 and the server never reads the journal.
+export default class extends Controller {
+  static targets = ["body"]
+  static values = {
+    url: String,
+    interval: { type: Number, default: 5000 }
+  }
+
+  connect() {
+    this.failures = 0
+    this.scheduleNext()
+  }
+
+  disconnect() {
+    this.cancel()
+  }
+
+  cancel() {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  // Only schedules while the rendered body says there is something left to learn. The
+  // server decides that, not the client: it knows the lifecycle, and a client guessing
+  // from a label would keep polling a finished run forever.
+  scheduleNext() {
+    this.cancel()
+    if (!this.shouldPoll()) return
+
+    this.timer = setTimeout(() => this.refresh(), this.delay())
+  }
+
+  shouldPoll() {
+    if (!this.hasBodyTarget) return false
+    return this.bodyTarget.dataset.poll === "true"
+  }
+
+  // Backs off after consecutive failures instead of hammering a server that is already
+  // struggling, and gives up entirely after a run of them rather than polling forever
+  // in a tab nobody is watching.
+  delay() {
+    if (this.failures === 0) return this.intervalValue
+    return Math.min(this.intervalValue * Math.pow(2, this.failures), 60000)
+  }
+
+  async refresh() {
+    try {
+      const response = await fetch(this.urlValue, {
+        headers: { Accept: "text/html" },
+        credentials: "same-origin"
+      })
+
+      if (response.status === 304) {
+        // Nothing changed. Not a failure: the conditional response is the point.
+        this.failures = 0
+        this.scheduleNext()
+        return
+      }
+
+      if (!response.ok) {
+        this.onFailure()
+        return
+      }
+
+      const html = await response.text()
+      this.failures = 0
+      this.replaceBody(html)
+
+      // A finished run stops the loop, and the freshly rendered body is what says so.
+      this.scheduleNext()
+    } catch (error) {
+      this.onFailure()
+    }
+  }
+
+  onFailure() {
+    this.failures += 1
+    if (this.failures >= 5) {
+      // The card keeps showing the last thing we knew, which is honest: it is stale,
+      // not wrong, and reloading the page recovers.
+      this.cancel()
+      return
+    }
+    this.scheduleNext()
+  }
+
+  replaceBody(html) {
+    if (!this.hasBodyTarget) return
+
+    const template = document.createElement("template")
+    template.innerHTML = html.trim()
+    const next = template.content.firstElementChild
+    if (!next) return
+
+    this.bodyTarget.replaceWith(next)
+  }
+}

--- a/app/jobs/check_stale_reports_job.rb
+++ b/app/jobs/check_stale_reports_job.rb
@@ -16,6 +16,11 @@
 #
 # @see HeartbeatThread in script/db_notifier.py (sends heartbeats every 30s)
 # @see RetryInterruptedReportsJob for automatic retry of interrupted scans
+# The four predicates below live in Reports::StallDetection, so the progress card a
+# reader sees and the reaper that acts cannot drift apart: the card must not call a run
+# healthy that this job is about to interrupt, nor warn about one this job considers
+# fine. What to DO about a stalled report -- the retry budget, the failure reasons --
+# stays here.
 class CheckStaleReportsJob < ApplicationJob
   queue_as :default
 
@@ -91,10 +96,7 @@ class CheckStaleReportsJob < ApplicationJob
   # Marks as 'interrupted' for automatic retry if under MAX_INTERRUPT_RETRIES,
   # otherwise marks as permanently 'failed'.
   def check_stale_running_reports
-    stale_reports = Report.running
-                          .where.not(heartbeat_at: nil)
-                          .where.not(pid: nil)
-                          .where("heartbeat_at < ?", HEARTBEAT_TIMEOUT.ago)
+    stale_reports = Reports::StallDetection.stale_heartbeat_scope
 
     stale_reports.find_each do |report|
       # Reload to get latest state (another process may have updated it)
@@ -105,7 +107,7 @@ class CheckStaleReportsJob < ApplicationJob
       # Skip if PID was cleared (now handled by check_orphaned_running_reports)
       next if report.pid.nil?
       # Skip if heartbeat arrived since the query ran
-      next if report.heartbeat_at.nil? || report.heartbeat_at > HEARTBEAT_TIMEOUT.ago
+      next unless Reports::StallDetection.stale_heartbeat?(report)
 
       heartbeat_age = (Time.current - report.heartbeat_at).round
       reason = "Scan stopped responding (no heartbeat for #{HEARTBEAT_TIMEOUT.inspect})"
@@ -134,9 +136,7 @@ class CheckStaleReportsJob < ApplicationJob
   # Marks as 'interrupted' for automatic retry if under MAX_INTERRUPT_RETRIES,
   # otherwise marks as permanently 'failed'.
   def check_never_started_running_reports
-    zombie_reports = Report.running
-                           .where(heartbeat_at: nil)
-                           .where("updated_at < ?", HEARTBEAT_TIMEOUT.ago)
+    zombie_reports = Reports::StallDetection.never_started_scope
 
     zombie_reports.find_each do |report|
       report.reload
@@ -188,10 +188,7 @@ class CheckStaleReportsJob < ApplicationJob
   # The heartbeat distinguishes from never-started (handled separately).
   # The updated_at check provides a safety window against race conditions.
   def check_orphaned_running_reports
-    orphaned_reports = Report.running
-                             .where(pid: nil)
-                             .where.not(heartbeat_at: nil)
-                             .where("updated_at < ?", HEARTBEAT_TIMEOUT.ago)
+    orphaned_reports = Reports::StallDetection.orphaned_scope
 
     orphaned_reports.find_each do |report|
       report.reload
@@ -205,7 +202,7 @@ class CheckStaleReportsJob < ApplicationJob
       # Skip reports with a pending ProcessReportJob — these are completed scans
       # awaiting async processing, not true orphans. This prevents interrupting
       # reports during normal queue backlog between scan completion and processing.
-      if pending_process_job_report_ids.include?(report.id)
+      if awaiting_processing?(report)
         Rails.logger.info(
           "[CheckStaleReports] Report #{report.id} (#{report.uuid}) has pending ProcessReportJob - " \
           "skipping orphan detection (scan completed, awaiting processing)"
@@ -236,8 +233,7 @@ class CheckStaleReportsJob < ApplicationJob
   # Retries up to the start-retry ceiling (max of MAX_START_RETRIES and the
   # interrupt budget; see .start_retry_ceiling) with exponential backoff.
   def check_stuck_starting_reports
-    stuck_reports = Report.starting
-                          .where("updated_at < ?", STARTING_TIMEOUT.ago)
+    stuck_reports = Reports::StallDetection.stuck_starting_scope
 
     stuck_reports.find_each do |report|
       # Reload to get latest state
@@ -339,21 +335,28 @@ class CheckStaleReportsJob < ApplicationJob
   # Report IDs that have a pending ProcessReportJob in Solid Queue.
   # Used to distinguish completed scans awaiting processing from true orphans.
   # Memoized per perform cycle to avoid repeated queries.
-  def pending_process_job_report_ids
-    @pending_process_job_report_ids ||= begin
-      pending_jobs = SolidQueue::Job
-        .where(class_name: "ProcessReportJob")
-        .where(finished_at: nil)
-        .pluck(:arguments)
+  # Delegated so the reaper and the progress card cannot disagree about whether a
+  # report's results are already queued for ingest. It also excludes jobs whose
+  # executions have failed: an exhausted ProcessReportJob keeps finished_at NULL
+  # forever, and treating it as pending exempts the report from orphan detection
+  # permanently -- nothing is going to ingest those results.
+  #
+  # Batched and memoized for one run of this job: asking per report would turn a single
+  # query into one per orphan candidate and re-parse the whole pending set each time.
+  #
+  # nil means the queue could not be read. This job then reaps nothing on that pass
+  # rather than treating "we could not look" as "nothing is pending" and interrupting a
+  # queue of healthy finished scans.
+  def awaiting_processing?(report)
+    ids = awaiting_processing_report_ids
+    return true if ids.nil?
 
-      report_ids = pending_jobs.filter_map do |args_json|
-        args = args_json.is_a?(String) ? JSON.parse(args_json) : args_json
-        args.dig("arguments", 0)&.to_i
-      rescue JSON::ParserError
-        nil
-      end
+    ids.include?(report.id)
+  end
 
-      Set.new(report_ids)
-    end
+  def awaiting_processing_report_ids
+    return @awaiting_processing_report_ids if defined?(@awaiting_processing_report_ids)
+
+    @awaiting_processing_report_ids = Reports::StallDetection.awaiting_processing_report_ids
   end
 end

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -9,6 +9,10 @@ class ReportPolicy < TenantScopedPolicy
     true
   end
 
+  def progress?
+    true
+  end
+
   def top_probes?
     true
   end

--- a/app/services/reports/journal_summary.rb
+++ b/app/services/reports/journal_summary.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+module Reports
+  # What a run has actually finished, read from the journal garak is still writing.
+  #
+  # This is the ONE definition of "completed probe" while a scan is in flight.
+  # Resumption already had one -- RunGarakScan skips probes that produced a valid eval
+  # row -- and a progress figure that counted differently would tell a user a probe was
+  # done that the next attempt then re-ran, or the reverse. RunGarakScan now calls this,
+  # so there is a single answer.
+  #
+  # A probe is complete when it has at least one eval row GarakEvalRowValidator accepts
+  # with a probe and detector present. garak emits one eval per DETECTOR, so counting
+  # rows would multiply a probe by its detector count; the unit is the distinct probe
+  # classname. Rows with a zero total, a missing probe or detector, or impossible counts
+  # are not completed work -- they are exactly what the resume path retries.
+  #
+  # ## Why the journal is read through SQL
+  #
+  # jsonl_data holds every attempt with its full prompts and outputs, so a long run's
+  # column is large. Loading it into Ruby on every poll would allocate all of it per
+  # viewer per cycle, so Postgres splits the journal into lines and returns only the
+  # candidates.
+  #
+  # The filter is a strict SUPERSET of the lines that matter: every real eval or init row
+  # carries `entry_type` at the top level, so it must contain the marker. It cannot be
+  # forged from prompt or output text, because JSON escapes an inner quote as \" -- a
+  # prompt containing the literal marker does not match. Nested objects (an attempt's
+  # `notes`) can match, which costs one extra line of transfer and nothing else: every
+  # candidate is still parsed and re-validated in Ruby.
+  class JournalSummary
+    # Bump when the shape of the cached payload changes, so a deploy cannot read a stale
+    # entry written by the previous shape.
+    CACHE_VERSION = 1
+    CACHE_TTL = 1.hour
+
+    # Anchored on nothing deliberately: `entry_type` is not guaranteed to be the first
+    # key, and garak writes with Python's json.dumps (`"key": "value"`) while specs build
+    # fixtures with Ruby's to_json (`"key":"value"`). Both, and tabs, match.
+    CANDIDATE_LINE_PATTERN = '"entry_type"[[:space:]]*:[[:space:]]*"(eval|init)"'
+
+    # WITH ORDINALITY + ORDER BY: "first init" and "last completed probe" are positional
+    # claims, and a set-returning function's output order is not contractually the input
+    # order.
+    CANDIDATE_LINE_SQL = <<~SQL.squish
+      SELECT candidate.line
+      FROM raw_report_data,
+           LATERAL unnest(string_to_array(raw_report_data.jsonl_data, chr(10)))
+             WITH ORDINALITY AS candidate(line, ordinality)
+      WHERE raw_report_data.report_id = :report_id
+        AND candidate.line ~ :pattern
+      ORDER BY candidate.ordinality
+    SQL
+
+    EMPTY = {
+      completed_probes: [],
+      started_at: nil,
+      last_completed_probe: nil,
+      present: false
+    }.freeze
+
+    # @param report [Report]
+    # @param journal_updated_at [Time, nil, :unknown] raw_report_data.updated_at when the
+    #   caller already has it. It is the cache version: the sync thread only writes when
+    #   the journal content changed, so an unchanged timestamp means an unchanged answer.
+    def self.for(report, journal_updated_at: :unknown)
+      new(report, journal_updated_at: journal_updated_at)
+    end
+
+    def initialize(report, journal_updated_at: :unknown)
+      @report = report
+      @journal_updated_at = journal_updated_at
+    end
+
+    attr_reader :report
+
+    def completed_probes
+      @completed_probes ||= Set.new(payload[:completed_probes])
+    end
+
+    def completed_count
+      completed_probes.size
+    end
+
+    # The run's own start, as garak recorded it. reports.start_time is not written until
+    # Reports::Process ingests the journal, so during a run this is the only source.
+    # First valid init, not last: a resumed run appends a second init, and the elapsed
+    # time a user is judging covers the whole run, not the latest attempt.
+    def started_at
+      payload[:started_at]
+    end
+
+    def last_completed_probe
+      payload[:last_completed_probe]
+    end
+
+    # Whether a journal exists at all. False both before the first sync lands and after
+    # Reports::Cleanup deletes it -- callers must not read "no journal" as "no work done".
+    def present?
+      payload[:present]
+    end
+
+    private
+
+    def payload
+      @payload ||= cached_payload
+    end
+
+    def cached_payload
+      version = journal_version
+      # No journal row: nothing to read, and nothing worth a cache entry either.
+      return EMPTY.dup if version.nil?
+
+      Rails.cache.fetch(cache_key(version), expires_in: CACHE_TTL) { compute_payload }
+    end
+
+    # Scalar read, never the association: RawReportData's default select would pull the
+    # whole jsonl_data blob back just to look at a timestamp. nil means the row is gone.
+    def journal_version
+      unless defined?(@journal_version)
+        @journal_version =
+          if @journal_updated_at == :unknown
+            RawReportData.where(report_id: report.id).pick(:updated_at)
+          else
+            @journal_updated_at
+          end
+      end
+
+      @journal_version
+    end
+
+    def cache_key(version)
+      [ "reports/journal_summary", CACHE_VERSION, report.id, version.to_f ]
+    end
+
+    def compute_payload
+      completed = Set.new
+      started_at = nil
+      last_probe = nil
+
+      candidate_lines.each do |line|
+        entry = parse_line(line)
+        next if entry.nil?
+
+        if entry["entry_type"] == "init"
+          started_at ||= parse_time(entry["start_time"])
+          next
+        end
+
+        next unless GarakEvalRowValidator.valid?(entry, require_probe_detector: true)
+
+        completed.add(entry["probe"])
+        last_probe = entry["probe"]
+      end
+
+      {
+        completed_probes: completed.to_a,
+        started_at: started_at,
+        last_completed_probe: last_probe,
+        # compute_payload only runs when the row exists; a journal holding attempts but
+        # no eval or init line yet is still present, so presence is the row, not matches.
+        present: true
+      }
+    end
+
+    def candidate_lines
+      ActiveRecord::Base.connection.select_values(
+        ActiveRecord::Base.sanitize_sql_array(
+          [ CANDIDATE_LINE_SQL, { report_id: report.id, pattern: CANDIDATE_LINE_PATTERN } ]
+        )
+      )
+    end
+
+    def parse_line(line)
+      parsed = JSON.parse(line.to_s)
+      parsed.is_a?(Hash) ? parsed : nil
+    rescue JSON::ParserError, EncodingError
+      nil
+    end
+
+    def parse_time(value)
+      return nil if value.blank?
+
+      Time.zone.parse(value.to_s)
+    rescue ArgumentError, TypeError
+      nil
+    end
+  end
+end

--- a/app/services/reports/progress.rb
+++ b/app/services/reports/progress.rb
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+module Reports
+  # What to tell a reader about a run that has not finished.
+  #
+  # A running report's page used to render the same four figures a finished one does --
+  # Duration N/A, ASR N/A, 0 / 0 attacks, 0 vulnerabilities -- in the same layout, so a
+  # scan still in flight read as one that had completed and found nothing. Those are not
+  # partial results; they are the absence of any, because probe_results is not written
+  # until the journal is ingested at the end.
+  #
+  # Three separate questions, deliberately not collapsed into one status:
+  #
+  #   PHASE           where the run is in its lifecycle
+  #   OWNERSHIP       whether a scanner process still holds this report
+  #   FEED FRESHNESS  whether what we know is current
+  #
+  # A run can be running and unowned (its process exited, the results are queued for
+  # ingest), or owned and silent (alive but not reporting). Collapsing those would make
+  # one of them a lie.
+  class Progress
+    # How recently the journal must have changed for the feed to count as live. Longer
+    # than a poll interval, because a probe can legitimately take a while to produce its
+    # next line.
+    FEED_FRESH_WINDOW = 60.seconds
+
+    # Bump when the shape of the rendered representation changes, so a cached response
+    # from the previous shape cannot be served after a deploy.
+    REPRESENTATION_VERSION = 1
+
+    PHASE_LABELS = {
+      queued: "Queued",
+      starting: "Starting",
+      running: "Running",
+      stalled: "Not responding",
+      interrupted: "Interrupted, will retry",
+      finalizing: "Recording results",
+      unknown: "Status unavailable",
+      finished: "Finished"
+    }.freeze
+
+    # Phases where the page should keep asking. `finished` is absent on purpose: there
+    # is nothing further to learn.
+    # `unknown` polls too: not knowing is a reason to ask again, not to stop.
+    POLLING_PHASES = %i[queued starting running stalled interrupted finalizing unknown].freeze
+
+    def initialize(report, now: Time.current)
+      @report = report
+      @now = now
+    end
+
+    attr_reader :report, :now
+
+    def phase
+      @phase ||= derive_phase
+    end
+
+    def phase_label
+      PHASE_LABELS.fetch(phase, PHASE_LABELS[:running])
+    end
+
+    def poll?
+      POLLING_PHASES.include?(phase)
+    end
+
+    def in_flight?
+      phase != :finished
+    end
+
+    def stalled?
+      phase == :stalled
+    end
+
+    # Named for what was observed, never for a cause we cannot see. We do not know that
+    # a process died; we know no heartbeat arrived.
+    def stall_reason
+      return nil unless stalled?
+
+      if StallDetection.stuck_starting?(report)
+        "This scan was claimed for launch but never started running."
+      elsif StallDetection.never_started?(report)
+        "This scan started but never reported any activity."
+      elsif StallDetection.stale_heartbeat?(report)
+        "This scan has stopped reporting activity."
+      else
+        "This scan is no longer held by a scanner process."
+      end
+    end
+
+    # :yes / :no / :unknown. A finished scan sits `running` with its pid cleared until
+    # ProcessReportJob runs, so ownership rather than the clock decides between
+    # `finalizing` and `stalled` -- and when the queue cannot be read, neither answer is
+    # earned.
+    def awaiting_processing
+      @awaiting_processing ||= StallDetection.awaiting_processing(report)
+    end
+
+    # A variant child executes mapped threat variants and its recorded plan counts
+    # variants, so calling them probes would misstate what is being measured -- the same
+    # distinction Report#processed_scope_summary makes.
+    def unit
+      report.is_variant_report? ? "variant" : "probe"
+    end
+
+    def completed_units
+      journal.completed_count
+    end
+
+    # The plan recorded at launch. Nil for a report launched before that was recorded,
+    # which is exactly when we must not state a ratio.
+    def total_units
+      recorded = report.planned_probe_count
+      recorded if recorded.present? && recorded.positive?
+    end
+
+    # A ratio is only stated when both halves are real. Anything else shows completed
+    # work alone, rather than inventing a denominator.
+    def determinate?
+      total_units.present? && journal.present?
+    end
+
+    def percent_complete
+      return nil unless determinate?
+
+      # Capped: a resumed run can re-evaluate a probe the plan did not anticipate, and
+      # "7 of 5" reads as a bug rather than as progress.
+      [ (completed_units.to_f / total_units * 100).round, 100 ].min
+    end
+
+    def last_completed_probe
+      journal.last_completed_probe
+    end
+
+    # garak's own start, from the journal. reports.start_time is not written until the
+    # journal is ingested, so during a run this is the only source.
+    def started_at
+      journal.started_at || report.created_at
+    end
+
+    def elapsed_seconds
+      return nil if started_at.nil?
+
+      (now - started_at).round
+    end
+
+    # Exactly what the card shows, so the representation key and the rendered text
+    # cannot disagree about when they change.
+    def elapsed_label
+      return nil if elapsed_seconds.nil?
+
+      ActionController::Base.helpers.distance_of_time_in_words(elapsed_seconds)
+    end
+
+    def last_contact_at
+      [ report.heartbeat_at, journal_updated_at ].compact.max
+    end
+
+    # fresh / stale / unknown -- three answers, because "we have never heard anything"
+    # is not the same as "we heard something and it was a while ago".
+    def feed_state
+      contact = last_contact_at
+      return :unknown if contact.nil?
+
+      contact >= FEED_FRESH_WINDOW.ago(now) ? :fresh : :stale
+    end
+
+    def retry_attempt
+      report.retry_count
+    end
+
+    # Everything the rendered card is derived from. The endpoint is conditional on THIS
+    # rather than on updated_at, so a transition driven only by the clock -- a run
+    # crossing the stall threshold with no database write -- still re-renders, and an
+    # unchanged representation can skip the journal read entirely.
+    def representation_key
+      Digest::SHA256.hexdigest(
+        [
+          REPRESENTATION_VERSION,
+          report.id,
+          report.status,
+          phase,
+          completed_units,
+          total_units,
+          feed_state,
+          retry_attempt,
+          started_at&.to_i,
+          determinate?,
+          journal.present?,
+          last_completed_probe,
+          stall_reason,
+          unit,
+          # The rendered elapsed STRING, not a bucket approximating it.
+          #
+          # A key that changed every five seconds would make every poll a 200 carrying
+          # an identical card, turning the conditional response off while looking like
+          # it works. But a plain per-minute bucket is wrong in the other direction:
+          # distance_of_time_in_words rounds at 30, 90, 150 seconds, so 89s renders
+          # "1 minute" and 90s renders "2 minutes" while sharing bucket 1 -- a 304
+          # carrying text the card has outgrown. Keying what is displayed cannot drift
+          # from what is displayed.
+          elapsed_label
+        ].join("|")
+      )
+    end
+
+    def as_json
+      {
+        phase: phase,
+        phase_label: phase_label,
+        poll: poll?,
+        stalled: stalled?,
+        stall_reason: stall_reason,
+        unit: unit,
+        completed_units: completed_units,
+        total_units: total_units,
+        determinate: determinate?,
+        percent_complete: percent_complete,
+        last_completed_probe: last_completed_probe,
+        started_at: started_at&.iso8601,
+        elapsed_seconds: elapsed_seconds,
+        feed_state: feed_state,
+        retry_attempt: retry_attempt
+      }
+    end
+
+    private
+
+    def derive_phase
+      return :finished if terminal_status?
+
+      case report.status
+      when "pending"
+        :queued
+      when "interrupted"
+        :interrupted
+      when "processing"
+        :finalizing
+      when "starting"
+        StallDetection.stuck_starting?(report) ? :stalled : :starting
+      when "running"
+        running_phase
+      else
+        :running
+      end
+    end
+
+    def running_phase
+      # Ownership first, and ONLY for a report that is orphan-shaped. A run whose
+      # process has exited with results queued for ingest is finalizing, however long
+      # ago its last heartbeat was -- but a run that still holds a pid is neither, and
+      # asking the queue about it would be a query per poll for nothing.
+      if report.pid.nil?
+        case awaiting_processing
+        when :yes then return :finalizing
+        when :unknown
+          # An orphan-shaped report with an unreadable queue could be either finishing
+          # or genuinely stalled, and a fresh launch is neither. Saying so is better
+          # than picking one: guessing `finalizing` would hide a real stall behind a
+          # reassuring label, and guessing `stalled` would raise a false alarm from a
+          # failed query.
+          return :unknown if StallDetection.orphaned?(report)
+        end
+
+        return :stalled if StallDetection.orphaned?(report)
+      end
+
+      return :stalled if StallDetection.stale_heartbeat?(report) || StallDetection.never_started?(report)
+
+      :running
+    end
+
+    # `stopped` is terminal here: Reports::Stop writes it immediately and the scanner
+    # process self-terminates on its next heartbeat, so there is no intermediate
+    # cancelling state to model. Inventing one would describe a lifecycle this app does
+    # not have.
+    def terminal_status?
+      %w[completed failed stopped].include?(report.status)
+    end
+
+    def journal
+      @journal ||= JournalSummary.for(report, journal_updated_at: journal_updated_at)
+    end
+
+    def journal_updated_at
+      unless defined?(@journal_updated_at)
+        @journal_updated_at = RawReportData.where(report_id: report.id).pick(:updated_at)
+      end
+
+      @journal_updated_at
+    end
+  end
+end

--- a/app/services/reports/stall_detection.rb
+++ b/app/services/reports/stall_detection.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+module Reports
+  # The reaper's four predicates, in one place.
+  #
+  # CheckStaleReportsJob decides when a run has stopped making progress and must be
+  # retried or failed. The progress card has to answer the same question for a reader
+  # -- "is this run stuck?" -- and if it derived its own answer the two would drift:
+  # the card would call a run healthy that the reaper was about to interrupt, or warn
+  # about one the reaper considers fine.
+  #
+  # Predicates only. Nothing here decides what to DO about a stalled report; that stays
+  # in the job, along with the retry budget.
+  module StallDetection
+    HEARTBEAT_TIMEOUT = CheckStaleReportsJob::HEARTBEAT_TIMEOUT
+    STARTING_TIMEOUT = CheckStaleReportsJob::STARTING_TIMEOUT
+
+    module_function
+
+    # Running, owned by a live process, but the heartbeat has gone quiet.
+    def stale_heartbeat_scope(relation = Report.all)
+      relation.running
+              .where.not(heartbeat_at: nil)
+              .where.not(pid: nil)
+              .where(heartbeat_at: ...HEARTBEAT_TIMEOUT.ago)
+    end
+
+    # Running, but no heartbeat ever arrived: the process never got far enough to send
+    # one.
+    def never_started_scope(relation = Report.all)
+      relation.running
+              .where(heartbeat_at: nil)
+              .where(updated_at: ...HEARTBEAT_TIMEOUT.ago)
+    end
+
+    # Running with no owning process. NOT necessarily stalled: this is also what a
+    # finished scan looks like between the moment its process exits and the moment
+    # ProcessReportJob picks it up, which is why the reaper exempts reports with a
+    # queued job. Callers that want "stalled" must apply that exemption too -- see
+    # `orphaned?`.
+    def orphaned_scope(relation = Report.all)
+      relation.running
+              .where(pid: nil)
+              .where.not(heartbeat_at: nil)
+              .where(updated_at: ...HEARTBEAT_TIMEOUT.ago)
+    end
+
+    # Claimed for launch but never became running.
+    def stuck_starting_scope(relation = Report.all)
+      relation.starting.where(updated_at: ...STARTING_TIMEOUT.ago)
+    end
+
+    def stale_heartbeat?(report)
+      report.running? && report.heartbeat_at.present? && report.pid.present? &&
+        report.heartbeat_at < HEARTBEAT_TIMEOUT.ago
+    end
+
+    def never_started?(report)
+      report.running? && report.heartbeat_at.nil? && report.updated_at < HEARTBEAT_TIMEOUT.ago
+    end
+
+    # @param awaiting_processing [Boolean] whether a ProcessReportJob is already queued
+    #   for this report. A finished scan sits here with its pid cleared until that job
+    #   runs, so without this it reads as an orphan -- and telling a user their finished
+    #   scan is stuck is worse than saying nothing.
+    def orphaned?(report, awaiting_processing: false)
+      return false if awaiting_processing
+
+      report.running? && report.pid.nil? && report.heartbeat_at.present? &&
+        report.updated_at < HEARTBEAT_TIMEOUT.ago
+    end
+
+    def stuck_starting?(report)
+      report.starting? && report.updated_at < STARTING_TIMEOUT.ago
+    end
+
+    # :yes / :no / :unknown -- whether a ProcessReportJob is waiting to ingest this
+    # report's results.
+    #
+    # Three answers, because the queue lives in its own database and an unreadable one
+    # is not the same as an empty one. A caller that collapsed :unknown into either
+    # answer would either claim a finished scan is stuck or claim a genuinely stalled
+    # one is finishing, on the strength of a failed query.
+    #
+    # Failed executions are excluded: a ProcessReportJob that exhausted its retries
+    # keeps finished_at NULL forever, and counting it as pending would mean nothing is
+    # ever going to ingest those results while we say ingestion is imminent.
+    def awaiting_processing(report)
+      # Savepointed on SolidQueue::Job's OWN connection, not ActiveRecord::Base's. The
+      # queue has its own pool in a real deployment and shares the primary one in tests,
+      # and only the model knows which -- a savepoint opened on the wrong connection
+      # contains nothing, and a failed query would abort the caller's transaction
+      # instead of just this read. A progress card must not be able to break the request
+      # that renders it.
+      queued = SolidQueue::Job.transaction(requires_new: true) do
+        queued_process_job?(report)
+      end
+
+      queued ? :yes : :no
+    rescue ActiveRecord::ActiveRecordError => e
+      Rails.logger.warn("[StallDetection] could not read the job queue: #{e.class}: #{e.message}")
+      :unknown
+    end
+
+    # Batched form for a caller with many reports to judge -- the reaper walks every
+    # orphan candidate, and asking per report turns one query into N transactions and
+    # re-parses the whole pending set each time.
+    #
+    # Returns nil, not an empty set, when the queue cannot be read: an empty set means
+    # "nothing is pending", and a caller must be able to tell that from "we could not
+    # look".
+    def awaiting_processing_report_ids
+      SolidQueue::Job.transaction(requires_new: true) do
+        Set.new(pending_process_job_report_ids)
+      end
+    rescue ActiveRecord::ActiveRecordError => e
+      Rails.logger.warn("[StallDetection] could not read the job queue: #{e.class}: #{e.message}")
+      nil
+    end
+
+    def pending_process_job_report_ids
+      SolidQueue::Job
+        .where(class_name: "ProcessReportJob", finished_at: nil)
+        .where.missing(:failed_execution)
+        .pluck(:arguments)
+        .filter_map do |args_json|
+          args = args_json.is_a?(String) ? JSON.parse(args_json) : args_json
+          args.dig("arguments", 0)&.to_i
+        rescue JSON::ParserError
+          nil
+        end
+    end
+
+    def queued_process_job?(report)
+      SolidQueue::Job
+        .where(class_name: "ProcessReportJob", finished_at: nil)
+        .where.missing(:failed_execution)
+        .pluck(:arguments)
+        .any? do |args_json|
+          args = args_json.is_a?(String) ? JSON.parse(args_json) : args_json
+          args.dig("arguments", 0)&.to_i == report.id
+        rescue JSON::ParserError
+          false
+        end
+    end
+
+    # Any of the four. `awaiting_processing` is passed through to the one predicate it
+    # applies to.
+    def stalled?(report, awaiting_processing: false)
+      stale_heartbeat?(report) || never_started?(report) ||
+        orphaned?(report, awaiting_processing: awaiting_processing) ||
+        stuck_starting?(report)
+    end
+  end
+end

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -646,29 +646,12 @@ class RunGarakScan
   # Parses existing raw_report_data JSONL for eval entries to identify completed probes.
   # A probe is "completed" if it has at least one eval entry in the saved data.
   # Memoized because it's called from both all_probes_completed? and probes_config.
+  # Delegated so resumption and the progress card cannot disagree about what "done"
+  # means. The definition -- a probe with at least one valid eval row -- was already
+  # here; JournalSummary is where it now lives, and it reads the journal through SQL
+  # rather than pulling a long run's whole jsonl_data column into Ruby.
   def completed_probes_from_raw_data
-    @completed_probes_from_raw_data ||= begin
-      raw_data = report.raw_report_data
-      if raw_data&.jsonl_data.present?
-        completed = Set.new
-        raw_data.jsonl_data.each_line do |line|
-          line = line.strip
-          next if line.empty?
-          begin
-            entry = JSON.parse(line)
-            if GarakEvalRowValidator.valid?(entry, require_probe_detector: true)
-              probe_name = entry["probe"]
-              completed.add(probe_name)
-            end
-          rescue JSON::ParserError
-            next
-          end
-        end
-        completed
-      else
-        Set.new
-      end
-    end
+    @completed_probes_from_raw_data ||= Reports::JournalSummary.for(report).completed_probes
   end
 
   # Returns true if all probes have already been completed in a previous run.

--- a/app/views/admin/reports/_progress_card.html.erb
+++ b/app/views/admin/reports/_progress_card.html.erb
@@ -1,0 +1,17 @@
+<%#
+  Shown only while a run has not finished. The body is swapped in by polling; this
+  wrapper is what the Stimulus controller attaches to and is rendered once.
+
+  locals: report, progress
+%>
+<div class="bg-zinc-900 rounded-lg border border-zinc-700 p-4 mb-4"
+     data-controller="report-progress"
+     data-report-progress-url-value="<%= progress_report_path(report) %>"
+     data-report-progress-interval-value="5000">
+  <h2 class="text-xl font-sans font-semibold text-primary tracking-wide mb-3">
+    Scan Progress
+  </h2>
+
+  <%= render partial: "admin/reports/progress_card_body",
+             locals: { report: report, progress: progress } %>
+</div>

--- a/app/views/admin/reports/_progress_card_body.html.erb
+++ b/app/views/admin/reports/_progress_card_body.html.erb
@@ -1,0 +1,73 @@
+<%#
+  The live half of the progress card, re-rendered by the polling controller.
+
+  Everything here is derived from Reports::Progress, which answers phase, ownership and
+  feed freshness separately -- so a run whose process has exited with results queued for
+  ingest reads as "Recording results" rather than as one that stopped responding.
+
+  locals: report, progress
+%>
+<div class="space-y-3"
+     data-report-progress-target="body"
+     data-poll="<%= progress.poll? %>"
+     data-phase="<%= progress.phase %>">
+
+  <div class="flex items-center justify-between gap-3">
+    <div class="flex items-center gap-2">
+      <span class="<%= progress.stalled? ? "text-amber-400" : "text-primary" %> font-sans text-sm font-semibold">
+        <%= progress.phase_label %>
+      </span>
+      <% if progress.feed_state == :stale && !progress.stalled? %>
+        <%# Distinct from stalled: we have heard nothing lately, which is not the same
+            as having decided the run is stuck. %>
+        <span class="text-contentTertiary font-sans text-xs">no recent activity</span>
+      <% end %>
+    </div>
+
+    <% if progress.elapsed_seconds %>
+      <span class="text-contentSecondary font-sans text-xs" data-report-progress-target="elapsed">
+        <%= progress.elapsed_label %> elapsed
+      </span>
+    <% end %>
+  </div>
+
+  <% if progress.determinate? %>
+    <div>
+      <div class="flex justify-between items-baseline mb-1">
+        <span class="text-contentSecondary font-sans text-xs">
+          <%= progress.completed_units %> of <%= progress.total_units %> <%= progress.unit.pluralize %>
+        </span>
+        <span class="text-white font-sans text-xs font-semibold"><%= progress.percent_complete %>%</span>
+      </div>
+      <div class="w-full bg-zinc-800 rounded-full h-2 overflow-hidden">
+        <div class="bg-primary h-2 rounded-full transition-all duration-500"
+             style="width: <%= progress.percent_complete %>%"></div>
+      </div>
+    </div>
+  <% elsif progress.completed_units.positive? %>
+    <%# Completed work alone, rather than inventing a denominator we do not have. %>
+    <p class="text-contentSecondary font-sans text-xs">
+      <%= pluralize(progress.completed_units, progress.unit) %> completed so far
+    </p>
+  <% end %>
+
+  <% if progress.last_completed_probe.present? %>
+    <p class="text-contentTertiary font-sans text-xs truncate">
+      Last finished: <%= progress.last_completed_probe %>
+    </p>
+  <% end %>
+
+  <% if progress.stalled? %>
+    <p class="text-amber-400 font-sans text-xs"><%= progress.stall_reason %></p>
+  <% end %>
+
+  <% if progress.retry_attempt.positive? %>
+    <p class="text-contentTertiary font-sans text-xs">
+      Attempt <%= progress.retry_attempt + 1 %> after an interruption
+    </p>
+  <% end %>
+
+  <p class="text-contentTertiary font-sans text-xs">
+    Results are recorded when the scan finishes, so the figures below stay pending until then.
+  </p>
+</div>

--- a/app/views/admin/reports/_show_v2.html.erb
+++ b/app/views/admin/reports/_show_v2.html.erb
@@ -42,7 +42,13 @@
         <%= render partial: 'reports/partial_results_notice', locals: { report: report } %>
       <% end %>
 
-      <%= render partial: 'admin/reports/statistics_section', locals: { report: report } %>
+      <% progress = Reports::Progress.new(report) %>
+      <% if progress.in_flight? %>
+        <%= render partial: 'admin/reports/progress_card', locals: { report: report, progress: progress } %>
+      <% end %>
+
+      <%= render partial: 'admin/reports/statistics_section',
+                 locals: { report: report, in_flight: progress.in_flight? } %>
 
       <% if show_activity_stream_for_report?(report, params: params, user: current_user) %>
         <%= render partial: 'admin/reports/logs_section',

--- a/app/views/admin/reports/_statistics_section.html.erb
+++ b/app/views/admin/reports/_statistics_section.html.erb
@@ -1,3 +1,13 @@
+<%#
+  in_flight: the run has not been ingested yet, so probe_results is still empty and
+  every figure below would render as N/A, 0 / 0 and 0. Those are not partial results --
+  they are the absence of any -- and showing them in the identical layout a finished
+  report uses is what made an in-progress scan read as one that found nothing. Live
+  progress belongs to the progress card; this section says, once, that results arrive
+  at the end.
+%>
+<% in_flight = local_assigns.fetch(:in_flight, false) %>
+<% pending_marker = content_tag(:span, "Pending", class: "text-contentTertiary font-sans text-sm italic") %>
 <div class="bg-zinc-900 rounded-lg border border-zinc-700 p-4">
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
     <%# Left Column - Key Statistics %>
@@ -9,22 +19,22 @@
       <div class="space-y-2">
         <div class="flex justify-between items-center">
           <span class="text-contentSecondary font-sans text-sm">Duration</span>
-          <span class="text-white font-sans text-sm"><%= formatted_duration(report) %></span>
+          <span class="text-white font-sans text-sm"><%= in_flight ? pending_marker : formatted_duration(report) %></span>
         </div>
 
         <div class="flex justify-between items-center">
           <span class="text-contentSecondary font-sans text-sm">Attack Success Rate</span>
-          <% asr_figure = report.asr %><span class="<%= asr_color_class(asr_figure.percent) %> font-sans text-sm font-semibold"><%= asr_display(asr_figure) %></span>
+          <% if in_flight %><%= pending_marker %><% else %><% asr_figure = report.asr %><span class="<%= asr_color_class(asr_figure.percent) %> font-sans text-sm font-semibold"><%= asr_display(asr_figure) %></span><% end %>
         </div>
 
         <div class="flex justify-between items-center">
           <span class="text-contentSecondary font-sans text-sm">Attacks Succeeded</span>
-          <span class="text-white font-sans text-sm"><%= report.total_successful_attacks %> / <%= report.total_attacks %></span>
+          <span class="text-white font-sans text-sm"><%= in_flight ? pending_marker : "#{report.total_successful_attacks} / #{report.total_attacks}" %></span>
         </div>
 
         <div class="flex justify-between items-center">
           <span class="text-contentSecondary font-sans text-sm">Vulnerabilities Found</span>
-          <span class="text-primary font-sans text-sm font-semibold"><%= report.security_vulnerabilities_count %></span>
+          <span class="text-primary font-sans text-sm font-semibold"><%= in_flight ? pending_marker : report.security_vulnerabilities_count %></span>
         </div>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
         get :top_probes
         get :probes_tab
         get :probe_attempts
+        get :progress
         get :attempt_content
         post :refresh_debug_lease
       end

--- a/script/tests/javascript_controller_tests.mjs
+++ b/script/tests/javascript_controller_tests.mjs
@@ -1561,6 +1561,165 @@ async function testDashboardControllerAvgAsrScoreRendering() {
   assert.equal(await renderedScoreText(42.5), "42.5%")
 }
 
+
+// The progress controller polls an endpoint and swaps the rendered card body in. Its
+// whole job is deciding WHEN to ask again, so the tests drive the clock and the
+// responses rather than the DOM.
+function loadReportProgressController({ responses = [] } = {}) {
+  const transformed = loadControllerSource(
+    "report_progress_controller.js",
+    "ReportProgressController"
+  )
+
+  const timers = []
+  const calls = []
+
+  const makeElement = (attrs = {}) => ({
+    dataset: { ...attrs },
+    replaced: null,
+    replaceWith(next) { this.replaced = next }
+  })
+
+  const context = {
+    Controller: class {},
+    console: { warn() {} },
+    clearTimeout(id) {
+      const timer = timers[id - 1]
+      if (timer) timer.cancelled = true
+    },
+    setTimeout(fn, delay) {
+      timers.push({ fn, delay, cancelled: false })
+      return timers.length
+    },
+    document: {
+      createElement() {
+        return {
+          innerHTML: "",
+          content: { get firstElementChild() { return makeElement({ poll: "false" }) } }
+        }
+      }
+    },
+    fetch: async (url) => {
+      calls.push(url)
+      const next = responses.shift()
+      if (next instanceof Error) throw next
+      return next || { ok: true, status: 200, text: async () => "<div></div>" }
+    }
+  }
+  context.Math = Math
+
+  const ControllerClass = vm.runInNewContext(
+    `${transformed}\nReportProgressController`,
+    context
+  )
+
+  const build = ({ poll = "true" } = {}) => {
+    const instance = new ControllerClass()
+    const body = makeElement({ poll })
+    instance.hasBodyTarget = true
+    instance.bodyTarget = body
+    instance.urlValue = "/reports/1/progress"
+    instance.intervalValue = 5000
+    return { instance, body }
+  }
+
+  return { build, timers, calls, makeElement }
+}
+
+function testReportProgressSchedulesOnlyWhileWorkRemains() {
+  const { build, timers } = loadReportProgressController()
+
+  const running = build({ poll: "true" })
+  running.instance.connect()
+  // The SERVER decides whether there is more to learn; a client guessing from a label
+  // would poll a finished run forever.
+  assert.equal(timers.filter((t) => !t.cancelled).length, 1)
+
+  const finished = build({ poll: "false" })
+  finished.instance.connect()
+  assert.equal(timers.filter((t) => !t.cancelled).length, 1)
+}
+
+function testReportProgressStopsOnDisconnect() {
+  const { build, timers } = loadReportProgressController()
+  const { instance } = build()
+
+  instance.connect()
+  instance.disconnect()
+
+  assert.equal(timers.every((t) => t.cancelled), true)
+}
+
+async function testReportProgressTreatsNotModifiedAsSuccess() {
+  const { build, timers, calls } = loadReportProgressController({
+    responses: [ { ok: false, status: 304 } ]
+  })
+  const { instance } = build()
+
+  instance.connect()
+  await instance.refresh()
+
+  // 304 is the endpoint working as designed, not a failure -- backing off on it would
+  // slow the poll down exactly when nothing is wrong.
+  assert.equal(instance.failures, 0)
+  assert.equal(calls.length, 1)
+  assert.equal(timers[timers.length - 1].delay, 5000)
+}
+
+async function testReportProgressBacksOffThenGivesUp() {
+  const { build, timers } = loadReportProgressController({
+    responses: [
+      { ok: false, status: 500 },
+      { ok: false, status: 500 },
+      { ok: false, status: 500 },
+      { ok: false, status: 500 },
+      { ok: false, status: 500 }
+    ]
+  })
+  const { instance } = build()
+
+  instance.connect()
+  await instance.refresh()
+  assert.equal(instance.failures, 1)
+  assert.equal(timers[timers.length - 1].delay, 10000)
+
+  await instance.refresh()
+  assert.equal(timers[timers.length - 1].delay, 20000)
+
+  await instance.refresh()
+  await instance.refresh()
+  const scheduledBeforeGivingUp = timers.length
+
+  await instance.refresh()
+  // After a run of failures it stops rather than polling forever in a tab nobody is
+  // watching. The card keeps showing the last thing we knew, which is stale, not wrong.
+  assert.equal(instance.failures, 5)
+  assert.equal(timers.length, scheduledBeforeGivingUp)
+}
+
+async function testReportProgressSurvivesANetworkError() {
+  const { build } = loadReportProgressController({
+    responses: [ new Error("offline") ]
+  })
+  const { instance } = build()
+
+  instance.connect()
+  await instance.refresh()
+
+  assert.equal(instance.failures, 1)
+}
+
+async function testReportProgressSwapsTheRenderedBody() {
+  const { build } = loadReportProgressController({
+    responses: [ { ok: true, status: 200, text: async () => "<div data-poll=\"false\"></div>" } ]
+  })
+  const { instance, body } = build()
+
+  await instance.refresh()
+
+  assert.notEqual(body.replaced, null)
+}
+
 await testDebugStreamLeaseController()
 testActivityStreamController()
 testDebugTabsController()
@@ -1578,4 +1737,10 @@ testGaugeChartConfigDetailFormatter()
 testGaugeChartConfigPointer()
 testGaugeChartConfigTooltipFormatter()
 await testDashboardControllerAvgAsrScoreRendering()
+testReportProgressSchedulesOnlyWhileWorkRemains()
+testReportProgressStopsOnDisconnect()
+await testReportProgressTreatsNotModifiedAsSuccess()
+await testReportProgressBacksOffThenGivesUp()
+await testReportProgressSurvivesANetworkError()
+await testReportProgressSwapsTheRenderedBody()
 console.log("JavaScript controller tests passed")

--- a/spec/e2e/interrupted_reports_e2e_spec.rb
+++ b/spec/e2e/interrupted_reports_e2e_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Interrupted Reports E2E", type: :feature do
     # Don't actually run garak scans
     allow_any_instance_of(RunGarakScan).to receive(:call)
     # Stub the Solid Queue lookup - in test env we don't have Solid Queue tables
-    allow_any_instance_of(CheckStaleReportsJob).to receive(:pending_process_job_report_ids).and_return(Set.new)
+    allow(Reports::StallDetection).to receive(:awaiting_processing_report_ids).and_return(Set.new)
   end
 
   describe "Scenario 1: Pod crash during scan execution" do

--- a/spec/integration/interrupted_reports_lifecycle_spec.rb
+++ b/spec/integration/interrupted_reports_lifecycle_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Interrupted Reports Lifecycle", type: :integration do
     allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
     allow_any_instance_of(RunGarakScan).to receive(:call)
     # Stub the Solid Queue lookup - in test env we don't have Solid Queue tables
-    allow_any_instance_of(CheckStaleReportsJob).to receive(:pending_process_job_report_ids).and_return(Set.new)
+    allow(Reports::StallDetection).to receive(:awaiting_processing_report_ids).and_return(Set.new)
   end
 
   describe "complete lifecycle: running -> interrupted -> pending -> starting" do

--- a/spec/jobs/check_stale_reports_job_spec.rb
+++ b/spec/jobs/check_stale_reports_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CheckStaleReportsJob, type: :job do
     allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
     # Stub the Solid Queue lookup - in test env we don't have Solid Queue tables
     # Default: return empty set (no pending jobs found)
-    allow_any_instance_of(described_class).to receive(:pending_process_job_report_ids).and_return(Set.new)
+    allow(Reports::StallDetection).to receive(:awaiting_processing_report_ids).and_return(Set.new)
   end
 
   describe "#perform" do
@@ -411,8 +411,7 @@ RSpec.describe CheckStaleReportsJob, type: :job do
           report = create(:report, target: target, scan: scan, status: :running,
                           pid: nil, heartbeat_at: 1.minute.ago, updated_at: 3.minutes.ago, retry_count: 0)
 
-          allow_any_instance_of(described_class).to receive(:pending_process_job_report_ids)
-            .and_return(Set.new([ report.id ]))
+          allow(Reports::StallDetection).to receive(:awaiting_processing_report_ids).and_return(Set.new([ report.id ]))
 
           described_class.new.perform
 

--- a/spec/requests/admin/reports_progress_spec.rb
+++ b/spec/requests/admin/reports_progress_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GET /reports/:id/progress", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, :super_admin, company: company) }
+  let(:report) do
+    ActsAsTenant.with_tenant(company) { create(:report, company: company, status: :running) }
+  end
+
+  before do
+    user.update!(current_company: company)
+    sign_in user
+    ActsAsTenant.current_tenant = company
+  end
+
+  it "renders the progress body for a run in flight" do
+    ActsAsTenant.with_tenant(company) { report.update_columns(pid: 1, heartbeat_at: Time.current) }
+
+    get progress_report_path(report)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Running")
+    expect(response.body).not_to include("<!DOCTYPE html>")
+  end
+
+  it "answers 304 when the derived representation has not changed" do
+    ActsAsTenant.with_tenant(company) { report.update_columns(pid: 1, heartbeat_at: Time.current) }
+
+    get progress_report_path(report)
+    etag = response.headers["ETag"]
+    expect(etag).to be_present
+
+    get progress_report_path(report), headers: { "HTTP_IF_NONE_MATCH" => etag }
+
+    # The point of the conditional response: a matching etag skips the journal read,
+    # which is the expensive half of answering.
+    expect(response).to have_http_status(:not_modified)
+  end
+
+  it "re-renders when the representation changes even though the row did not" do
+    # Crossing the stall threshold writes nothing to the database, so an etag derived
+    # from updated_at would serve the same card indefinitely.
+    ActsAsTenant.with_tenant(company) { report.update_columns(pid: 1, heartbeat_at: Time.current) }
+    get progress_report_path(report)
+    etag = response.headers["ETag"]
+
+    ActsAsTenant.with_tenant(company) { report.update_columns(heartbeat_at: 1.hour.ago) }
+
+    get progress_report_path(report), headers: { "HTTP_IF_NONE_MATCH" => etag }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Not responding")
+  end
+
+  it "tells the client to stop polling once the run has finished" do
+    ActsAsTenant.with_tenant(company) { report.update!(status: :completed) }
+
+    get progress_report_path(report)
+
+    expect(response.body).to include('data-poll="false"')
+  end
+end

--- a/spec/services/reports/journal_summary_spec.rb
+++ b/spec/services/reports/journal_summary_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The single definition of "completed probe" while a scan is in flight. Resumption and
+# the progress card both read it, so a disagreement here would tell a user a probe was
+# done that the next attempt then re-ran, or the reverse.
+RSpec.describe Reports::JournalSummary do
+  let(:company) { create(:company) }
+  let(:report) { ActsAsTenant.with_tenant(company) { create(:report, company: company) } }
+
+  def journal(*lines)
+    create(:raw_report_data, report: report, jsonl_data: lines.map(&:to_json).join("\n"), logs_data: nil)
+  end
+
+  def eval_row(probe:, detector: "detector.test", passed: 1, total: 4)
+    { entry_type: "eval", probe: probe, detector: detector, passed: passed, total_evaluated: total }
+  end
+
+  describe "completed probes" do
+    it "counts a probe once however many detectors evaluated it" do
+      # garak emits one eval per DETECTOR. Counting rows would multiply a probe by its
+      # detector count and report more work done than there is.
+      journal(eval_row(probe: "0din.A", detector: "detector.one"),
+              eval_row(probe: "0din.A", detector: "detector.two"))
+
+      expect(described_class.for(report).completed_count).to eq(1)
+    end
+
+    it "ignores an eval row that evaluated nothing" do
+      # A zero total is not completed work -- it is what the resume path retries.
+      journal(eval_row(probe: "0din.A", total: 0))
+
+      expect(described_class.for(report).completed_probes).to be_empty
+    end
+
+    it "ignores an eval row with no probe or detector" do
+      journal({ entry_type: "eval", passed: 1, total_evaluated: 4 })
+
+      expect(described_class.for(report).completed_probes).to be_empty
+    end
+
+    it "ignores impossible counts" do
+      journal(eval_row(probe: "0din.A", passed: 9, total: 4))
+
+      expect(described_class.for(report).completed_probes).to be_empty
+    end
+
+    it "reports the last completed probe in journal order" do
+      journal(eval_row(probe: "0din.A"), eval_row(probe: "0din.B"))
+
+      expect(described_class.for(report).last_completed_probe).to eq("0din.B")
+    end
+  end
+
+  describe "start time" do
+    it "takes the FIRST init, so a resumed run still reports the whole run's start" do
+      journal({ entry_type: "init", start_time: "2026-08-26T10:00:00Z" },
+              eval_row(probe: "0din.A"),
+              { entry_type: "init", start_time: "2026-08-26T12:00:00Z" })
+
+      expect(described_class.for(report).started_at).to eq(Time.zone.parse("2026-08-26T10:00:00Z"))
+    end
+
+    it "is nil when no init has been written yet" do
+      journal(eval_row(probe: "0din.A"))
+
+      expect(described_class.for(report).started_at).to be_nil
+    end
+  end
+
+  describe "presence" do
+    it "is false before any journal exists" do
+      # Callers must not read "no journal" as "no work done": the row is also absent
+      # before the first sync lands and after cleanup deletes it.
+      summary = described_class.for(report)
+
+      expect(summary.present?).to be(false)
+      expect(summary.completed_probes).to be_empty
+    end
+
+    it "is true for a journal holding only attempts" do
+      journal({ entry_type: "attempt", probe_classname: "0din.A", uuid: "x" })
+
+      expect(described_class.for(report).present?).to be(true)
+    end
+  end
+
+  describe "reading through SQL" do
+    it "is not fooled by a prompt containing the entry_type marker" do
+      # JSON escapes an inner quote as \", so a prompt quoting the marker cannot match
+      # the candidate filter -- and every candidate is re-validated in Ruby anyway.
+      journal({ entry_type: "attempt", uuid: "x",
+                prompt: %q(here is a line: "entry_type": "eval" and a probe),
+                outputs: [ "ok" ] },
+              eval_row(probe: "0din.Real"))
+
+      expect(described_class.for(report).completed_probes).to contain_exactly("0din.Real")
+    end
+
+    it "survives a malformed line" do
+      raw = create(:raw_report_data, report: report, logs_data: nil,
+                   jsonl_data: [ "{not json", eval_row(probe: "0din.A").to_json ].join("\n"))
+      expect(raw).to be_persisted
+
+      expect(described_class.for(report).completed_probes).to contain_exactly("0din.A")
+    end
+  end
+
+  describe "caching" do
+    # The test environment uses :null_store, so the cache is exercised explicitly here
+    # rather than relied on implicitly.
+    around do |example|
+      previous = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      example.run
+      Rails.cache = previous
+    end
+
+    it "does not recompute while the journal timestamp is unchanged" do
+      journal(eval_row(probe: "0din.A"))
+      described_class.for(report).completed_probes
+
+      expect_any_instance_of(described_class).not_to receive(:compute_payload)
+      expect(described_class.for(report).completed_probes).to contain_exactly("0din.A")
+    end
+
+    it "recomputes once the journal has been written again" do
+      raw = journal(eval_row(probe: "0din.A"))
+      expect(described_class.for(report).completed_probes).to contain_exactly("0din.A")
+
+      raw.update!(jsonl_data: [ eval_row(probe: "0din.A"), eval_row(probe: "0din.B") ].map(&:to_json).join("\n"))
+
+      expect(described_class.for(report).completed_probes).to contain_exactly("0din.A", "0din.B")
+    end
+  end
+end

--- a/spec/services/reports/progress_spec.rb
+++ b/spec/services/reports/progress_spec.rb
@@ -1,0 +1,237 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Three separate questions -- phase, ownership, feed freshness -- deliberately not
+# collapsed into one status. A run can be running and unowned (process exited, results
+# queued for ingest) or owned and silent (alive but not reporting); collapsing those
+# would make one of them a lie.
+RSpec.describe Reports::Progress do
+  let(:company) { create(:company) }
+  let(:report) do
+    ActsAsTenant.with_tenant(company) { create(:report, company: company, status: status) }
+  end
+  let(:status) { :running }
+
+  subject(:progress) { described_class.new(report) }
+
+  def journal(*lines)
+    create(:raw_report_data, report: report, logs_data: nil,
+           jsonl_data: lines.map(&:to_json).join("\n"))
+  end
+
+  def eval_row(probe:)
+    { entry_type: "eval", probe: probe, detector: "detector.test", passed: 1, total_evaluated: 4 }
+  end
+
+  describe "phase" do
+    context "pending" do
+      let(:status) { :pending }
+      it { expect(progress.phase).to eq(:queued) }
+    end
+
+    context "interrupted" do
+      let(:status) { :interrupted }
+      it { expect(progress.phase).to eq(:interrupted) }
+    end
+
+    context "processing" do
+      let(:status) { :processing }
+      it { expect(progress.phase).to eq(:finalizing) }
+    end
+
+    context "completed" do
+      let(:status) { :completed }
+
+      it "is finished and stops polling" do
+        expect(progress.phase).to eq(:finished)
+        expect(progress.poll?).to be(false)
+        expect(progress.in_flight?).to be(false)
+      end
+    end
+
+    context "starting" do
+      let(:status) { :starting }
+
+      it "is starting while it is still fresh" do
+        report.update_columns(updated_at: Time.current)
+        expect(progress.phase).to eq(:starting)
+      end
+
+      it "is stalled once it has been claimed too long without running" do
+        report.update_columns(updated_at: 10.minutes.ago)
+        expect(progress.phase).to eq(:stalled)
+      end
+    end
+
+    context "running with a live heartbeat" do
+      it "is running" do
+        report.update_columns(pid: 123, heartbeat_at: Time.current)
+        expect(progress.phase).to eq(:running)
+      end
+    end
+
+    context "running with a silent heartbeat" do
+      it "is stalled" do
+        report.update_columns(pid: 123, heartbeat_at: 10.minutes.ago)
+        expect(progress.phase).to eq(:stalled)
+      end
+    end
+
+    context "running with no owning process" do
+      before { report.update_columns(pid: nil, heartbeat_at: 10.minutes.ago, updated_at: 10.minutes.ago) }
+
+      it "is finalizing while its results are queued for ingest" do
+        # A finished scan looks exactly like an orphan until ProcessReportJob runs.
+        # Telling a user their completed scan is stuck is worse than saying nothing.
+        allow(Reports::StallDetection).to receive(:awaiting_processing).and_return(:yes)
+
+        expect(progress.phase).to eq(:finalizing)
+      end
+
+      it "says so plainly when the queue cannot be read" do
+        # Neither answer is earned from a failed query: guessing finalizing would hide a
+        # real stall behind a reassuring label, and guessing stalled would raise a false
+        # alarm. Polling continues, because not knowing is a reason to ask again.
+        allow(Reports::StallDetection).to receive(:awaiting_processing).and_return(:unknown)
+
+        expect(progress.phase).to eq(:unknown)
+        expect(progress.poll?).to be(true)
+      end
+
+      it "is stalled when nothing is queued to pick it up" do
+        allow(Reports::StallDetection).to receive(:awaiting_processing).and_return(:no)
+
+        expect(progress.phase).to eq(:stalled)
+      end
+    end
+  end
+
+  describe "stall reason" do
+    it "describes what was observed, not a cause it cannot see" do
+      report.update_columns(pid: 123, heartbeat_at: 10.minutes.ago)
+
+      # Not "the process died" -- we know no heartbeat arrived, not why.
+      expect(progress.stall_reason).to eq("This scan has stopped reporting activity.")
+    end
+
+    it "is absent when the run is healthy" do
+      report.update_columns(pid: 123, heartbeat_at: Time.current)
+
+      expect(progress.stall_reason).to be_nil
+    end
+  end
+
+  describe "the ratio" do
+    before { report.update_columns(pid: 123, heartbeat_at: Time.current) }
+
+    it "is stated when both halves are real" do
+      report.update_columns(planned_probe_count: 4)
+      journal(eval_row(probe: "0din.A"), eval_row(probe: "0din.B"))
+
+      expect(progress.determinate?).to be(true)
+      expect(progress.completed_units).to eq(2)
+      expect(progress.percent_complete).to eq(50)
+    end
+
+    it "is withheld when no plan was recorded" do
+      # Inventing a denominator would be worse than showing completed work alone.
+      journal(eval_row(probe: "0din.A"))
+
+      expect(progress.determinate?).to be(false)
+      expect(progress.percent_complete).to be_nil
+      expect(progress.completed_units).to eq(1)
+    end
+
+    it "is withheld before any journal exists" do
+      report.update_columns(planned_probe_count: 4)
+
+      expect(progress.determinate?).to be(false)
+    end
+
+    it "cannot exceed 100" do
+      # A resumed run can re-evaluate a probe the plan did not anticipate.
+      report.update_columns(planned_probe_count: 1)
+      journal(eval_row(probe: "0din.A"), eval_row(probe: "0din.B"))
+
+      expect(progress.percent_complete).to eq(100)
+    end
+  end
+
+  describe "the unit" do
+    it "is probes for an ordinary report" do
+      expect(progress.unit).to eq("probe")
+    end
+
+    it "is variants for a variant child, whose plan counts variants" do
+      allow(report).to receive(:is_variant_report?).and_return(true)
+
+      expect(progress.unit).to eq("variant")
+    end
+  end
+
+  describe "feed freshness" do
+    it "is unknown when nothing has ever been heard" do
+      expect(progress.feed_state).to eq(:unknown)
+    end
+
+    it "is fresh on a recent heartbeat" do
+      report.update_columns(heartbeat_at: 5.seconds.ago)
+      expect(progress.feed_state).to eq(:fresh)
+    end
+
+    it "is stale on an old one" do
+      report.update_columns(heartbeat_at: 10.minutes.ago)
+      expect(progress.feed_state).to eq(:stale)
+    end
+  end
+
+  describe "the representation key" do
+    before { report.update_columns(pid: 123, heartbeat_at: Time.current, planned_probe_count: 4) }
+
+    it "changes when completed work changes" do
+      journal(eval_row(probe: "0din.A"))
+      before_key = described_class.new(report).representation_key
+
+      report.raw_report_data.update!(
+        jsonl_data: [ eval_row(probe: "0din.A"), eval_row(probe: "0din.B") ].map(&:to_json).join("\n")
+      )
+
+      expect(described_class.new(report.reload).representation_key).not_to eq(before_key)
+    end
+
+    it "does not change across a poll interval when nothing has happened" do
+      # The card renders elapsed time as "6 minutes", so a key that moved every few
+      # seconds would make every poll a 200 carrying an identical card -- the
+      # conditional response switched off while looking like it works.
+      journal(eval_row(probe: "0din.A"))
+      now = Time.current
+
+      expect(described_class.new(report, now: now + 5.seconds).representation_key)
+        .to eq(described_class.new(report, now: now).representation_key)
+    end
+
+    it "changes exactly when the displayed elapsed text does" do
+      # distance_of_time_in_words rounds at 30, 90, 150 seconds. A plain per-minute
+      # bucket would give 89s and 90s the same key while they render "1 minute" and
+      # "2 minutes" -- a 304 carrying text the card has outgrown.
+      journal(eval_row(probe: "0din.A"))
+      started = report.created_at
+
+      at = ->(seconds) { described_class.new(report, now: started + seconds) }
+
+      expect(at.call(89).elapsed_label).not_to eq(at.call(90).elapsed_label)
+      expect(at.call(89).representation_key).not_to eq(at.call(90).representation_key)
+      expect(at.call(91).representation_key).to eq(at.call(90).representation_key)
+    end
+
+    it "changes on a transition driven only by the clock" do
+      # Crossing the stall threshold writes nothing to the database, so a key derived
+      # from updated_at would serve a stale card indefinitely.
+      journal(eval_row(probe: "0din.A"))
+      healthy = described_class.new(report, now: Time.current).representation_key
+
+      expect(described_class.new(report, now: 1.hour.from_now).representation_key).not_to eq(healthy)
+    end
+  end
+end


### PR DESCRIPTION
A running scan's report page showed "Running" beside `Duration N/A`, `Attack Success Rate N/A`, `Attacks Succeeded 0 / 0` and `Vulnerabilities Found 0` — the same four figures a finished report renders in the same layout, so a scan still in flight read as one that had completed and found nothing. Those are not partial results; `probe_results` is not written at all until the journal is ingested at the end.

Adds a progress card, polled over HTTP.

**`Reports::JournalSummary`** reads completed work from the journal garak is still writing. This is now the one definition of "completed probe": `RunGarakScan`'s resume logic already had one — a probe with a valid eval row — and a progress figure that counted differently would tell a user a probe was done that the next attempt then re-ran. `RunGarakScan` calls it too. Postgres filters the journal to candidate lines, so a long run's `jsonl_data` is never pulled into Ruby.

**`Reports::StallDetection`** holds the reaper's four predicates and its queue lookup. `CheckStaleReportsJob` decides when a run has stopped making progress, and the card has to answer the same question for a reader; deriving it separately would let the card call a run healthy that the reaper was about to interrupt. The reaper's behaviour is unchanged except that jobs with a failed execution no longer count as pending — an exhausted `ProcessReportJob` keeps `finished_at` NULL forever, and was exempting its report from orphan detection permanently.

**`Reports::Progress`** asks phase, scanner ownership and feed freshness separately. A run can be running and unowned (its process has exited with results queued for ingest) or owned and silent (alive but not reporting); collapsing those would make one of them a lie. A finished scan sits `running` with its pid cleared until `ProcessReportJob` runs, so the card reports that as "Recording results" rather than telling someone their completed scan is stuck. When the queue cannot be read at all the phase is "Status unavailable" and polling continues, because neither answer is earned from a failed query. A ratio is stated only when there is a recorded plan *and* a journal to count against.

**`GET /reports/:id/progress`** is conditional on the derived representation rather than on `updated_at`: a run crossing the stall threshold writes nothing to the database, so an `updated_at` etag would serve the same card indefinitely, and a matching etag lets the request skip the journal read entirely. The key includes the rendered elapsed *string* rather than a bucket approximating it, so it cannot change more often than the card does — or less.

Key Statistics renders `Pending` while a run is in flight instead of N/A and zeros.

There is no cancelling phase: `Reports::Stop` writes `stopped` immediately and the scanner process self-terminates on its next heartbeat, so modelling an intermediate state would describe a lifecycle this app does not have.

### Verification

Against a live run, the card tracked `Running`, then no-recent-activity, then "Interrupted, will retry", then "Queued — attempt 2 after an interruption", and disappeared when the run finished, leaving `Duration 6 minutes / ASR 50.0% / 4 of 8 / 1 vulnerability` in its place. The endpoint answered 200 once and 304 thereafter, including across a full poll interval.

### Not addressed here

A report left in `processing` by a job that failed after the status was written reads as "Recording results" indefinitely. That predates this change and is a lifecycle gap rather than a display one.