### PR TITLE
fix(deploy): refuse to start on the placeholder secrets this repo ships

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,19 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore Python bytecode. The build context is the working tree, so a local
+# `docker compose build` would otherwise bake whatever __pycache__ happens to be
+# lying about -- and a .pyc embeds the ABSOLUTE path of the machine that compiled
+# it. CI builds from a fresh checkout and none of these are tracked, so this
+# protects local and repackaged images rather than the published one.
+# `**/` because .dockerignore uses Go filepath.Match, where `*` does not cross a
+# `/` -- a bare `__pycache__/` or `*.pyc` matches only at the context root and lets
+# script/garak_plugins/__pycache__/*.pyc straight through. Verified by building a
+# throwaway image both ways.
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+
 # Ignore all environment files.
 /.env*
 

--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,16 @@
 # Copy this file to .env and update with your actual values
 
 # Rails Configuration
+#
+# Left EMPTY on purpose. The Compose files guard this with ${SECRET_KEY_BASE:?...},
+# which fires on an unset or empty value and NOT on a non-empty one -- so a
+# placeholder here would sail through the guard and every deployment that copied this
+# file unchanged would share one key. Rails derives the ActiveRecord encryption keys
+# from it, so that is the keys protecting stored target credentials, published in a
+# public repository.
+#
 # Generate with: openssl rand -hex 64
-SECRET_KEY_BASE=generate_me_with_openssl_rand_hex_64
+SECRET_KEY_BASE=
 SOLID_QUEUE_IN_PUMA=true
 RUBY_YJIT_ENABLE=1  # Enable YJIT for ~2x performance boost (Ruby 3.3+)
 
@@ -36,7 +44,14 @@ ASSUME_SSL=false  # true behind a TLS-terminating proxy; also decides whether th
 # POSTGRES_PASSWORD is required for production compose (docker-compose.yml)
 # For managed PostgreSQL (AWS RDS, Azure, Google Cloud SQL), also set POSTGRES_HOST
 POSTGRES_USER=scanner                  # Database username
-POSTGRES_PASSWORD=change_me            # Required for production docker-compose.yml
+# Required, and empty on purpose -- see SECRET_KEY_BASE above.
+#
+# The comment lives on its OWN line, not after the value. Compose strips a trailing
+# comment from a NON-EMPTY value, but with nothing before the `#` it takes the whole
+# remainder as the value -- so `POSTGRES_PASSWORD=   # Required` sets the password to
+# the words "# Required", which sails through the required-variable guard exactly like
+# the placeholder this replaced.
+POSTGRES_PASSWORD=
 # POSTGRES_HOST=postgres               # Hostname (default: postgres docker service name)
 # POSTGRES_PORT=5432                   # Port number (default: 5432)
 

--- a/spec/deployment/environment_passthrough_spec.rb
+++ b/spec/deployment/environment_passthrough_spec.rb
@@ -59,6 +59,15 @@ RSpec.describe "deployment environment passthrough" do
   # The raw `environment:` entries for the scanner service, as written. List form is
   # what makes pass-through-if-set possible, so the shape matters and is not normalised
   # away here.
+  # Every environment entry in the file, whatever service it belongs to and whichever
+  # syntax it uses -- the required-secret guards live on postgres as well as scanner.
+  def compose_entries(path)
+    YAML.load_file(Rails.root.join(path), aliases: true)
+        .fetch("services").values
+        .filter_map { |service| service["environment"] }
+        .flat_map { |env| env.is_a?(Array) ? env : env.map { |k, v| "#{k}=#{v}" } }
+  end
+
   def scanner_environment(path)
     entries = YAML.load_file(Rails.root.join(path), aliases: true)
                   .fetch("services").fetch("scanner").fetch("environment")
@@ -150,6 +159,58 @@ RSpec.describe "deployment environment passthrough" do
     expect(unaccounted).to be_empty,
       "advertised in .env.example and read by the app, but neither forwarded nor listed " \
       "as deliberately excluded: #{unaccounted.join(', ')}"
+  end
+
+  describe "secrets the operator must supply" do
+    # Compose guards these with ${VAR:?...}, which fires on an unset or EMPTY value and
+    # not on a non-empty one. A placeholder in .env.example therefore sails through the
+    # guard, and every deployment that copied the file unchanged shares the value --
+    # published, in a public repository. Rails derives the ActiveRecord encryption keys
+    # from SECRET_KEY_BASE, so that is the keys protecting stored target credentials.
+    #
+    # Empty is not laziness here: it is the only value the guard can catch.
+    #
+    # Derived from the Compose files rather than hand-listed, so a secret added there
+    # cannot be left out of this contract by omission.
+    def required_secret_names
+      COMPOSE_FILES.flat_map { |path| compose_entries(path) }
+                   .flat_map { |entry| entry.to_s.scan(/\$\{([A-Z][A-Z0-9_]*):\?/) }
+                   .flatten.uniq.sort
+    end
+
+    it "finds the secrets Compose refuses to start without" do
+      expect(required_secret_names).to include("SECRET_KEY_BASE", "POSTGRES_PASSWORD",
+                                               "ADMIN_INITIAL_PASSWORD")
+    end
+
+    it "leaves every required secret empty in .env.example so the guard can fire" do
+      offenders = required_secret_names.filter_map do |name|
+        match = env_example[/^\s*#{name}=(.*)$/, 1]
+        # A DELETED assignment must not read as an empty one: nil.to_s would pass while
+        # telling an operator nothing about a secret they still have to supply.
+        next "#{name} (no assignment line)" if match.nil?
+
+        "#{name}=#{match.strip}" unless match.strip.empty?
+      end
+
+      expect(offenders).to be_empty,
+        "a non-empty value here passes Compose's required-variable guard and ships as a " \
+        "shared secret: #{offenders.join(', ')}"
+    end
+
+    it "keeps trailing comments off the required-secret value lines" do
+      # Compose strips a trailing comment from a NON-EMPTY value, but with nothing
+      # before the `#` it takes the whole remainder as the value -- so
+      # `POSTGRES_PASSWORD=   # Required` sets the password to the words "# Required"
+      # and passes the required-variable guard just like a placeholder would.
+      offenders = required_secret_names.select do |name|
+        env_example[/^\s*#{name}=.*$/].to_s.include?("#")
+      end
+
+      expect(offenders).to be_empty,
+        "value line carries a trailing comment; put it on its own line above: " \
+        "#{offenders.join(', ')}"
+    end
   end
 
   describe "a variable an operator sets to nothing" do


### PR DESCRIPTION
`.env.example` carried live assignments for two secrets:

```
SECRET_KEY_BASE=generate_me_with_openssl_rand_hex_64
POSTGRES_PASSWORD=change_me
```

Both Compose files guard these with `${VAR:?...}`, which fires on an unset or **empty** value and **not** on a non-empty one — so the placeholders passed straight through to the container. Rails derives the ActiveRecord encryption keys from `SECRET_KEY_BASE`, so any deployment that kept them shared the keys protecting stored target credentials, and both values are published in this repository.

The path is not "copies the file and ignores every warning". The guard *did* catch `ADMIN_INITIAL_PASSWORD`, which is commented out — so an operator hit one clear error, set that one variable, and started successfully, taught by the guard that a missing secret gets caught. Reproduced: with the previous template plus `ADMIN_INITIAL_PASSWORD`, the rendered config carried both published values. After this change the same path stops on `SECRET_KEY_BASE`, then on `POSTGRES_PASSWORD`, then renders clean.

Both are now empty, because empty is the only value the guard can catch.

### The subtle half

Their explanatory comments moved onto their own lines. Compose strips a trailing comment from a **non-empty** value, but with nothing before the `#` it takes the whole remainder as the value — so `POSTGRES_PASSWORD=   # Required` sets the password to the words `# Required` and sails through the guard exactly like the placeholder it replaced. The first attempt at this fix did that; the spec caught it, and now pins it.

The spec derives the secret list from the `${VAR:?}` entries in the Compose files rather than hand-listing it, so a secret added there cannot be omitted by oversight, and a *deleted* assignment is reported rather than reading as an empty one.

### Bytecode

Adds Python bytecode to `.dockerignore`. The build context is the working tree, so a local `docker compose build` baked whatever `__pycache__` was lying about, and a `.pyc` embeds the absolute path of the machine that compiled it. The patterns need `**/` — `.dockerignore` uses Go `filepath.Match`, where `*` does not cross a `/`, so a bare `*.pyc` excludes only the context root. Verified by building a throwaway image both ways. CI builds from a fresh checkout and none are tracked, so this protects local and repackaged images rather than the published one.

### Not covered

This does not remediate a `.env` already copied from an earlier release. Rotating `SECRET_KEY_BASE` re-keys ActiveRecord encryption, so an existing deployment needs a migration path rather than an edit-and-restart.

`/etc/machine-id` is shared across containers from one image. The bundled Chromium does read it, but Playwright launches it with background networking and crash reporting off, so there is no demonstrated effect and clearing it would need per-container regeneration at startup.