### PR TITLE
security(browser): screen browser connections through a validating proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -174,6 +174,7 @@ COPY --from=build /rails/RELEASE_NOTES.md* /rails/
 COPY --from=build /rails/script/garak_plugins/openrouter.py /opt/venv/lib/python3.13/site-packages/garak/generators/openrouter.py
 COPY --from=build /rails/script/garak_plugins/web_chatbot.py /opt/venv/lib/python3.13/site-packages/garak/generators/web_chatbot.py
 COPY --from=build /rails/script/garak_plugins/_network_guard.py /opt/venv/lib/python3.13/site-packages/garak/generators/_network_guard.py
+COPY --from=build /rails/script/garak_plugins/_screening_proxy.py /opt/venv/lib/python3.13/site-packages/garak/generators/_screening_proxy.py
 COPY --from=build /rails/script/garak_plugins/probes/0din.py /opt/venv/lib/python3.13/site-packages/garak/probes/0din.py
 COPY --from=build /rails/script/garak_plugins/probes/0din_variants.py /opt/venv/lib/python3.13/site-packages/garak/probes/0din_variants.py
 COPY --from=build /rails/script/garak_plugins/detectors/0din.py /opt/venv/lib/python3.13/site-packages/garak/detectors/0din.py

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -90,6 +90,7 @@ RUN GARAK_SITE=$(/opt/venv/bin/python -c "import site; print([p for p in site.ge
     cp script/garak_plugins/openrouter.py "$GARAK_SITE/garak/generators/openrouter.py" && \
     cp script/garak_plugins/web_chatbot.py "$GARAK_SITE/garak/generators/web_chatbot.py" && \
     cp script/garak_plugins/_network_guard.py "$GARAK_SITE/garak/generators/_network_guard.py" && \
+    cp script/garak_plugins/_screening_proxy.py "$GARAK_SITE/garak/generators/_screening_proxy.py" && \
     cp script/garak_plugins/probes/0din.py "$GARAK_SITE/garak/probes/0din.py" && \
     cp script/garak_plugins/probes/0din_variants.py "$GARAK_SITE/garak/probes/0din_variants.py" && \
     cp script/garak_plugins/detectors/0din.py "$GARAK_SITE/garak/detectors/0din.py" && \

--- a/app/services/browser_automation/network_guard.rb
+++ b/app/services/browser_automation/network_guard.rb
@@ -44,6 +44,37 @@ module BrowserAutomation
       }
     end
 
+    # Configuration for the screening proxy each guarded browser launches behind.
+    #
+    # The route guard screens the URLs it is handed, but it cannot reach three
+    # things: the browser resolves each host again, independently of the lookup
+    # just validated, so a name answering publicly for us and privately for the
+    # browser walks past the check; a redirect hop the browser follows internally
+    # never reaches a route handler; and WebSocket traffic is not intercepted at
+    # all, including a socket opened from a Worker.
+    #
+    # The proxy sits below all of it. It resolves each authority once, validates
+    # every answer against the same blocklist, and connects to the address it
+    # approved -- while the hostname stays in the CONNECT authority, so TLS still
+    # verifies strictly against the real host.
+    def proxy_payload(allow_localhost: nil, allowed_addresses: [])
+      allow = allow_localhost.nil? ? UrlSafetyValidator.allow_localhost? : allow_localhost
+      cidrs = UrlSafetyValidator.blocked_cidrs
+      cidrs = cidrs.reject { |cidr| LOOPBACK_CIDRS.include?(cidr) } if allow
+
+      {
+        "modulePath" => Rails.root.join("app", "services", "browser_automation", "screening_proxy_runner.cjs").to_s,
+        "blockedCidrs" => cidrs,
+        # Scoped to this launch: an address approved for this navigation does not
+        # stay approved for whatever DNS returns later.
+        "allowedAddresses" => Array(allowed_addresses).compact.map(&:to_s)
+      }
+    end
+
+    # The proxy takes no allow-loopback flag, so permitting loopback means
+    # omitting those ranges from the blocklist it screens against.
+    LOOPBACK_CIDRS = [ "127.0.0.0/8", "::1/128" ].freeze
+
     # Defines __installNetworkGuard(context, guard). Returns a handle whose
     # .blocked() lists what was aborted, for the caller to report back to Rails.
     #

--- a/app/services/browser_automation/network_guard.rb
+++ b/app/services/browser_automation/network_guard.rb
@@ -60,7 +60,7 @@ module BrowserAutomation
     def proxy_payload(allow_localhost: nil, allowed_addresses: [])
       allow = allow_localhost.nil? ? UrlSafetyValidator.allow_localhost? : allow_localhost
       cidrs = UrlSafetyValidator.blocked_cidrs
-      cidrs = cidrs.reject { |cidr| LOOPBACK_CIDRS.include?(cidr) } if allow
+      cidrs = cidrs.reject { |cidr| loopback_cidr?(cidr) } if allow
 
       {
         "modulePath" => Rails.root.join("app", "services", "browser_automation", "screening_proxy_runner.cjs").to_s,
@@ -73,7 +73,20 @@ module BrowserAutomation
 
     # The proxy takes no allow-loopback flag, so permitting loopback means
     # omitting those ranges from the blocklist it screens against.
-    LOOPBACK_CIDRS = [ "127.0.0.0/8", "::1/128" ].freeze
+    #
+    # Compared semantically, not by string: blocked_cidrs renders IPv6 in full
+    # canonical form, so "::1/128" never matches "0000:...:0001/128" and IPv6
+    # loopback would stay blocked while IPv4 loopback was allowed. localhost
+    # resolves to both, and the proxy refuses if ANY answer is blocked, so the
+    # mismatch denies localhost outright.
+    LOOPBACK_RANGES = [ IPAddr.new("127.0.0.0/8"), IPAddr.new("::1/128") ].freeze
+
+    def loopback_cidr?(cidr)
+      address = IPAddr.new(cidr)
+      LOOPBACK_RANGES.any? { |range| range.include?(address) && range.prefix == address.prefix }
+    rescue IPAddr::Error
+      false
+    end
 
     # Defines __installNetworkGuard(context, guard). Returns a handle whose
     # .blocked() lists what was aborted, for the caller to report back to Rails.

--- a/app/services/browser_automation/playwright_service.rb
+++ b/app/services/browser_automation/playwright_service.rb
@@ -33,17 +33,43 @@ module BrowserAutomation
         output_path: output_path.to_s,
         wait_until: options[:wait_until] || "networkidle",
         type: options[:type] || "png",
-        network_guard: NetworkGuard.payload
+        network_guard: NetworkGuard.payload,
+        screening_proxy: NetworkGuard.proxy_payload
       }
 
       script = <<~JS
         const { chromium } = require('playwright');
         const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
+        const { withScreeningProxy } = require(__data.screening_proxy.modulePath);
+        // The route guard reports {url, reason} objects; the proxy reports plain
+        // URL strings and keeps its own total. Concatenating them raw would hand
+        // callers a mixed-shape array and silently drop the proxy's count of what
+        // it truncated, so normalise to one shape and carry the overflow.
+        const __mergeBlocked = (guard, proxy) => {
+          const report = proxy.getBlockReport();
+          const fromProxy = (report.blocked_requests || []).map((url) => ({
+            url: String(url),
+            reason: 'blocked by screening proxy'
+          }));
+          const merged = guard.blocked().concat(fromProxy);
+          const dropped = (report.blocked_request_count || 0) - fromProxy.length;
+          if (dropped > 0) {
+            merged.push({ url: '(' + dropped + ' more)', reason: 'blocked by screening proxy' });
+          }
+          return merged;
+        };
         #{NetworkGuard::GUARD_JS}
         (async () => {
+          await withScreeningProxy(__data.screening_proxy, async (proxy) => {
           const browser = await chromium.launch({
             headless: true,
-            args: ['--no-sandbox', '--disable-setuid-sandbox']
+            proxy: { server: proxy.url() },
+            args: [
+              '--no-sandbox',
+              '--disable-setuid-sandbox',
+              '--disable-dev-shm-usage',
+              '--disable-gpu'
+            ]
           });
 
           try {
@@ -64,13 +90,15 @@ module BrowserAutomation
               type: __data.type
             });
 
-            console.log(JSON.stringify({ success: true, path: __data.output_path, blocked_requests: __guard.blocked() }));
+            console.log(JSON.stringify({ success: true, path: __data.output_path, blocked_requests: __mergeBlocked(__guard, proxy) }));
           } catch (error) {
             console.error(JSON.stringify({ error: error.message }));
             process.exitCode = 1;
           } finally {
             await browser.close();
           }
+        #{'        '}
+          });
         })();
       JS
 
@@ -138,7 +166,7 @@ module BrowserAutomation
           } finally {
             await browser.close();
           }
-        })();
+                })();
       JS
 
       result = execute_playwright_script(script, data: data)
@@ -170,17 +198,43 @@ module BrowserAutomation
         send_selector: (send_selector.present? && send_selector != "null") ? send_selector : nil,
         test_message: test_message,
         auth: auth_payload(config[:auth] || config["auth"]),
-        network_guard: NetworkGuard.payload
+        network_guard: NetworkGuard.payload,
+        screening_proxy: NetworkGuard.proxy_payload
       }
 
       script = <<~JS
         const { chromium } = require('playwright');
         const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
+        const { withScreeningProxy } = require(__data.screening_proxy.modulePath);
+        // The route guard reports {url, reason} objects; the proxy reports plain
+        // URL strings and keeps its own total. Concatenating them raw would hand
+        // callers a mixed-shape array and silently drop the proxy's count of what
+        // it truncated, so normalise to one shape and carry the overflow.
+        const __mergeBlocked = (guard, proxy) => {
+          const report = proxy.getBlockReport();
+          const fromProxy = (report.blocked_requests || []).map((url) => ({
+            url: String(url),
+            reason: 'blocked by screening proxy'
+          }));
+          const merged = guard.blocked().concat(fromProxy);
+          const dropped = (report.blocked_request_count || 0) - fromProxy.length;
+          if (dropped > 0) {
+            merged.push({ url: '(' + dropped + ' more)', reason: 'blocked by screening proxy' });
+          }
+          return merged;
+        };
         #{NetworkGuard::GUARD_JS}
         (async () => {
+          await withScreeningProxy(__data.screening_proxy, async (proxy) => {
           const browser = await chromium.launch({
             headless: true,
-            args: ['--no-sandbox', '--disable-setuid-sandbox']
+            proxy: { server: proxy.url() },
+            args: [
+              '--no-sandbox',
+              '--disable-setuid-sandbox',
+              '--disable-dev-shm-usage',
+              '--disable-gpu'
+            ]
           });
 
           try {
@@ -257,7 +311,7 @@ module BrowserAutomation
                 success: false,
                 errors: errors,
                 response_detected: false,
-                blocked_requests: __guard.blocked()
+                blocked_requests: __mergeBlocked(__guard, proxy)
               }));
               await browser.close();
               return;
@@ -297,7 +351,7 @@ module BrowserAutomation
                 success: false,
                 errors: errors,
                 response_detected: false,
-                blocked_requests: __guard.blocked()
+                blocked_requests: __mergeBlocked(__guard, proxy)
               }));
               await browser.close();
               return;
@@ -316,7 +370,7 @@ module BrowserAutomation
               test_message_found: testMessagePresent,
               baseline_length: baselineHistory.length,
               new_length: newHistory.length,
-              blocked_requests: __guard.blocked()
+              blocked_requests: __mergeBlocked(__guard, proxy)
             }));
 
           } catch (error) {
@@ -328,6 +382,8 @@ module BrowserAutomation
           } finally {
             await browser.close();
           }
+        #{'        '}
+          });
         })();
       JS
 
@@ -357,17 +413,43 @@ module BrowserAutomation
         url: url,
         user_agent: options[:user_agent] || "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
         auth: auth_payload(options[:auth]),
-        network_guard: NetworkGuard.payload
+        network_guard: NetworkGuard.payload,
+        screening_proxy: NetworkGuard.proxy_payload
       }
 
       script = <<~JS
         const { chromium } = require('playwright');
         const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
+        const { withScreeningProxy } = require(__data.screening_proxy.modulePath);
+        // The route guard reports {url, reason} objects; the proxy reports plain
+        // URL strings and keeps its own total. Concatenating them raw would hand
+        // callers a mixed-shape array and silently drop the proxy's count of what
+        // it truncated, so normalise to one shape and carry the overflow.
+        const __mergeBlocked = (guard, proxy) => {
+          const report = proxy.getBlockReport();
+          const fromProxy = (report.blocked_requests || []).map((url) => ({
+            url: String(url),
+            reason: 'blocked by screening proxy'
+          }));
+          const merged = guard.blocked().concat(fromProxy);
+          const dropped = (report.blocked_request_count || 0) - fromProxy.length;
+          if (dropped > 0) {
+            merged.push({ url: '(' + dropped + ' more)', reason: 'blocked by screening proxy' });
+          }
+          return merged;
+        };
         #{NetworkGuard::GUARD_JS}
         (async () => {
+          await withScreeningProxy(__data.screening_proxy, async (proxy) => {
           const browser = await chromium.launch({
             headless: true,
-            args: ['--no-sandbox', '--disable-setuid-sandbox']
+            proxy: { server: proxy.url() },
+            args: [
+              '--no-sandbox',
+              '--disable-setuid-sandbox',
+              '--disable-dev-shm-usage',
+              '--disable-gpu'
+            ]
           });
 
           try {
@@ -544,13 +626,15 @@ module BrowserAutomation
               screenshot: screenshotBase64
             };
 
-            console.log(JSON.stringify({ success: true, data: result, blocked_requests: __guard.blocked() }));
+            console.log(JSON.stringify({ success: true, data: result, blocked_requests: __mergeBlocked(__guard, proxy) }));
           } catch (error) {
             console.error(JSON.stringify({ error: error.message }));
             process.exitCode = 1;
           } finally {
             await browser.close();
           }
+        #{'        '}
+          });
         })();
       JS
 
@@ -711,16 +795,43 @@ module BrowserAutomation
       data = {
         url: url,
         wait_until: options[:wait_until] || "networkidle",
-        network_guard: NetworkGuard.payload
+        network_guard: NetworkGuard.payload,
+        screening_proxy: NetworkGuard.proxy_payload
       }
 
       script = <<~JS
         const { chromium } = require('playwright');
         const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
+        const { withScreeningProxy } = require(__data.screening_proxy.modulePath);
+        // The route guard reports {url, reason} objects; the proxy reports plain
+        // URL strings and keeps its own total. Concatenating them raw would hand
+        // callers a mixed-shape array and silently drop the proxy's count of what
+        // it truncated, so normalise to one shape and carry the overflow.
+        const __mergeBlocked = (guard, proxy) => {
+          const report = proxy.getBlockReport();
+          const fromProxy = (report.blocked_requests || []).map((url) => ({
+            url: String(url),
+            reason: 'blocked by screening proxy'
+          }));
+          const merged = guard.blocked().concat(fromProxy);
+          const dropped = (report.blocked_request_count || 0) - fromProxy.length;
+          if (dropped > 0) {
+            merged.push({ url: '(' + dropped + ' more)', reason: 'blocked by screening proxy' });
+          }
+          return merged;
+        };
         #{NetworkGuard::GUARD_JS}
         (async () => {
+          await withScreeningProxy(__data.screening_proxy, async (proxy) => {
           const browser = await chromium.launch({
-            headless: #{options[:headless] != false}
+            headless: #{options[:headless] != false},
+            proxy: { server: proxy.url() },
+            args: [
+              '--no-sandbox',
+              '--disable-setuid-sandbox',
+              '--disable-dev-shm-usage',
+              '--disable-gpu'
+            ]
           });
 
           try {
@@ -734,13 +845,15 @@ module BrowserAutomation
               await page.goto(__data.url, { waitUntil: __data.wait_until });
             }
 
-            console.log(JSON.stringify({ success: true, blocked_requests: __guard.blocked() }));
+            console.log(JSON.stringify({ success: true, blocked_requests: __mergeBlocked(__guard, proxy) }));
           } catch (error) {
             console.error(JSON.stringify({ error: error.message }));
             process.exitCode = 1;
           } finally {
             await browser.close();
           }
+
+          });
         })();
       JS
 

--- a/app/services/browser_automation/screening_proxy_runner.cjs
+++ b/app/services/browser_automation/screening_proxy_runner.cjs
@@ -401,6 +401,7 @@ function createScreeningProxy(options = {}) {
   const blocked = createBlockCollector({ limit: reportLimit, maxUrlLength });
   const detailSamples = [];
   const sockets = new Set();
+  const pendingConnects = new Set();
   let lastAddress = null;
   let closed = false;
   let closing = false;
@@ -444,7 +445,12 @@ function createScreeningProxy(options = {}) {
     return cidrs.some((cidr) => withinCidr(parsed, cidr));
   }
 
+  function ensureOpen() {
+    if (closing || closed) throw new ScreeningError('proxy-closed', 502);
+  }
+
   async function screen(target) {
+    ensureOpen();
     const isLiteral = Boolean(net.isIP(target.hostname));
     let rawAddresses;
     if (isLiteral) {
@@ -456,6 +462,9 @@ function createScreeningProxy(options = {}) {
         throw new ScreeningError('dns-failure', 502, { cause: error });
       }
     }
+    // DNS is asynchronous and may finish after close() has already torn down
+    // the listener. Never turn a stale answer into a post-shutdown connection.
+    ensureOpen();
     if (!Array.isArray(rawAddresses) || rawAddresses.length === 0) {
       throw new ScreeningError('unresolvable-authority', 502);
     }
@@ -521,12 +530,30 @@ function createScreeningProxy(options = {}) {
   }
 
   async function connectValidated(decision, port) {
+    ensureOpen();
     return new Promise((resolveConnect, rejectConnect) => {
       const attempts = [];
       const timers = [];
       let failures = 0;
       let lastError = null;
       let settled = false;
+      let operation;
+
+      const clearPending = () => {
+        timers.forEach(clearTimeout);
+        if (operation) pendingConnects.delete(operation);
+      };
+
+      const cancel = () => {
+        if (settled) return;
+        settled = true;
+        clearPending();
+        attempts.forEach((attempt) => attempt.socket.destroy());
+        rejectConnect(new ScreeningError('proxy-closed', 502));
+      };
+
+      operation = { cancel };
+      pendingConnects.add(operation);
 
       const fail = (error) => {
         if (settled) return;
@@ -534,6 +561,7 @@ function createScreeningProxy(options = {}) {
         lastError = error;
         if (failures !== decision.addresses.length) return;
         settled = true;
+        clearPending();
         rejectConnect(new ScreeningError('connection-failed', 502, {
           resolvedAddresses: decision.addresses,
           cause: lastError
@@ -546,7 +574,7 @@ function createScreeningProxy(options = {}) {
           return;
         }
         settled = true;
-        timers.forEach(clearTimeout);
+        clearPending();
         attempts.forEach((candidate) => {
           if (candidate !== attempt) candidate.socket.destroy();
         });
@@ -556,6 +584,10 @@ function createScreeningProxy(options = {}) {
       decision.addresses.forEach((address, index) => {
         timers.push(setTimeout(() => {
           if (settled) return;
+          if (closing || closed) {
+            cancel();
+            return;
+          }
           let attempt;
           try {
             attempt = { address, ...connectAddress(address, port) };
@@ -593,6 +625,34 @@ function createScreeningProxy(options = {}) {
         error.statusCode === 403 ? 'Forbidden' : 'Bad Gateway';
       socket.end(`HTTP/1.1 ${error.statusCode} ${reason}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`);
     }
+  }
+
+  function pipeTunnel(clientSocket, upstream) {
+    const destroy = (socket) => {
+      if (!socket.destroyed) socket.destroy();
+    };
+
+    // An error belongs to the endpoint that emitted it. Passing that Error into
+    // peer.destroy(error) makes the peer emit a second, potentially unhandled
+    // error after it has already closed. Consume both sides and tear the peer
+    // down without forwarding the Error object.
+    clientSocket.on('error', () => destroy(upstream));
+    upstream.on('error', () => destroy(clientSocket));
+
+    // Preserve TCP half-close semantics: FIN in one direction ends the peer's
+    // writable side while allowing already-buffered data in the other direction
+    // to drain. A full close/error then tears down the remaining endpoint.
+    clientSocket.once('end', () => {
+      if (!upstream.destroyed && !upstream.writableEnded) upstream.end();
+    });
+    upstream.once('end', () => {
+      if (!clientSocket.destroyed && !clientSocket.writableEnded) clientSocket.end();
+    });
+    clientSocket.once('close', () => destroy(upstream));
+    upstream.once('close', () => destroy(clientSocket));
+
+    clientSocket.pipe(upstream, { end: false });
+    upstream.pipe(clientSocket, { end: false });
   }
 
   const server = http.createServer((request, response) => {
@@ -654,13 +714,9 @@ function createScreeningProxy(options = {}) {
         const decision = await screen(target);
         const connection = await connectValidated(decision, target.port);
         const upstream = connection.socket;
+        pipeTunnel(clientSocket, upstream);
         clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
         if (head.length) upstream.write(head);
-        clientSocket.pipe(upstream);
-        upstream.pipe(clientSocket);
-        upstream.once('error', (cause) => {
-          clientSocket.destroy(cause);
-        });
       } catch (cause) {
         rejectSocket(clientSocket, screeningFailure(target, cause));
       }
@@ -676,16 +732,12 @@ function createScreeningProxy(options = {}) {
         const decision = await screen(target);
         const connection = await connectValidated(decision, target.port);
         const upstream = connection.socket;
+        pipeTunnel(clientSocket, upstream);
         upstream.write(
           `${request.method} ${target.path} HTTP/${request.httpVersion}\r\n` +
           `${upgradeHeaders(request, target.authority).join('\r\n')}\r\n\r\n`
         );
         if (head.length) upstream.write(head);
-        clientSocket.pipe(upstream);
-        upstream.pipe(clientSocket);
-        upstream.once('error', (cause) => {
-          clientSocket.destroy(cause);
-        });
       } catch (cause) {
         rejectSocket(clientSocket, screeningFailure(target, cause));
       }
@@ -747,6 +799,7 @@ function createScreeningProxy(options = {}) {
         return;
       }
       closing = true;
+      pendingConnects.forEach((operation) => operation.cancel());
       sockets.forEach((socket) => socket.destroy());
       await new Promise((resolveClose) => {
         if (!server.listening) {

--- a/app/services/browser_automation/screening_proxy_runner.cjs
+++ b/app/services/browser_automation/screening_proxy_runner.cjs
@@ -1,0 +1,882 @@
+'use strict';
+
+// Per-browser screening proxy for browser-driven scans.
+//
+// The browser keeps the original hostname so TLS SNI, cookies, and storage
+// origins remain correct. The proxy resolves every HTTP/CONNECT/Upgrade
+// authority, validates every returned address, and starts only those validated
+// IPs in resolver order with a short stagger, using the first one that connects.
+// Invalid input, failed DNS, blocked ranges, and exhausted transport attempts
+// fail closed. Block reporting is bounded for safe serialization back to Rails.
+
+const dns = require('dns').promises;
+const http = require('http');
+const net = require('net');
+
+class ScreeningError extends Error {
+  constructor(reason, statusCode, details = {}) {
+    super(reason);
+    this.name = 'ScreeningError';
+    this.reason = reason;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+function createBlockCollector({ limit = 50, maxUrlLength = 512 } = {}) {
+  if (!Number.isInteger(limit) || limit < 0) throw new TypeError('limit must be a non-negative integer');
+  if (!Number.isInteger(maxUrlLength) || maxUrlLength < 1) {
+    throw new TypeError('maxUrlLength must be a positive integer');
+  }
+  const samples = [];
+  let total = 0;
+  return {
+    record(value) {
+      total += 1;
+      if (samples.length < limit) samples.push(String(value).slice(0, maxUrlLength));
+    },
+    samples: () => samples.slice(),
+    count: () => total
+  };
+}
+
+function ipv4ToBytes(ip) {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  const bytes = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const value = Number(part);
+    if (value > 255) return null;
+    bytes.push(value);
+  }
+  return bytes;
+}
+
+function ipToBytes(ip) {
+  if (typeof ip !== 'string' || ip.length === 0) return null;
+  const address = ip.replace(/^\[|\]$/g, '').split('%')[0];
+  if (net.isIPv4(address)) {
+    const bytes = ipv4ToBytes(address);
+    return bytes ? { bytes, family: 4 } : null;
+  }
+  if (!net.isIPv6(address)) return null;
+
+  let head = address;
+  let tail = [];
+  const lastColon = address.lastIndexOf(':');
+  const suffix = address.slice(lastColon + 1);
+  if (suffix.includes('.')) {
+    const v4 = ipv4ToBytes(suffix);
+    if (!v4) return null;
+    tail = v4;
+    head = address.slice(0, lastColon);
+  }
+
+  const halves = head.split('::');
+  if (halves.length > 2) return null;
+  const groupsFor = (part) => part ? part.split(':').filter(Boolean) : [];
+  const left = groupsFor(halves[0]);
+  const right = halves.length === 2 ? groupsFor(halves[1]) : [];
+  const groupCount = 8 - (tail.length ? 2 : 0);
+  const missing = groupCount - left.length - right.length;
+  if (halves.length === 1 && missing !== 0) return null;
+  if (missing < 0) return null;
+  const groups = [...left, ...Array(halves.length === 2 ? missing : 0).fill('0'), ...right];
+  const bytes = [];
+  for (const group of groups) {
+    if (!/^[0-9a-fA-F]{1,4}$/.test(group)) return null;
+    const value = Number.parseInt(group, 16);
+    bytes.push((value >> 8) & 0xff, value & 0xff);
+  }
+  bytes.push(...tail);
+  return bytes.length === 16 ? { bytes, family: 6 } : null;
+}
+
+function normalizeIp(parsed) {
+  if (!parsed) return null;
+  if (parsed.family === 4) return parsed;
+  const bytes = parsed.bytes;
+  const mapped = bytes.slice(0, 10).every((value) => value === 0) &&
+    bytes[10] === 0xff && bytes[11] === 0xff;
+  return mapped ? { bytes: bytes.slice(12), family: 4 } : parsed;
+}
+
+function sameAddress(left, right) {
+  return left.family === right.family &&
+    left.bytes.length === right.bytes.length &&
+    left.bytes.every((byte, index) => byte === right.bytes[index]);
+}
+
+function parseCidr(value) {
+  if (typeof value !== 'string' || !value.length) return null;
+  const pieces = value.split('/');
+  if (pieces.length > 2) return null;
+  const address = normalizeIp(ipToBytes(pieces[0]));
+  if (!address) return null;
+  const maximum = address.family === 4 ? 32 : 128;
+  const prefix = pieces.length === 1 ? maximum : Number(pieces[1]);
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > maximum) return null;
+  return { ...address, prefix };
+}
+
+function withinCidr(address, cidr) {
+  if (address.family !== cidr.family) return false;
+  let remaining = cidr.prefix;
+  for (let index = 0; index < address.bytes.length && remaining > 0; index += 1) {
+    const bits = Math.min(8, remaining);
+    const mask = (0xff << (8 - bits)) & 0xff;
+    if ((address.bytes[index] & mask) !== (cidr.bytes[index] & mask)) return false;
+    remaining -= bits;
+  }
+  return true;
+}
+
+function canonicalHostname(value) {
+  if (typeof value !== 'string' || value.length === 0 || /[\\%\x00-\x20\x7f]/.test(value)) {
+    throw new ScreeningError('invalid-authority', 400);
+  }
+  let hostname = value;
+  if (hostname.startsWith('[') && hostname.endsWith(']')) hostname = hostname.slice(1, -1);
+  hostname = hostname.toLowerCase().replace(/\.$/, '');
+  if (!hostname) throw new ScreeningError('invalid-authority', 400);
+
+  const ipVersion = net.isIP(hostname);
+  if (ipVersion === 4) return hostname;
+  if (ipVersion === 6) return new URL(`http://[${hostname}]/`).hostname.slice(1, -1);
+  if (/^[0-9.]+$/.test(hostname)) throw new ScreeningError('invalid-authority', 400);
+
+  let ascii;
+  try {
+    ascii = new URL(`http://${hostname}/`).hostname.toLowerCase().replace(/\.$/, '');
+  } catch (_) {
+    throw new ScreeningError('invalid-authority', 400);
+  }
+  const labels = ascii.split('.');
+  const valid = ascii.length <= 253 && labels.every((label) =>
+    label.length >= 1 && label.length <= 63 &&
+    /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+  );
+  if (!valid) throw new ScreeningError('invalid-authority', 400);
+  return ascii;
+}
+
+function formatAuthority(hostname, port, defaultPort = null) {
+  const host = net.isIPv6(hostname) ? `[${hostname}]` : hostname;
+  return defaultPort !== null && port === defaultPort ? host : `${host}:${port}`;
+}
+
+function parseAuthority(value, defaultPort, requirePort = false) {
+  if (typeof value !== 'string' || !value.length || /[\\\/@?#\x00-\x20\x7f]/.test(value)) {
+    throw new ScreeningError('invalid-authority', 400);
+  }
+  let hostnameText;
+  let portText = null;
+  if (value.startsWith('[')) {
+    const closing = value.indexOf(']');
+    if (closing < 0) throw new ScreeningError('invalid-authority', 400);
+    hostnameText = value.slice(1, closing);
+    const remainder = value.slice(closing + 1);
+    if (remainder) {
+      if (!remainder.startsWith(':')) throw new ScreeningError('invalid-authority', 400);
+      portText = remainder.slice(1);
+    }
+  } else {
+    const firstColon = value.indexOf(':');
+    const lastColon = value.lastIndexOf(':');
+    if (firstColon !== lastColon) throw new ScreeningError('invalid-authority', 400);
+    if (lastColon >= 0) {
+      hostnameText = value.slice(0, lastColon);
+      portText = value.slice(lastColon + 1);
+    } else {
+      hostnameText = value;
+    }
+  }
+  if (requirePort && portText === null) throw new ScreeningError('invalid-authority', 400);
+  const port = portText === null ? defaultPort : Number(portText);
+  if (!Number.isInteger(port) || port < 1 || port > 65535 || (portText !== null && !/^\d+$/.test(portText))) {
+    throw new ScreeningError('invalid-authority', 400);
+  }
+  const hostname = canonicalHostname(hostnameText);
+  return { hostname, port, authority: formatAuthority(hostname, port, defaultPort) };
+}
+
+function rawHeaderValues(request, lowerName) {
+  const values = [];
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    if (request.rawHeaders[index].toLowerCase() === lowerName) values.push(request.rawHeaders[index + 1]);
+  }
+  return values;
+}
+
+function framingValid(request, expected, { upgrade = false } = {}) {
+  const hosts = rawHeaderValues(request, 'host');
+  if (hosts.length !== 1) return false;
+  let supplied;
+  try {
+    supplied = parseAuthority(hosts[0], expected.defaultPort, false);
+  } catch (_) {
+    return false;
+  }
+  if (supplied.hostname !== expected.hostname || supplied.port !== expected.port) return false;
+  const contentLengths = rawHeaderValues(request, 'content-length');
+  const transferEncodings = rawHeaderValues(request, 'transfer-encoding');
+  if (contentLengths.length > 1 || transferEncodings.length > 1) return false;
+  if (contentLengths.length && transferEncodings.length) return false;
+  if (upgrade) {
+    if (contentLengths.length || transferEncodings.length) return false;
+    const connections = rawHeaderValues(request, 'connection');
+    const upgrades = rawHeaderValues(request, 'upgrade');
+    const versions = rawHeaderValues(request, 'sec-websocket-version');
+    const keys = rawHeaderValues(request, 'sec-websocket-key');
+    if (connections.length !== 1 || upgrades.length !== 1 || versions.length !== 1 || keys.length !== 1) {
+      return false;
+    }
+    const connectionTokens = connections[0].split(',').map((token) => token.trim().toLowerCase()).filter(Boolean);
+    if (connectionTokens.length !== 1 || connectionTokens[0] !== 'upgrade') return false;
+    if (upgrades[0].trim().toLowerCase() !== 'websocket') return false;
+    if (versions[0].trim() !== '13' || !keys[0].trim()) return false;
+  } else if (rawHeaderValues(request, 'upgrade').length) {
+    return false;
+  }
+  return true;
+}
+
+function parseHttpRequest(request) {
+  let url;
+  try { url = new URL(request.url); }
+  catch (_) { throw new ScreeningError('invalid-url', 400); }
+  if (url.protocol !== 'http:' || url.username || url.password || url.hash) {
+    throw new ScreeningError('invalid-url', 400);
+  }
+  const hostname = canonicalHostname(url.hostname);
+  const port = url.port ? Number(url.port) : 80;
+  const target = {
+    kind: 'http', hostname, port, defaultPort: 80,
+    authority: formatAuthority(hostname, port, 80),
+    display: url.href,
+    path: url.pathname + url.search
+  };
+  if (!framingValid(request, target)) throw new ScreeningError('invalid-framing', 400);
+  return target;
+}
+
+function parseConnectRequest(request) {
+  const parsed = parseAuthority(request.url, 443, true);
+  return {
+    kind: 'connect', ...parsed, defaultPort: null,
+    authority: formatAuthority(parsed.hostname, parsed.port, null),
+    display: `https://${formatAuthority(parsed.hostname, parsed.port, 443)}/`
+  };
+}
+
+function connectFramingValid(request, target, head) {
+  if (request.method !== 'CONNECT' || (head && head.length)) return false;
+  const hosts = rawHeaderValues(request, 'host');
+  if (hosts.length !== 1) return false;
+  let supplied;
+  try {
+    supplied = parseAuthority(hosts[0], target.port, true);
+  } catch (_) {
+    return false;
+  }
+  if (supplied.hostname !== target.hostname || supplied.port !== target.port) return false;
+  if (rawHeaderValues(request, 'content-length').length) return false;
+  if (rawHeaderValues(request, 'transfer-encoding').length) return false;
+  if (rawHeaderValues(request, 'upgrade').length) return false;
+  return rawHeaderValues(request, 'connection').length <= 1;
+}
+
+function parseUpgradeRequest(request) {
+  if (request.method !== 'GET') throw new ScreeningError('invalid-framing', 400);
+  let url;
+  try { url = new URL(request.url); }
+  catch (_) { throw new ScreeningError('invalid-url', 400); }
+  if (url.protocol !== 'ws:' || url.username || url.password || url.hash) {
+    throw new ScreeningError('invalid-url', 400);
+  }
+  const hostname = canonicalHostname(url.hostname);
+  const port = url.port ? Number(url.port) : 80;
+  const target = {
+    kind: 'upgrade', hostname, port, defaultPort: 80,
+    authority: formatAuthority(hostname, port, 80),
+    display: url.href,
+    path: url.pathname + url.search
+  };
+  if (!framingValid(request, target, { upgrade: true })) {
+    throw new ScreeningError('invalid-framing', 400);
+  }
+  return target;
+}
+
+function connectionNamedHeaders(headers) {
+  const names = new Set();
+  for (const value of [].concat(headers.connection || [])) {
+    for (const token of String(value).split(',')) {
+      const name = token.trim().toLowerCase();
+      if (name) names.add(name);
+    }
+  }
+  return names;
+}
+
+function withoutHopByHopHeaders(headers) {
+  const blocked = new Set([
+    'connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization',
+    'proxy-connection', 'te', 'trailer', 'transfer-encoding', 'upgrade'
+  ]);
+  connectionNamedHeaders(headers).forEach((name) => blocked.add(name));
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) => !blocked.has(name.toLowerCase()))
+  );
+}
+
+function upgradeHeaders(request, authority) {
+  const connectionNames = new Set();
+  for (const value of rawHeaderValues(request, 'connection')) {
+    for (const token of value.split(',')) {
+      const lower = token.trim().toLowerCase();
+      if (lower) connectionNames.add(lower);
+    }
+  }
+  const blocked = new Set([
+    'host', 'connection', 'upgrade', 'content-length', 'transfer-encoding',
+    'proxy-authorization', 'proxy-connection', 'keep-alive', 'te', 'trailer'
+  ]);
+  connectionNames.forEach((name) => blocked.add(name));
+  const lines = [];
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    const name = request.rawHeaders[index];
+    const lower = name.toLowerCase();
+    if (blocked.has(lower)) continue;
+    lines.push(`${name}: ${request.rawHeaders[index + 1]}`);
+  }
+  lines.push(`Host: ${authority}`);
+  lines.push('Connection: Upgrade');
+  lines.push('Upgrade: websocket');
+  return lines;
+}
+
+function createScreeningProxy(options = {}) {
+  const {
+    blockedCidrs = [],
+    allowedInternalHosts = [],
+    allowedAddresses = [],
+    resolve = async (host) => (await dns.lookup(host, { all: true })).map((entry) => entry.address),
+    connect = (connectOptions) => net.connect(connectOptions),
+    onBlock = null,
+    connectTimeoutMs = 30000,
+    connectAttemptDelayMs = 250,
+    reportLimit = 50,
+    maxUrlLength = 512,
+    maxReportedAddresses = 16
+  } = options;
+  if (typeof resolve !== 'function') throw new TypeError('resolve must be a function');
+  if (typeof connect !== 'function') throw new TypeError('connect must be a function');
+  if (!Number.isInteger(connectTimeoutMs) || connectTimeoutMs < 1) {
+    throw new TypeError('connectTimeoutMs must be a positive integer');
+  }
+  if (!Number.isInteger(connectAttemptDelayMs) || connectAttemptDelayMs < 0) {
+    throw new TypeError('connectAttemptDelayMs must be a non-negative integer');
+  }
+  if (!Number.isInteger(maxReportedAddresses) || maxReportedAddresses < 1) {
+    throw new TypeError('maxReportedAddresses must be a positive integer');
+  }
+  if (!Array.isArray(blockedCidrs) || blockedCidrs.length === 0) {
+    throw new TypeError('blockedCidrs must be a non-empty array');
+  }
+
+  const cidrs = blockedCidrs.map((value) => {
+    const parsed = parseCidr(value);
+    if (!parsed) throw new TypeError(`invalid blocked CIDR: ${value}`);
+    return parsed;
+  });
+  const allowedHosts = new Set(allowedInternalHosts.map(canonicalHostname));
+  if (!Array.isArray(allowedAddresses)) throw new TypeError('allowedAddresses must be an array');
+  const approvedAddresses = allowedAddresses.map((value) => {
+    const parsed = normalizeIp(ipToBytes(value));
+    if (!parsed) throw new TypeError(`invalid allowed address: ${value}`);
+    return parsed;
+  });
+  const blocked = createBlockCollector({ limit: reportLimit, maxUrlLength });
+  const detailSamples = [];
+  const sockets = new Set();
+  let lastAddress = null;
+  let closed = false;
+  let closing = false;
+
+  function track(socket) {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+    return socket;
+  }
+
+  function recordBlock(target, reason, details = {}) {
+    const display = target?.display || target?.authority || details.input || reason;
+    blocked.record(display);
+    const allResolvedAddresses = Array.isArray(details.resolvedAddresses) ?
+      details.resolvedAddresses.slice() :
+      (details.resolvedAddresses == null ? [] : [details.resolvedAddresses]);
+    const allBlockedAddresses = Array.isArray(details.blockedAddresses) ?
+      details.blockedAddresses.slice() :
+      (details.blockedAddresses == null ? [] : [details.blockedAddresses]);
+    const event = {
+      target: String(display).slice(0, maxUrlLength),
+      kind: target?.kind || details.kind || 'unknown',
+      authority: target?.authority || null,
+      reason,
+      resolvedAddresses: allResolvedAddresses.slice(0, maxReportedAddresses),
+      resolvedAddressesTruncated: Math.max(0, allResolvedAddresses.length - maxReportedAddresses),
+      blockedAddresses: allBlockedAddresses.slice(0, maxReportedAddresses),
+      blockedAddressesTruncated: Math.max(0, allBlockedAddresses.length - maxReportedAddresses),
+      selectedAddress: details.selectedAddress || null
+    };
+    if (detailSamples.length < reportLimit) detailSamples.push(event);
+    if (typeof onBlock === 'function') {
+      try { onBlock(event); } catch (_) { /* Reporting must not alter enforcement. */ }
+    }
+    return event;
+  }
+
+  function blockedAddress(address) {
+    const parsed = normalizeIp(ipToBytes(address));
+    if (!parsed) return true;
+    return cidrs.some((cidr) => withinCidr(parsed, cidr));
+  }
+
+  async function screen(target) {
+    const isLiteral = Boolean(net.isIP(target.hostname));
+    let rawAddresses;
+    if (isLiteral) {
+      rawAddresses = [target.hostname];
+    } else {
+      try {
+        rawAddresses = await resolve(target.hostname);
+      } catch (error) {
+        throw new ScreeningError('dns-failure', 502, { cause: error });
+      }
+    }
+    if (!Array.isArray(rawAddresses) || rawAddresses.length === 0) {
+      throw new ScreeningError('unresolvable-authority', 502);
+    }
+    const addresses = [];
+    for (const value of rawAddresses) {
+      if (typeof value !== 'string' || !normalizeIp(ipToBytes(value))) {
+        throw new ScreeningError('invalid-dns-answer', 502, { resolvedAddresses: rawAddresses });
+      }
+      if (!addresses.includes(value)) addresses.push(value);
+    }
+    const hostApproved = !isLiteral && allowedHosts.has(target.hostname);
+    const forbidden = addresses.filter((address) => {
+      if (!blockedAddress(address)) return false;
+      if (!hostApproved) return true;
+      const parsed = normalizeIp(ipToBytes(address));
+      return !approvedAddresses.some((approved) => sameAddress(parsed, approved));
+    });
+    if (forbidden.length) {
+      throw new ScreeningError('blocked-address', 403, {
+        resolvedAddresses: addresses,
+        blockedAddresses: forbidden
+      });
+    }
+    return {
+      addresses,
+      selectedAddress: addresses[0],
+      family: net.isIP(addresses[0]),
+      exempt: hostApproved && addresses.some(blockedAddress)
+    };
+  }
+
+  function connectAddress(address, port) {
+    const socket = track(connect({
+        host: address,
+        family: net.isIP(address),
+        port
+      }));
+    const connected = new Promise((resolveConnect, rejectConnect) => {
+      let settled = false;
+      const finish = (callback, value) => {
+        if (settled) return;
+        settled = true;
+        socket.setTimeout(0);
+        socket.off('connect', onConnect);
+        socket.off('error', onError);
+        socket.off('close', onClose);
+        callback(value);
+      };
+      const onConnect = () => finish(resolveConnect, socket);
+      const onError = (error) => {
+        socket.destroy();
+        finish(rejectConnect, error);
+      };
+      const onClose = () => finish(rejectConnect, new Error('connection closed before connect'));
+      socket.setTimeout(connectTimeoutMs, () => {
+        socket.destroy(new Error('connect timeout'));
+      });
+      socket.once('connect', onConnect);
+      socket.once('error', onError);
+      socket.once('close', onClose);
+    });
+    return { socket, connected };
+  }
+
+  async function connectValidated(decision, port) {
+    return new Promise((resolveConnect, rejectConnect) => {
+      const attempts = [];
+      const timers = [];
+      let failures = 0;
+      let lastError = null;
+      let settled = false;
+
+      const fail = (error) => {
+        if (settled) return;
+        failures += 1;
+        lastError = error;
+        if (failures !== decision.addresses.length) return;
+        settled = true;
+        rejectConnect(new ScreeningError('connection-failed', 502, {
+          resolvedAddresses: decision.addresses,
+          cause: lastError
+        }));
+      };
+
+      const succeed = (attempt, socket) => {
+        if (settled) {
+          socket.destroy();
+          return;
+        }
+        settled = true;
+        timers.forEach(clearTimeout);
+        attempts.forEach((candidate) => {
+          if (candidate !== attempt) candidate.socket.destroy();
+        });
+        resolveConnect({ socket, selectedAddress: attempt.address });
+      };
+
+      decision.addresses.forEach((address, index) => {
+        timers.push(setTimeout(() => {
+          if (settled) return;
+          let attempt;
+          try {
+            attempt = { address, ...connectAddress(address, port) };
+          } catch (error) {
+            fail(error);
+            return;
+          }
+          attempts.push(attempt);
+          attempt.connected.then(
+            (socket) => succeed(attempt, socket),
+            fail
+          );
+        }, index * connectAttemptDelayMs));
+      });
+    });
+  }
+
+  function screeningFailure(target, error) {
+    const screeningError = error instanceof ScreeningError ? error :
+      new ScreeningError('internal-proxy-error', 502, { cause: error });
+    recordBlock(target, screeningError.reason, screeningError.details);
+    return screeningError;
+  }
+
+  function rejectHttp(response, error) {
+    if (!response.headersSent) {
+      response.writeHead(error.statusCode, { connection: 'close', 'content-length': '0' });
+    }
+    response.end();
+  }
+
+  function rejectSocket(socket, error) {
+    if (!socket.destroyed) {
+      const reason = error.statusCode === 400 ? 'Bad Request' :
+        error.statusCode === 403 ? 'Forbidden' : 'Bad Gateway';
+      socket.end(`HTTP/1.1 ${error.statusCode} ${reason}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`);
+    }
+  }
+
+  const server = http.createServer((request, response) => {
+    (async () => {
+      let target;
+      try {
+        target = parseHttpRequest(request);
+        const decision = await screen(target);
+        const connection = await connectValidated(decision, target.port);
+        const headers = withoutHopByHopHeaders(request.headers);
+        headers.host = target.authority;
+        const agent = new http.Agent({ keepAlive: false, maxSockets: 1 });
+        agent.createConnection = () => connection.socket;
+        const upstream = http.request({
+          hostname: connection.selectedAddress,
+          family: net.isIP(connection.selectedAddress),
+          port: target.port,
+          method: request.method,
+          path: target.path,
+          headers,
+          agent
+        });
+        let responseStarted = false;
+        upstream.on('response', (upstreamResponse) => {
+          responseStarted = true;
+          response.writeHead(
+            upstreamResponse.statusCode,
+            withoutHopByHopHeaders(upstreamResponse.headers)
+          );
+          upstreamResponse.pipe(response);
+        });
+        upstream.once('error', (cause) => {
+          if (responseStarted || response.destroyed) return;
+          const error = screeningFailure(target, new ScreeningError('connection-failed', 502, {
+            resolvedAddresses: decision.addresses,
+            selectedAddress: connection.selectedAddress,
+            cause
+          }));
+          rejectHttp(response, error);
+        });
+        upstream.once('close', () => agent.destroy());
+        request.once('aborted', () => upstream.destroy());
+        request.pipe(upstream);
+      } catch (cause) {
+        rejectHttp(response, screeningFailure(target, cause));
+      }
+    })();
+  });
+
+  server.on('connect', (request, clientSocket, head) => {
+    track(clientSocket);
+    (async () => {
+      let target;
+      try {
+        target = parseConnectRequest(request);
+        if (!connectFramingValid(request, target, head)) {
+          throw new ScreeningError('invalid-framing', 400);
+        }
+        const decision = await screen(target);
+        const connection = await connectValidated(decision, target.port);
+        const upstream = connection.socket;
+        clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+        if (head.length) upstream.write(head);
+        clientSocket.pipe(upstream);
+        upstream.pipe(clientSocket);
+        upstream.once('error', (cause) => {
+          clientSocket.destroy(cause);
+        });
+      } catch (cause) {
+        rejectSocket(clientSocket, screeningFailure(target, cause));
+      }
+    })();
+  });
+
+  server.on('upgrade', (request, clientSocket, head) => {
+    track(clientSocket);
+    (async () => {
+      let target;
+      try {
+        target = parseUpgradeRequest(request);
+        const decision = await screen(target);
+        const connection = await connectValidated(decision, target.port);
+        const upstream = connection.socket;
+        upstream.write(
+          `${request.method} ${target.path} HTTP/${request.httpVersion}\r\n` +
+          `${upgradeHeaders(request, target.authority).join('\r\n')}\r\n\r\n`
+        );
+        if (head.length) upstream.write(head);
+        clientSocket.pipe(upstream);
+        upstream.pipe(clientSocket);
+        upstream.once('error', (cause) => {
+          clientSocket.destroy(cause);
+        });
+      } catch (cause) {
+        rejectSocket(clientSocket, screeningFailure(target, cause));
+      }
+    })();
+  });
+
+  server.on('clientError', (_error, socket) => {
+    recordBlock(null, 'invalid-client-request', { kind: 'client' });
+    if (!socket.destroyed) {
+      socket.end('HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n');
+    }
+  });
+  server.on('connection', track);
+
+  const controller = {
+    server,
+    blocked,
+    async listen(port = 0) {
+      if (closed || closing) throw new Error('proxy is closed');
+      if (server.listening) throw new Error('proxy is already listening');
+      await new Promise((resolveListen, rejectListen) => {
+        const onError = (error) => { server.off('listening', onListening); rejectListen(error); };
+        const onListening = () => { server.off('error', onError); resolveListen(); };
+        server.once('error', onError);
+        server.once('listening', onListening);
+        server.listen(port, '127.0.0.1');
+      });
+      lastAddress = server.address();
+      return controller;
+    },
+    address() {
+      return server.address() || lastAddress;
+    },
+    url() {
+      const address = controller.address();
+      if (!address) throw new Error('proxy is not listening');
+      return `http://127.0.0.1:${address.port}`;
+    },
+    getBlockReport() {
+      return {
+        blocked_requests: blocked.samples(),
+        blocked_request_count: blocked.count()
+      };
+    },
+    blockedEvents() {
+      return detailSamples.map((event) => ({
+        ...event,
+        resolvedAddresses: event.resolvedAddresses.slice(),
+        blockedAddresses: event.blockedAddresses.slice()
+      }));
+    },
+    isClosed() {
+      return closed;
+    },
+    async close() {
+      if (closed) return;
+      if (closing) {
+        while (!closed) await new Promise((resolveWait) => setTimeout(resolveWait, 5));
+        return;
+      }
+      closing = true;
+      sockets.forEach((socket) => socket.destroy());
+      await new Promise((resolveClose) => {
+        if (!server.listening) {
+          resolveClose();
+          return;
+        }
+        server.close(() => resolveClose());
+      });
+      closed = true;
+      closing = false;
+    }
+  };
+  return controller;
+}
+
+async function withScreeningProxy(options, callback) {
+  if (typeof callback !== 'function') throw new TypeError('callback must be a function');
+  const proxy = createScreeningProxy(options);
+  await proxy.listen(options.listenPort || 0);
+  try {
+    return await callback(proxy);
+  } finally {
+    await proxy.close();
+  }
+}
+
+module.exports = {
+  createBlockCollector,
+  createScreeningProxy,
+  withScreeningProxy
+};
+
+if (require.main === module) {
+  const readline = require('readline');
+  const maximumInputBytes = 1024 * 1024;
+  let controller = null;
+  let configured = false;
+  let shuttingDown = null;
+  let inputBytes = 0;
+
+  const input = readline.createInterface({
+    input: process.stdin,
+    crlfDelay: Infinity,
+    terminal: false
+  });
+
+  const emit = (message) => {
+    process.stdout.write(`${JSON.stringify(message)}\n`);
+  };
+
+  const errorMessage = (error) =>
+    String(error && error.message ? error.message : error).slice(0, 500);
+
+  const shutdown = ({ report = false, exitCode = 0 } = {}) => {
+    if (shuttingDown) return shuttingDown;
+    shuttingDown = (async () => {
+      let closeError = null;
+      if (controller) {
+        try {
+          await controller.close();
+        } catch (error) {
+          closeError = error;
+          exitCode = 1;
+        }
+      }
+      if (report) {
+        emit({
+          type: closeError ? 'error' : 'closed',
+          ...(closeError ? { error: errorMessage(closeError) } : {}),
+          report: controller ? controller.getBlockReport() : {
+            blocked_requests: [],
+            blocked_request_count: 0
+          },
+          blocked_events: controller ? controller.blockedEvents() : []
+        });
+      }
+      process.exitCode = exitCode;
+      process.stdin.pause();
+      input.close();
+    })();
+    return shuttingDown;
+  };
+
+  const fail = async (error) => {
+    emit({ type: 'error', error: errorMessage(error) });
+    await shutdown({ exitCode: 1 });
+  };
+
+  const configure = async (line) => {
+    let options;
+    try {
+      options = JSON.parse(line);
+    } catch (_error) {
+      throw new Error('screening proxy configuration must be valid JSON');
+    }
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+      throw new Error('screening proxy configuration must be an object');
+    }
+    controller = createScreeningProxy(options);
+    await controller.listen(options.listenPort || 0);
+    configured = true;
+    emit({ type: 'ready', proxyUrl: controller.url() });
+  };
+
+  const command = async (line) => {
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch (_error) {
+      throw new Error('screening proxy command must be valid JSON');
+    }
+    if (!message || message.command !== 'close') {
+      throw new Error('unsupported screening proxy command');
+    }
+    await shutdown({ report: true });
+  };
+
+  input.on('line', (line) => {
+    if (shuttingDown) return;
+    inputBytes += Buffer.byteLength(line, 'utf8') + 1;
+    if (inputBytes > maximumInputBytes) {
+      void fail(new Error('screening proxy input exceeds the size limit'));
+      return;
+    }
+    void (configured ? command(line) : configure(line)).catch(fail);
+  });
+
+  input.on('close', () => {
+    if (!shuttingDown) void shutdown();
+  });
+  process.once('SIGINT', () => { void shutdown({ exitCode: 130 }); });
+  process.once('SIGTERM', () => { void shutdown({ exitCode: 143 }); });
+}

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -507,15 +507,15 @@ class RunGarakScan
 
     web_config = target.web_config.is_a?(String) ? JSON.parse(target.web_config) : target.web_config
 
-    # Hand the browser driver the same blocklist UrlSafetyValidator enforces, so the
-    # webchat URL stays screened for the whole scan rather than only at launch: a
-    # redirect from the target, or JS on its page, can otherwise steer the browser to
-    # an internal address that was never checked. WebChatbotGenerator refuses to
-    # launch without this key.
+    # Hand both browser layers the same blocklist UrlSafetyValidator enforces. The
+    # route guard refuses visible HTTP requests early; the screening proxy owns DNS
+    # and the exact transport connection, including redirects and WebSockets.
+    # WebChatbotGenerator refuses to launch if either layer is missing.
     garak_config = {
       "web_chatbot" => {
         "WebChatbotGenerator" => (web_config.is_a?(Hash) ? web_config : {}).merge(
-          "network_guard" => BrowserAutomation::NetworkGuard.payload
+          "network_guard" => BrowserAutomation::NetworkGuard.payload,
+          "screening_proxy" => BrowserAutomation::NetworkGuard.proxy_payload
         )
       }
     }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "build:css": "npx @tailwindcss/cli -i ./app/assets/stylesheets/application.css -o ./app/assets/builds/application.css --minify",
-    "test:js": "node script/tests/javascript_controller_tests.mjs",
+    "test:js": "node script/tests/javascript_controller_tests.mjs && node --test script/tests/screening_proxy_test.mjs",
     "playwright:install": "npx playwright install chromium",
     "playwright:install-deps": "npx playwright install-deps chromium",
     "playwright:test": "npx playwright test",

--- a/script/garak_plugins/_network_guard.py
+++ b/script/garak_plugins/_network_guard.py
@@ -8,10 +8,9 @@ import asyncio
 import ipaddress
 import logging
 import socket
-from urllib.parse import urljoin, urlsplit
+from urllib.parse import urlsplit
 
 
-MAX_REDIRECTS = 20
 INERT_SCHEMES = ("data", "blob", "about")
 
 
@@ -30,17 +29,16 @@ class NetworkGuard:
     screened. The browser runs in the same container as Rails, so that reaches
     whatever the container can reach.
 
-    Screening the request URL alone is not enough. Chromium follows 3xx responses
-    internally and does not re-invoke route handlers for the redirected hop, so this
-    walks the redirect chain itself and screens every hop.
+    This route handler is defense in depth: it refuses visible HTTP requests early
+    and reports them. The browser's screening proxy owns connection-level DNS
+    validation, redirect hops, and WebSocket traffic.
 
     `blocked_cidrs` is supplied by Rails from UrlSafetyValidator::BLOCKED_RANGES so
     there is one blocklist in the product rather than a Python copy that drifts.
 
-    Known limits: DNS may still flip between this lookup and Chromium's own (TOCTOU),
-    WebSocket handshakes are not intercepted by route(), and Server-Sent Events are
-    host-screened but not redirect-screened because buffering them would hold the
-    stream open forever.
+    The handler deliberately continues allowed requests unchanged. Fetching and
+    fulfilling them here would buffer streaming responses and duplicate transport
+    enforcement already performed by the proxy.
     """
 
     LOOPBACK = (ipaddress.ip_network("127.0.0.0/8"), ipaddress.ip_network("::1/128"))
@@ -56,8 +54,12 @@ class NetworkGuard:
         except ValueError as exc:
             raise NetworkGuardError(f"network_guard.blocked_cidrs unparsable: {exc}") from exc
         self.allow_loopback = config.get("allow_loopback") is True
+        report_limit = config.get("report_limit", 50)
+        if not isinstance(report_limit, int) or isinstance(report_limit, bool) or report_limit < 0:
+            raise NetworkGuardError("network_guard.report_limit must be a non-negative integer")
+        self.report_limit = report_limit
         self.blocked = []
-        self._decisions = {}
+        self.blocked_count = 0
 
     @staticmethod
     def _parse_ip(host):
@@ -94,9 +96,6 @@ class NetworkGuard:
         return addresses
 
     async def _host_allowed(self, host):
-        if host in self._decisions:
-            return self._decisions[host]
-
         addresses = await self._resolve(host)
         # No usable address is fail-closed, matching the Ruby validator.
         if not addresses:
@@ -116,7 +115,6 @@ class NetworkGuard:
                 if not verdict[0]:
                     break
 
-        self._decisions[host] = verdict
         return verdict
 
     async def screen(self, url):
@@ -130,7 +128,9 @@ class NetworkGuard:
         return None if allowed else reason
 
     def _deny(self, url, reason):
-        self.blocked.append({"url": url[:200], "reason": reason})
+        self.blocked_count += 1
+        if len(self.blocked) < self.report_limit:
+            self.blocked.append({"url": url[:200], "reason": reason})
         logging.warning("WebChatbotGenerator network guard blocked %s (%s)", url[:200], reason)
 
     async def handle(self, route):
@@ -147,39 +147,4 @@ class NetworkGuard:
             await route.abort("blockedbyclient")
             return
 
-        accept = (request.headers.get("accept") or "").lower()
-        if "text/event-stream" in accept:
-            # Streaming responses must not be buffered through route.fetch(); doing so
-            # holds the connection open and hangs any target that streams tokens.
-            await route.continue_()
-            return
-
-        current = url
-        try:
-            response = await route.fetch(max_redirects=0)
-            for hop in range(MAX_REDIRECTS):
-                if not 300 <= response.status <= 399:
-                    break
-                location = response.headers.get("location")
-                if not location:
-                    break
-
-                nxt = urljoin(current, location)
-                nxt_reason = await self.screen(nxt)
-                if nxt_reason:
-                    self._deny(nxt, f"redirect to {nxt_reason}")
-                    await route.abort("blockedbyclient")
-                    return
-
-                current = nxt
-                response = await route.fetch(url=nxt, max_redirects=0)
-                if hop == MAX_REDIRECTS - 1:
-                    self._deny(nxt, "too many redirects")
-                    await route.abort("blockedbyclient")
-                    return
-        except Exception as exc:  # network failure mid-chain - fail closed
-            logging.debug("WebChatbotGenerator network guard aborting %s: %s", url[:200], exc)
-            await route.abort("failed")
-            return
-
-        await route.fulfill(response=response)
+        await route.continue_()

--- a/script/garak_plugins/_screening_proxy.py
+++ b/script/garak_plugins/_screening_proxy.py
@@ -1,0 +1,222 @@
+"""Lifecycle adapter for the shared Node screening proxy.
+
+The proxy owns DNS resolution and the exact outbound connection. This module
+contains no address-policy implementation; it only starts the shared proxy,
+validates its loopback endpoint, and guarantees process teardown.
+"""
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import shutil
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+START_TIMEOUT_SECONDS = 10
+CLOSE_TIMEOUT_SECONDS = 5
+MAX_PROTOCOL_LINE_BYTES = 1024 * 1024
+
+
+class ScreeningProxyError(Exception):
+    """Raised when the proxy cannot be configured or started safely."""
+
+
+class ScreeningProxyProcess:
+    """Own one screening-proxy process for one browser launch."""
+
+    def __init__(self, config):
+        if not isinstance(config, dict):
+            raise ScreeningProxyError("screening_proxy config missing - refusing to browse unguarded")
+
+        runner_path = config.get("modulePath")
+        blocked_cidrs = config.get("blockedCidrs")
+        if not isinstance(runner_path, str) or not os.path.isabs(runner_path):
+            raise ScreeningProxyError("screening_proxy.modulePath must be an absolute path")
+        if not Path(runner_path).is_file():
+            raise ScreeningProxyError("screening_proxy.modulePath is not a regular file")
+        if not isinstance(blocked_cidrs, list) or not blocked_cidrs:
+            raise ScreeningProxyError("screening_proxy.blockedCidrs missing - refusing to browse unguarded")
+        if not all(isinstance(cidr, str) and cidr for cidr in blocked_cidrs):
+            raise ScreeningProxyError("screening_proxy.blockedCidrs must contain strings")
+
+        node_path = config.get("nodePath") or shutil.which("node")
+        if not node_path or not os.path.isabs(node_path) or not os.access(node_path, os.X_OK):
+            raise ScreeningProxyError("screening proxy requires an executable Node.js runtime")
+
+        self.config = dict(config)
+        self.runner_path = runner_path
+        self.node_path = node_path
+        self.process = None
+        self.url = None
+        self.report = {"blocked_requests": [], "blocked_request_count": 0}
+        self.blocked_events = []
+        self._closed = False
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, _error_type, _error, _traceback):
+        await self.close()
+
+    async def start(self):
+        if self.process is not None:
+            raise ScreeningProxyError("screening proxy process already started")
+
+        try:
+            self.process = await asyncio.create_subprocess_exec(
+                self.node_path,
+                self.runner_path,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                limit=MAX_PROTOCOL_LINE_BYTES,
+            )
+            payload = (json.dumps(self.config, separators=(",", ":")) + "\n").encode("utf-8")
+            if len(payload) > MAX_PROTOCOL_LINE_BYTES:
+                raise ScreeningProxyError("screening proxy configuration exceeds the size limit")
+            self.process.stdin.write(payload)
+            await self.process.stdin.drain()
+
+            message = await self._read_message(START_TIMEOUT_SECONDS)
+            endpoint = message.get("proxyUrl") if message.get("type") == "ready" else None
+            if not self._valid_endpoint(endpoint):
+                detail = message.get("error") if isinstance(message, dict) else None
+                suffix = f": {detail}" if detail else ""
+                raise ScreeningProxyError(f"screening proxy returned an invalid ready response{suffix}")
+            self.url = endpoint
+            return endpoint
+        except ScreeningProxyError:
+            await self._terminate()
+            raise
+        except Exception as error:
+            await self._terminate()
+            raise ScreeningProxyError(f"screening proxy failed to start: {error}") from error
+
+    async def close(self):
+        if self._closed:
+            return self.report
+        self._closed = True
+
+        if self.process is None:
+            return self.report
+
+        try:
+            if self.process.returncode is None and self.process.stdin is not None:
+                self.process.stdin.write(b'{"command":"close"}\n')
+                await self.process.stdin.drain()
+                message = await self._read_message(CLOSE_TIMEOUT_SECONDS)
+                if message.get("type") == "closed":
+                    self._accept_report(message)
+                else:
+                    logging.warning(
+                        "WebChatbotGenerator screening proxy returned an invalid close response: %s",
+                        str(message.get("error") or message.get("type"))[:500],
+                    )
+        except (BrokenPipeError, ConnectionResetError, ScreeningProxyError) as error:
+            logging.warning("WebChatbotGenerator screening proxy cleanup failed: %s", error)
+        finally:
+            await self._terminate()
+
+        self._log_report()
+        return self.report
+
+    async def _read_message(self, timeout):
+        try:
+            line = await asyncio.wait_for(self.process.stdout.readline(), timeout=timeout)
+        except asyncio.TimeoutError as error:
+            raise ScreeningProxyError("screening proxy protocol timed out") from error
+        except ValueError as error:
+            raise ScreeningProxyError("screening proxy protocol line exceeds the size limit") from error
+        if not line:
+            raise ScreeningProxyError("screening proxy exited before replying")
+        try:
+            message = json.loads(line)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ScreeningProxyError("screening proxy returned invalid JSON") from error
+        if not isinstance(message, dict):
+            raise ScreeningProxyError("screening proxy returned an invalid protocol message")
+        return message
+
+    @staticmethod
+    def _valid_endpoint(endpoint):
+        if not isinstance(endpoint, str):
+            return False
+        try:
+            parsed = urlsplit(endpoint)
+            port = parsed.port
+        except ValueError:
+            return False
+        return (
+            parsed.scheme == "http"
+            and parsed.hostname == "127.0.0.1"
+            and port is not None
+            and 1 <= port <= 65535
+            and parsed.username is None
+            and parsed.password is None
+            and parsed.path in ("", "/")
+            and not parsed.query
+            and not parsed.fragment
+        )
+
+    def _accept_report(self, message):
+        report = message.get("report")
+        events = message.get("blocked_events")
+        if isinstance(report, dict):
+            requests = report.get("blocked_requests")
+            count = report.get("blocked_request_count")
+            if isinstance(requests, list) and isinstance(count, int) and count >= len(requests):
+                self.report = {
+                    "blocked_requests": requests,
+                    "blocked_request_count": count,
+                }
+        if isinstance(events, list):
+            self.blocked_events = events
+
+    def _log_report(self):
+        count = self.report["blocked_request_count"]
+        if count <= 0:
+            return
+        samples = []
+        for event in self.blocked_events:
+            if not isinstance(event, dict):
+                continue
+            samples.append(f"{event.get('reason', 'blocked')} {event.get('target', '')}".strip())
+        detail = f": {'; '.join(samples)}" if samples else ""
+        logging.warning(
+            "WebChatbotGenerator screening proxy blocked %d request(s)%s",
+            count,
+            detail,
+        )
+
+    async def _terminate(self):
+        process = self.process
+        if process is None:
+            return
+
+        if process.stdin is not None and not process.stdin.is_closing():
+            process.stdin.close()
+            with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                await process.stdin.wait_closed()
+
+        if process.returncode is None:
+            try:
+                await asyncio.wait_for(process.wait(), timeout=CLOSE_TIMEOUT_SECONDS)
+            except asyncio.TimeoutError:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=CLOSE_TIMEOUT_SECONDS)
+                except asyncio.TimeoutError:
+                    process.kill()
+                    await process.wait()
+
+        if process.stderr is not None:
+            stderr = await process.stderr.read()
+            if stderr:
+                logging.warning(
+                    "WebChatbotGenerator screening proxy stderr: %s",
+                    stderr.decode("utf-8", errors="replace")[:1000],
+                )

--- a/script/garak_plugins/web_chatbot.py
+++ b/script/garak_plugins/web_chatbot.py
@@ -15,8 +15,12 @@ from playwright.async_api import async_playwright, Page, Browser, TimeoutError a
 
 from garak.generators.base import Generator
 from garak.generators._network_guard import NetworkGuard
+from garak.generators._screening_proxy import ScreeningProxyProcess
 from garak import _config
 from garak.attempt import Conversation, Message
+
+
+RESOURCE_CLOSE_TIMEOUT_SECONDS = 5
 
 
 class WebChatbotGenerator(Generator):
@@ -76,6 +80,9 @@ class WebChatbotGenerator(Generator):
         # Supplied by Rails from UrlSafetyValidator::BLOCKED_RANGES. Required:
         # _init_browser refuses to launch without it rather than browsing unguarded.
         "network_guard": None,      # {"blocked_cidrs": [...], "allow_loopback": bool}
+        # Starts the shared connection-level proxy before Chromium. Required so
+        # DNS rebinding and WebSockets use the same address policy as HTTP routes.
+        "screening_proxy": None,
     }
 
     generator_family_name = "WebChatbot"
@@ -89,6 +96,7 @@ class WebChatbotGenerator(Generator):
         self._page = None
         self._playwright = None
         self._network_guard = None
+        self._screening_proxy = None
 
         # Call parent to load configuration
         super().__init__(name=name, config_root=config_root)
@@ -158,10 +166,13 @@ class WebChatbotGenerator(Generator):
     async def _init_browser(self):
         """Initialize Playwright browser instance"""
         try:
+            self._screening_proxy = ScreeningProxyProcess(getattr(self, "screening_proxy", None))
+            proxy_url = await self._screening_proxy.start()
             self._playwright = await async_playwright().start()
             self._browser = await self._playwright.chromium.launch(
                 headless=self.browser_options.get("headless", True),
-                args=['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--disable-gpu']
+                args=['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--disable-gpu'],
+                proxy={"server": proxy_url},
             )
 
             self._context = await self._browser.new_context(
@@ -196,6 +207,7 @@ class WebChatbotGenerator(Generator):
 
         except Exception as e:
             logging.error(f"Failed to initialize browser: {e}")
+            await self._async_cleanup()
             raise
 
     def _extract_prompt_text(self, prompt: Union[Conversation, str]) -> str:
@@ -633,7 +645,7 @@ class WebChatbotGenerator(Generator):
     def __del__(self):
         """Clean up browser resources"""
         # Cannot use await in __del__, need to handle cleanup carefully
-        if self._page or self._browser or self._playwright:
+        if self._page or self._browser or self._playwright or self._screening_proxy:
             try:
                 # Try to get the running loop
                 loop = asyncio.get_event_loop()
@@ -653,16 +665,29 @@ class WebChatbotGenerator(Generator):
 
     async def _async_cleanup(self):
         """Async cleanup helper"""
-        try:
-            if self._page:
-                await self._page.close()
-            if self._context:
-                await self._context.close()
-            if self._browser:
-                await self._browser.close()
-            if self._playwright:
-                await self._playwright.stop()
-        except Exception as e:
-            logging.warning(f"Error during WebChatbotGenerator cleanup: {e}")
+        resources = [
+            ("page", self._page, "close"),
+            ("context", self._context, "close"),
+            ("browser", self._browser, "close"),
+            ("playwright", self._playwright, "stop"),
+            ("screening proxy", self._screening_proxy, "close"),
+        ]
+        for name, resource, method in resources:
+            if resource is None:
+                continue
+            try:
+                await asyncio.wait_for(
+                    getattr(resource, method)(),
+                    timeout=RESOURCE_CLOSE_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logging.warning(f"Timed out closing WebChatbotGenerator {name}")
+            except Exception as e:
+                logging.warning(f"Error closing WebChatbotGenerator {name}: {e}")
+        self._page = None
+        self._context = None
+        self._browser = None
+        self._playwright = None
+        self._screening_proxy = None
 
 DEFAULT_CLASS = "WebChatbotGenerator"

--- a/script/tests/screening_proxy_test.mjs
+++ b/script/tests/screening_proxy_test.mjs
@@ -1,0 +1,1032 @@
+// Integration and parser-hardening tests for the browser screening proxy.
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import dns from 'node:dns/promises';
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync, spawn } from 'node:child_process';
+import { EventEmitter, once } from 'node:events';
+import { createRequire } from 'node:module';
+import { after, before, test } from 'node:test';
+import { createInterface } from 'node:readline';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const RUNNER_PATH = path.join(__dirname, '..', '..', 'app', 'services', 'browser_automation', 'screening_proxy_runner.cjs');
+let chromium;
+let playwrightUnavailable;
+try {
+  ({ chromium } = require('playwright'));
+  if (!fs.existsSync(chromium.executablePath())) {
+    playwrightUnavailable = `Chromium executable is absent at ${chromium.executablePath()}`;
+    chromium = undefined;
+  }
+} catch (error) {
+  playwrightUnavailable = error.message;
+}
+
+let proxyApi;
+function screeningProxyApi() {
+  proxyApi ||= require('../../app/services/browser_automation/screening_proxy_runner.cjs');
+  return proxyApi;
+}
+
+function createBlockCollector(options) {
+  return screeningProxyApi().createBlockCollector(options);
+}
+
+function createScreeningProxy(options) {
+  return screeningProxyApi().createScreeningProxy(options);
+}
+
+function withScreeningProxy(options, callback) {
+  return screeningProxyApi().withScreeningProxy(options, callback);
+}
+
+const BLOCKED_CIDRS = [
+  '127.0.0.0/8', '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16',
+  '169.254.0.0/16', '0.0.0.0/8', '::1/128', 'fc00::/7', 'fe80::/10',
+  '100.64.0.0/10', '240.0.0.0/4', '224.0.0.0/4', '255.255.255.255/32',
+  '::/128', 'ff00::/8'
+];
+const ALLOWED_INTERNAL_HOSTS = ['chat.allowed.test', 'dual.allowed.test'];
+const CHROMIUM_ARGS = [
+  '--no-sandbox',
+  '--disable-setuid-sandbox',
+  '--disable-dev-shm-usage',
+  '--disable-gpu'
+];
+const observed = {};
+const targetSockets = new Set();
+const chatRequestUrls = [];
+const chatUpgradeRequests = [];
+
+let certDir;
+let chatServer;
+let blockedHttpServer;
+let blockedWssServer;
+let chatPort;
+let blockedHttpPort;
+let blockedWssPort;
+let hangStartedResolve;
+let hangStarted;
+
+const counters = {
+  chatConnections: 0,
+  chatRequests: 0,
+  chatUpgrades: 0,
+  blockedHttpConnections: 0,
+  blockedHttpRequests: 0,
+  blockedHttpUpgrades: 0,
+  blockedWssConnections: 0,
+  blockedWssUpgrades: 0
+};
+
+function listen(server, host = '127.0.0.1', port = 0) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => resolve(server.address().port));
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => {
+    targetSockets.forEach((socket) => socket.destroy());
+    server.closeAllConnections?.();
+    server.close(() => resolve());
+  });
+}
+
+function trackTargetSocket(socket) {
+  targetSockets.add(socket);
+  socket.once('close', () => targetSockets.delete(socket));
+}
+
+function websocketAccept(request) {
+  return crypto
+    .createHash('sha1')
+    .update(`${request.headers['sec-websocket-key']}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+    .digest('base64');
+}
+
+function acceptChatWebSocket(request, socket) {
+  counters.chatUpgrades += 1;
+  chatUpgradeRequests.push({ url: request.url, rawHeaders: request.rawHeaders.slice() });
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n' +
+    'Upgrade: websocket\r\n' +
+    'Connection: Upgrade\r\n' +
+    `Sec-WebSocket-Accept: ${websocketAccept(request)}\r\n\r\n`
+  );
+  const payload = Buffer.from('chat-ok');
+  socket.write(Buffer.concat([Buffer.from([0x81, payload.length]), payload]));
+  socket.write(Buffer.from([0x88, 0x02, 0x03, 0xe8]));
+  setTimeout(() => socket.end(), 100);
+}
+
+function workerPage() {
+  return `<!doctype html><script>
+    const params = new URLSearchParams(location.search);
+    window.workerDone = false;
+    const worker = new Worker('/worker.js?ws=' + encodeURIComponent(params.get('ws')) +
+      '&wss=' + encodeURIComponent(params.get('wss')));
+    worker.onmessage = (event) => { window.workerResult = event.data; window.workerDone = true; worker.terminate(); };
+    worker.onerror = (event) => { window.workerResult = { error: event.message }; window.workerDone = true; };
+  </script>`;
+}
+
+function workerScript() {
+  return `
+    function attempt(url) {
+      return new Promise((resolve) => {
+        const result = { url, opened: false, error: null, closeCode: null };
+        const socket = new WebSocket(url);
+        const timer = setTimeout(() => { result.error = 'timeout'; socket.close(); resolve(result); }, 5000);
+        socket.onopen = () => { result.opened = true; };
+        socket.onerror = () => { result.error = 'websocket-error'; };
+        socket.onclose = (event) => { clearTimeout(timer); result.closeCode = event.code; resolve(result); };
+      });
+    }
+    const params = new URLSearchParams(location.search);
+    (async () => postMessage({ ws: await attempt(params.get('ws')), wss: await attempt(params.get('wss')) }))();
+  `;
+}
+
+async function defaultResolver(host) {
+  if (host === 'chat.allowed.test') return ['127.0.0.1'];
+  if (host === 'dual.allowed.test') return ['2001:db8::1', '127.0.0.1'];
+  if (host === 'rebind.test') return ['127.0.0.1'];
+  if (host === 'mixed.test') return ['93.184.216.34', '127.0.0.1'];
+  return (await dns.lookup(host, { all: true, family: 4 })).map((entry) => entry.address);
+}
+
+function requireOutboundHttps() {
+  return new Promise((resolve, reject) => {
+    const request = https.get('https://example.com/', { timeout: 5000 }, (response) => {
+      response.resume();
+      response.once('end', resolve);
+    });
+    request.once('timeout', () => request.destroy(new Error('outbound HTTPS preflight timed out')));
+    request.once('error', reject);
+  });
+}
+
+function proxyOptions(overrides = {}) {
+  return {
+    blockedCidrs: BLOCKED_CIDRS,
+    allowedInternalHosts: ALLOWED_INTERNAL_HOSTS,
+    allowedAddresses: ['127.0.0.1'],
+    resolve: defaultResolver,
+    connectTimeoutMs: 5000,
+    ...overrides
+  };
+}
+
+function requireChromium(t) {
+  if (chromium) return true;
+  observed.chromium = { skipped: true, reason: playwrightUnavailable };
+  t.skip(`Playwright Chromium unavailable: ${playwrightUnavailable}`);
+  return false;
+}
+
+async function launchChromium(proxy) {
+  return chromium.launch({
+    headless: true,
+    proxy: { server: proxy.url() },
+    args: CHROMIUM_ARGS
+  });
+}
+
+async function withBrowser(options, callback) {
+  return withScreeningProxy(options, async (proxy) => {
+    const browser = await launchChromium(proxy);
+    try {
+      return await callback({ proxy, browser });
+    } finally {
+      await browser.close();
+    }
+  });
+}
+
+function proxyHttpGet(proxy, absoluteUrl, hostHeader) {
+  return new Promise((resolve, reject) => {
+    const request = http.get({
+      hostname: '127.0.0.1',
+      port: proxy.address().port,
+      path: absoluteUrl,
+      headers: { host: hostHeader, connection: 'close' },
+      agent: false
+    }, (response) => {
+      const chunks = [];
+      response.on('data', (chunk) => chunks.push(chunk));
+      response.on('end', () => resolve({
+        status: response.statusCode,
+        body: Buffer.concat(chunks).toString('utf8')
+      }));
+    });
+    request.on('error', reject);
+  });
+}
+
+function socketCanConnect(port) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host: '127.0.0.1', port });
+    socket.once('connect', () => { socket.destroy(); resolve(true); });
+    socket.once('error', () => resolve(false));
+  });
+}
+
+async function unusedLoopbackPort() {
+  const server = http.createServer();
+  const port = await listen(server);
+  await closeServer(server);
+  return port;
+}
+
+function rawProxyExchange(proxy, payload, timeoutMs = 1000) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    const socket = net.connect({ host: '127.0.0.1', port: proxy.address().port }, () => socket.write(payload));
+    const finish = () => {
+      socket.destroy();
+      resolve(Buffer.concat(chunks).toString('latin1'));
+    };
+    const timer = setTimeout(finish, timeoutMs);
+    socket.on('data', (chunk) => {
+      chunks.push(chunk);
+      if (Buffer.concat(chunks).includes('\r\n\r\n')) {
+        clearTimeout(timer);
+        finish();
+      }
+    });
+    socket.on('error', () => { clearTimeout(timer); finish(); });
+    socket.on('end', () => { clearTimeout(timer); finish(); });
+  });
+}
+
+function nextChildLine(lines, child, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      lines.off('line', onLine);
+      child.off('exit', onExit);
+    };
+    const onLine = (line) => { cleanup(); resolve(line); };
+    const onExit = (code, signal) => {
+      cleanup();
+      reject(new Error(`runner exited before replying (code=${code}, signal=${signal})`));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('runner did not reply before timeout'));
+    }, timeoutMs);
+    lines.once('line', onLine);
+    child.once('exit', onExit);
+  });
+}
+
+before(async () => {
+  certDir = fs.mkdtempSync(path.join(os.tmpdir(), 'screening-proxy-test-'));
+  execFileSync('openssl', [
+    'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+    '-keyout', path.join(certDir, 'key.pem'),
+    '-out', path.join(certDir, 'cert.pem'),
+    '-days', '1', '-subj', '/CN=127.0.0.1',
+    '-addext', 'subjectAltName=IP:127.0.0.1'
+  ], { stdio: 'ignore' });
+
+  chatServer = http.createServer((request, response) => {
+    counters.chatRequests += 1;
+    chatRequestUrls.push(request.url);
+    if (request.url.startsWith('/plain')) {
+      response.writeHead(200, { 'content-type': 'text/plain', connection: 'close' });
+      response.end('plain-http-ok');
+    } else if (request.url.startsWith('/worker-page')) {
+      response.writeHead(200, { 'content-type': 'text/html', connection: 'close' });
+      response.end(workerPage());
+    } else if (request.url.startsWith('/worker.js')) {
+      response.writeHead(200, { 'content-type': 'application/javascript', connection: 'close' });
+      response.end(workerScript());
+    } else if (request.url.startsWith('/redirect-to-blocked')) {
+      response.writeHead(302, {
+        location: `http://127.0.0.1:${blockedHttpPort}/redirected`,
+        connection: 'close'
+      });
+      response.end();
+    } else if (request.url.startsWith('/hang')) {
+      hangStartedResolve?.();
+      // Deliberately never respond; proxy teardown must destroy this path.
+    } else {
+      response.writeHead(404, { connection: 'close' }).end();
+    }
+  });
+  chatServer.on('connection', (socket) => { counters.chatConnections += 1; trackTargetSocket(socket); });
+  chatServer.on('upgrade', acceptChatWebSocket);
+  chatPort = await listen(chatServer);
+
+  blockedHttpServer = http.createServer((_request, response) => {
+    counters.blockedHttpRequests += 1;
+    response.writeHead(200).end('should-not-arrive');
+  });
+  blockedHttpServer.on('connection', (socket) => {
+    counters.blockedHttpConnections += 1;
+    trackTargetSocket(socket);
+  });
+  blockedHttpServer.on('upgrade', (_request, socket) => {
+    counters.blockedHttpUpgrades += 1;
+    socket.destroy();
+  });
+  blockedHttpPort = await listen(blockedHttpServer);
+
+  blockedWssServer = https.createServer({
+    key: fs.readFileSync(path.join(certDir, 'key.pem')),
+    cert: fs.readFileSync(path.join(certDir, 'cert.pem'))
+  });
+  blockedWssServer.on('connection', (socket) => {
+    counters.blockedWssConnections += 1;
+    trackTargetSocket(socket);
+  });
+  blockedWssServer.on('upgrade', (_request, socket) => {
+    counters.blockedWssUpgrades += 1;
+    socket.destroy();
+  });
+  blockedWssPort = await listen(blockedWssServer);
+});
+
+after(async () => {
+  await closeServer(chatServer);
+  await closeServer(blockedHttpServer);
+  await closeServer(blockedWssServer);
+  fs.rmSync(certDir, { recursive: true, force: true });
+  console.log(`OBSERVED_OUTPUT ${JSON.stringify(observed, null, 2)}`);
+});
+
+test('strict public HTTPS preserves hostname/SNI while proxy pins the connection', { concurrency: false }, async (t) => {
+  if (!requireChromium(t)) return;
+  try {
+    await requireOutboundHttps();
+  } catch (error) {
+    observed.https = { skipped: true, reason: error.message };
+    t.skip(`outbound HTTPS unavailable: ${error.message}`);
+    return;
+  }
+  await withBrowser(proxyOptions(), async ({ proxy, browser }) => {
+    const context = await browser.newContext({ ignoreHTTPSErrors: false });
+    const page = await context.newPage();
+    const response = await page.goto('https://example.com/', { waitUntil: 'domcontentloaded', timeout: 15000 });
+    observed.https = {
+      status: response.status(),
+      title: await page.title(),
+      finalUrl: page.url(),
+      report: proxy.getBlockReport()
+    };
+    assert.equal(response.status(), 200);
+    assert.equal(await page.title(), 'Example Domain');
+    assert.equal(page.url(), 'https://example.com/');
+    await context.close();
+  });
+});
+
+test('plain HTTP allowed target works through the proxy', { concurrency: false }, async (t) => {
+  if (!requireChromium(t)) return;
+  const beforeRequests = chatRequestUrls.length;
+  await withBrowser(proxyOptions(), async ({ proxy, browser }) => {
+    const page = await browser.newPage();
+    const response = await page.goto(`http://chat.allowed.test:${chatPort}/plain`, { waitUntil: 'domcontentloaded' });
+    observed.http = {
+      status: response.status(),
+      body: await response.text(),
+      finalUrl: page.url(),
+      listener: proxy.address(),
+      targetRequests: chatRequestUrls.slice(beforeRequests)
+    };
+    assert.equal(response.status(), 200);
+    assert.equal(observed.http.body, 'plain-http-ok');
+    assert.equal(proxy.address().address, '127.0.0.1');
+  });
+  assert.equal(chatRequestUrls.slice(beforeRequests).some((url) => url.startsWith('/plain')), true);
+});
+
+test('allowlisted hostname is exempt only for launch-approved internal addresses', { concurrency: false }, async () => {
+  let currentAnswer = '127.0.0.1';
+  const allowedHost = 'scoped.allowed.test';
+  await withScreeningProxy(proxyOptions({
+    allowedInternalHosts: [allowedHost],
+    allowedAddresses: ['127.0.0.1'],
+    resolve: async (host) => host === allowedHost ? [currentAnswer] : defaultResolver(host)
+  }), async (proxy) => {
+    const approved = await proxyHttpGet(
+      proxy,
+      `http://${allowedHost}:${chatPort}/plain`,
+      `${allowedHost}:${chatPort}`
+    );
+    currentAnswer = '127.0.0.2';
+    const changed = await proxyHttpGet(
+      proxy,
+      `http://${allowedHost}:${chatPort}/plain`,
+      `${allowedHost}:${chatPort}`
+    );
+    observed.scopedAllowlist = {
+      approvedStatus: approved.status,
+      changedStatus: changed.status,
+      allowedAddresses: ['127.0.0.1'],
+      changedAnswer: currentAnswer,
+      detailed: proxy.blockedEvents()
+    };
+    assert.equal(approved.status, 200);
+    assert.equal(changed.status, 403);
+    assert.equal(proxy.blockedEvents()[0].reason, 'blocked-address');
+    assert.deepEqual(proxy.blockedEvents()[0].blockedAddresses, ['127.0.0.2']);
+  });
+});
+
+test('blocked-range authority is refused before target TCP', { concurrency: false }, async (t) => {
+  if (!requireChromium(t)) return;
+  const beforeConnections = counters.blockedHttpConnections;
+  await withBrowser(proxyOptions(), async ({ proxy, browser }) => {
+    const page = await browser.newPage();
+    let error;
+    let responseStatus;
+    try {
+      const response = await page.goto(`http://127.0.0.1:${blockedHttpPort}/blocked`, { timeout: 10000 });
+      responseStatus = response.status();
+    } catch (caught) {
+      error = caught.message;
+    }
+    observed.blockedAuthority = {
+      navigationError: error,
+      responseStatus,
+      targetTcpDelta: counters.blockedHttpConnections - beforeConnections,
+      report: proxy.getBlockReport(),
+      detailed: proxy.blockedEvents()
+    };
+    assert.equal(responseStatus, 403);
+    assert.equal(counters.blockedHttpConnections, beforeConnections);
+    assert.equal(proxy.blocked.count(), 1);
+    assert.deepEqual(proxy.blockedEvents()[0].resolvedAddresses, ['127.0.0.1']);
+    assert.deepEqual(proxy.blockedEvents()[0].blockedAddresses, ['127.0.0.1']);
+  });
+});
+
+test('one blocked address rejects a mixed DNS answer before any TCP', { concurrency: false }, async () => {
+  const beforeConnections = counters.blockedHttpConnections;
+  await withScreeningProxy(proxyOptions(), async (proxy) => {
+    const response = await proxyHttpGet(
+      proxy,
+      `http://mixed.test:${blockedHttpPort}/mixed`,
+      `mixed.test:${blockedHttpPort}`
+    );
+    observed.mixedDnsAnswers = {
+      response,
+      targetTcpDelta: counters.blockedHttpConnections - beforeConnections,
+      detailed: proxy.blockedEvents()
+    };
+    assert.equal(response.status, 403);
+    assert.equal(counters.blockedHttpConnections, beforeConnections);
+    assert.deepEqual(proxy.blockedEvents()[0].resolvedAddresses, ['93.184.216.34', '127.0.0.1']);
+    assert.deepEqual(proxy.blockedEvents()[0].blockedAddresses, ['127.0.0.1']);
+  });
+});
+
+test('detailed block reports bound DNS answer lists and return defensive copies', { concurrency: false }, async () => {
+  const answers = [
+    ...Array.from({ length: 40 }, (_value, index) => `11.0.0.${index + 1}`),
+    '127.0.0.1'
+  ];
+  await withScreeningProxy(proxyOptions({
+    maxReportedAddresses: 8,
+    resolve: async (host) => host === 'large-answer.test' ? answers : defaultResolver(host)
+  }), async (proxy) => {
+    const response = await proxyHttpGet(
+      proxy,
+      `http://large-answer.test:${blockedHttpPort}/large`,
+      `large-answer.test:${blockedHttpPort}`
+    );
+    const firstRead = proxy.blockedEvents();
+    firstRead[0].resolvedAddresses.push('mutated-by-caller');
+    const secondRead = proxy.blockedEvents();
+    observed.boundedDetails = {
+      status: response.status,
+      resolvedAddressSamples: secondRead[0].resolvedAddresses,
+      resolvedAddressesTruncated: secondRead[0].resolvedAddressesTruncated,
+      blockedAddressSamples: secondRead[0].blockedAddresses
+    };
+    assert.equal(response.status, 403);
+    assert.equal(secondRead[0].resolvedAddresses.length, 8);
+    assert.equal(secondRead[0].resolvedAddresses.includes('mutated-by-caller'), false);
+    assert.equal(secondRead[0].resolvedAddressesTruncated, answers.length - 8);
+    assert.deepEqual(secondRead[0].blockedAddresses, ['127.0.0.1']);
+  });
+});
+
+test('proxy-owned DNS blocks split-horizon rebinding before browser transport', { concurrency: false }, async (t) => {
+  if (!requireChromium(t)) return;
+  const guardSideAnswer = '93.184.216.34';
+  const proxyLookups = [];
+  const beforeConnections = counters.blockedHttpConnections;
+  await withBrowser(proxyOptions({
+    resolve: async (host) => {
+      proxyLookups.push(host);
+      if (host === 'rebind.test') return ['127.0.0.1'];
+      return defaultResolver(host);
+    }
+  }), async ({ proxy, browser }) => {
+    const page = await browser.newPage();
+    let error;
+    try {
+      await page.goto(`http://rebind.test:${blockedHttpPort}/pivot`, { timeout: 10000 });
+    } catch (caught) {
+      error = caught.message;
+    }
+    observed.rebinding = {
+      simulatedEarlierGuardAnswer: guardSideAnswer,
+      proxyAnswer: '127.0.0.1',
+      proxyLookups,
+      navigationError: error,
+      targetTcpDelta: counters.blockedHttpConnections - beforeConnections,
+      report: proxy.getBlockReport()
+    };
+    assert.equal(proxyLookups.includes('rebind.test'), true);
+    assert.equal(counters.blockedHttpConnections, beforeConnections);
+    assert.equal(proxy.blocked.count(), 1);
+  });
+});
+
+test('browser-followed redirect to a blocked address is refused by the proxy', { concurrency: false }, async (t) => {
+  if (!requireChromium(t)) return;
+  const beforeConnections = counters.blockedHttpConnections;
+  await withBrowser(proxyOptions(), async ({ proxy, browser }) => {
+    const page = await browser.newPage();
+    let error;
+    let responseStatus;
+    try {
+      const response = await page.goto(
+        `http://chat.allowed.test:${chatPort}/redirect-to-blocked`,
+        { timeout: 10000 }
+      );
+      responseStatus = response.status();
+    } catch (caught) {
+      error = caught.message;
+    }
+    observed.redirect = {
+      navigationError: error,
+      responseStatus,
+      targetTcpDelta: counters.blockedHttpConnections - beforeConnections,
+      report: proxy.getBlockReport(),
+      detailed: proxy.blockedEvents()
+    };
+    assert.equal(responseStatus, 403);
+    assert.equal(counters.blockedHttpConnections, beforeConnections);
+    assert.equal(proxy.blocked.count(), 1);
+    assert.equal(proxy.blockedEvents()[0].reason, 'blocked-address');
+  });
+});
+
+test('Worker ws and wss to blocked addresses never reach target TCP', { concurrency: false }, async (t) => {
+  if (!requireChromium(t)) return;
+  const beforeWs = counters.blockedHttpConnections;
+  const beforeWss = counters.blockedWssConnections;
+  await withBrowser(proxyOptions(), async ({ proxy, browser }) => {
+    const page = await browser.newPage();
+    const wsUrl = `ws://127.0.0.1:${blockedHttpPort}/worker`;
+    const wssUrl = `wss://127.0.0.1:${blockedWssPort}/worker`;
+    await page.goto(
+      `http://chat.allowed.test:${chatPort}/worker-page?ws=${encodeURIComponent(wsUrl)}&wss=${encodeURIComponent(wssUrl)}`,
+      { waitUntil: 'domcontentloaded' }
+    );
+    await page.waitForFunction(() => window.workerDone === true, null, { timeout: 15000 });
+    const result = await page.evaluate(() => window.workerResult);
+    observed.workerWebSockets = {
+      result,
+      wsTargetTcpDelta: counters.blockedHttpConnections - beforeWs,
+      wssTargetTcpDelta: counters.blockedWssConnections - beforeWss,
+      report: proxy.getBlockReport()
+    };
+    assert.equal(result.ws.opened, false);
+    assert.equal(result.wss.opened, false);
+    assert.equal(counters.blockedHttpConnections, beforeWs);
+    assert.equal(counters.blockedWssConnections, beforeWss);
+    assert.equal(proxy.blocked.count(), 2);
+  });
+});
+
+test('allowlisted target chat WebSocket still works', { concurrency: false }, async (t) => {
+  if (!requireChromium(t)) return;
+  const beforeUpgrades = counters.chatUpgrades;
+  await withBrowser(proxyOptions(), async ({ proxy, browser }) => {
+    const page = await browser.newPage();
+    await page.goto(`http://chat.allowed.test:${chatPort}/plain`);
+    const result = await page.evaluate((url) => new Promise((resolve) => {
+      const socket = new WebSocket(url);
+      const state = { opened: false, message: null, error: null };
+      socket.onopen = () => { state.opened = true; };
+      socket.onmessage = (event) => { state.message = event.data; };
+      socket.onerror = () => { state.error = 'websocket-error'; };
+      socket.onclose = () => resolve(state);
+    }), `ws://chat.allowed.test:${chatPort}/socket`);
+    observed.chatWebSocket = {
+      result,
+      targetUpgradeDelta: counters.chatUpgrades - beforeUpgrades,
+      report: proxy.getBlockReport()
+    };
+    assert.deepEqual(result, { opened: true, message: 'chat-ok', error: null });
+    assert.equal(counters.chatUpgrades, beforeUpgrades + 1);
+    assert.equal(proxy.blocked.count(), 0);
+  });
+});
+
+test('malformed Upgrade framing is rejected without forwarding smuggling headers', { concurrency: false }, async () => {
+  const beforeUpgrades = counters.chatUpgrades;
+  const beforeRequests = chatUpgradeRequests.length;
+  await withScreeningProxy(proxyOptions(), async (proxy) => {
+    const response = await rawProxyExchange(proxy,
+      `GET ws://chat.allowed.test:${chatPort}/socket HTTP/1.1\r\n` +
+      `Host: chat.allowed.test:${chatPort}\r\n` +
+      'Connection: keep-alive, Upgrade, x-smuggle\r\n' +
+      'Upgrade: websocket\r\n' +
+      'Transfer-Encoding: chunked\r\n' +
+      'X-Smuggle: yes\r\n' +
+      'Sec-WebSocket-Version: 13\r\n' +
+      'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n' +
+      '0\r\n\r\n');
+    observed.malformedUpgrade = {
+      responseLine: response.split('\r\n')[0],
+      targetUpgradeDelta: counters.chatUpgrades - beforeUpgrades,
+      forwardedUpgradeRequests: chatUpgradeRequests.slice(beforeRequests),
+      report: proxy.getBlockReport()
+    };
+    assert.match(response, /^HTTP\/1\.1 400 /);
+    assert.equal(counters.chatUpgrades, beforeUpgrades);
+    assert.equal(chatUpgradeRequests.length, beforeRequests);
+  });
+});
+
+test('malformed CONNECT framing is rejected before opening the tunnel', { concurrency: false }, async () => {
+  const beforeConnections = counters.chatConnections;
+  await withScreeningProxy(proxyOptions(), async (proxy) => {
+    const response = await rawProxyExchange(proxy,
+      `CONNECT chat.allowed.test:${chatPort} HTTP/1.1\r\n` +
+      `Host: wrong.test:${chatPort}\r\n` +
+      `Host: chat.allowed.test:${chatPort}\r\n` +
+      'Content-Length: 4\r\n\r\n' +
+      'evil');
+    observed.malformedConnect = {
+      responseLine: response.split('\r\n')[0],
+      targetTcpDelta: counters.chatConnections - beforeConnections,
+      report: proxy.getBlockReport()
+    };
+    assert.match(response, /^HTTP\/1\.1 400 /);
+    assert.equal(counters.chatConnections, beforeConnections);
+  });
+});
+
+test('strictly framed plain WebSocket Upgrade is forwarded', { concurrency: false }, async () => {
+  const beforeUpgrades = counters.chatUpgrades;
+  await withScreeningProxy(proxyOptions(), async (proxy) => {
+    const response = await rawProxyExchange(proxy,
+      `GET ws://chat.allowed.test:${chatPort}/socket HTTP/1.1\r\n` +
+      `Host: chat.allowed.test:${chatPort}\r\n` +
+      'Connection: Upgrade\r\n' +
+      'Upgrade: websocket\r\n' +
+      'Sec-WebSocket-Version: 13\r\n' +
+      'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n');
+    observed.validUpgrade = {
+      responseLine: response.split('\r\n')[0],
+      targetUpgradeDelta: counters.chatUpgrades - beforeUpgrades
+    };
+    assert.match(response, /^HTTP\/1\.1 101 /);
+    assert.equal(counters.chatUpgrades, beforeUpgrades + 1);
+  });
+});
+
+test('unresolvable and unparsable authorities fail closed and are reported', { concurrency: false }, async () => {
+  await withScreeningProxy(proxyOptions({
+    resolve: async (host) => {
+      if (host === 'missing.test') throw new Error('ENOTFOUND');
+      return defaultResolver(host);
+    }
+  }), async (proxy) => {
+    const dnsFailure = await proxyHttpGet(
+      proxy,
+      `http://missing.test:${blockedHttpPort}/missing`,
+      `missing.test:${blockedHttpPort}`
+    );
+    const invalidConnect = await rawProxyExchange(proxy,
+      'CONNECT missing-port.test HTTP/1.1\r\n' +
+      'Host: missing-port.test\r\n\r\n');
+    observed.failClosedInputs = {
+      dnsFailureStatus: dnsFailure.status,
+      invalidConnectLine: invalidConnect.split('\r\n')[0],
+      reasons: proxy.blockedEvents().map((event) => event.reason),
+      report: proxy.getBlockReport()
+    };
+    assert.equal(dnsFailure.status, 502);
+    assert.match(invalidConnect, /^HTTP\/1\.1 400 /);
+    assert.deepEqual(observed.failClosedInputs.reasons, ['dns-failure', 'invalid-authority']);
+  });
+});
+
+test('missing or empty block policy refuses to create a proxy', { concurrency: false }, () => {
+  for (const options of [{}, { blockedCidrs: [] }, { blockedCidrs: null }]) {
+    assert.throws(
+      () => createScreeningProxy(options),
+      /blockedCidrs must be a non-empty array/
+    );
+  }
+});
+
+test('plain HTTP retries the next validated address when the first is unreachable', { concurrency: false }, async () => {
+  const beforeConnections = counters.chatConnections;
+  await withScreeningProxy(proxyOptions(), async (proxy) => {
+    const response = await proxyHttpGet(
+      proxy,
+      `http://dual.allowed.test:${chatPort}/plain`,
+      `dual.allowed.test:${chatPort}`
+    );
+    observed.dualStack = {
+      resolved: ['2001:db8::1', '127.0.0.1'],
+      status: response.status,
+      body: response.body,
+      ipv4FallbackTargetTcpDelta: counters.chatConnections - beforeConnections
+    };
+    assert.equal(response.status, 200);
+    assert.equal(response.body, 'plain-http-ok');
+    assert.equal(counters.chatConnections, beforeConnections + 1);
+    assert.equal(proxy.blocked.count(), 0);
+  });
+});
+
+test('a hanging first address cannot consume the fallback connection budget', {
+  concurrency: false,
+  timeout: 3000
+}, async () => {
+  const firstAddress = '198.51.100.10';
+  const targetHost = 'hanging-first.test';
+  const originalConnect = net.connect;
+  let hangingDestroyed = false;
+
+  class HangingConnectSocket extends EventEmitter {
+    constructor() {
+      super();
+      this.syntheticTimeout = setTimeout(
+        () => this.destroy(new Error('synthetic connect timeout')),
+        1000
+      );
+    }
+
+    setTimeout() {
+      return this;
+    }
+
+    destroy(error) {
+      if (hangingDestroyed) return this;
+      hangingDestroyed = true;
+      clearTimeout(this.syntheticTimeout);
+      queueMicrotask(() => {
+        if (error) this.emit('error', error);
+        this.emit('close');
+      });
+      return this;
+    }
+  }
+
+  const hangingSocket = new HangingConnectSocket();
+  const connect = (options) => options.host === firstAddress ? hangingSocket : originalConnect(options);
+  net.connect = connect;
+  try {
+    const startedAt = Date.now();
+    await withScreeningProxy(proxyOptions({
+      allowedInternalHosts: [targetHost],
+      allowedAddresses: ['127.0.0.1'],
+      connect,
+      connectAttemptDelayMs: 50,
+      connectTimeoutMs: 1000,
+      resolve: async (host) => {
+        assert.equal(host, targetHost);
+        return [firstAddress, '127.0.0.1'];
+      }
+    }), async (proxy) => {
+      const response = await proxyHttpGet(
+        proxy,
+        `http://${targetHost}:${chatPort}/plain`,
+        `${targetHost}:${chatPort}`
+      );
+      const elapsedMs = Date.now() - startedAt;
+      observed.hangingFirstAddress = { response, elapsedMs, hangingDestroyed };
+      assert.equal(response.status, 200);
+      assert.equal(response.body, 'plain-http-ok');
+      assert.ok(elapsedMs < 500, `fallback took ${elapsedMs}ms`);
+      assert.equal(hangingDestroyed, true);
+    });
+  } finally {
+    net.connect = originalConnect;
+    hangingSocket.destroy();
+  }
+});
+
+test('CONNECT retries the next validated address when the first is unreachable', { concurrency: false }, async () => {
+  const beforeConnections = counters.chatConnections;
+  await withScreeningProxy(proxyOptions(), async (proxy) => {
+    const response = await rawProxyExchange(proxy,
+      `CONNECT dual.allowed.test:${chatPort} HTTP/1.1\r\n` +
+      `Host: dual.allowed.test:${chatPort}\r\n\r\n`);
+    observed.dualStackConnect = {
+      responseLine: response.split('\r\n')[0],
+      targetTcpDelta: counters.chatConnections - beforeConnections
+    };
+    assert.match(response, /^HTTP\/1\.1 200 /);
+    assert.equal(counters.chatConnections, beforeConnections + 1);
+    assert.equal(proxy.blocked.count(), 0);
+  });
+});
+
+test('WebSocket Upgrade retries the next validated address when the first is unreachable', { concurrency: false }, async () => {
+  const beforeUpgrades = counters.chatUpgrades;
+  await withScreeningProxy(proxyOptions(), async (proxy) => {
+    const response = await rawProxyExchange(proxy,
+      `GET ws://dual.allowed.test:${chatPort}/socket HTTP/1.1\r\n` +
+      `Host: dual.allowed.test:${chatPort}\r\n` +
+      'Connection: Upgrade\r\n' +
+      'Upgrade: websocket\r\n' +
+      'Sec-WebSocket-Version: 13\r\n' +
+      'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n');
+    observed.dualStackUpgrade = {
+      responseLine: response.split('\r\n')[0],
+      targetUpgradeDelta: counters.chatUpgrades - beforeUpgrades
+    };
+    assert.match(response, /^HTTP\/1\.1 101 /);
+    assert.equal(counters.chatUpgrades, beforeUpgrades + 1);
+    assert.equal(proxy.blocked.count(), 0);
+  });
+});
+
+test('exhausting every validated address fails closed with one bounded report', { concurrency: false }, async () => {
+  const unusedPort = await unusedLoopbackPort();
+  let lookups = 0;
+  await withScreeningProxy(proxyOptions({
+    blockedCidrs: ['10.0.0.0/8'],
+    allowedInternalHosts: [],
+    allowedAddresses: [],
+    connectTimeoutMs: 100,
+    resolve: async (host) => {
+      assert.equal(host, 'validated-unreachable.test');
+      lookups += 1;
+      return ['127.0.0.2', '127.0.0.3'];
+    }
+  }), async (proxy) => {
+    const response = await proxyHttpGet(
+      proxy,
+      `http://validated-unreachable.test:${unusedPort}/resource`,
+      `validated-unreachable.test:${unusedPort}`
+    );
+    observed.exhaustedAddresses = {
+      status: response.status,
+      lookups,
+      report: proxy.getBlockReport(),
+      detailed: proxy.blockedEvents()
+    };
+    assert.equal(response.status, 502);
+    assert.equal(lookups, 1);
+    assert.equal(proxy.blocked.count(), 1);
+    assert.deepEqual(proxy.blockedEvents()[0].resolvedAddresses, ['127.0.0.2', '127.0.0.3']);
+    assert.equal(proxy.blockedEvents()[0].reason, 'connection-failed');
+  });
+});
+
+test('block collector keeps compatible bounded samples and full count', { concurrency: false }, () => {
+  const collector = createBlockCollector({ limit: 2, maxUrlLength: 24 });
+  for (let index = 0; index < 5; index += 1) {
+    collector.record(`http://127.0.0.1/${'x'.repeat(40)}?i=${index}`);
+  }
+  observed.collector = { samples: collector.samples(), count: collector.count() };
+  assert.equal(collector.count(), 5);
+  assert.equal(collector.samples().length, 2);
+  assert.equal(collector.samples().every((sample) => sample.length <= 24), true);
+});
+
+test('stdio runner starts the shared proxy and returns its bounded report before exit', { concurrency: false }, async () => {
+  const child = spawn(process.execPath, [RUNNER_PATH], {
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+  const lines = createInterface({ input: child.stdout });
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+
+  try {
+    const readyLine = nextChildLine(lines, child);
+    child.stdin.write(`${JSON.stringify({
+      blockedCidrs: BLOCKED_CIDRS,
+      reportLimit: 2,
+      connectTimeoutMs: 1000
+    })}\n`);
+    const readyText = await readyLine;
+    const ready = JSON.parse(readyText);
+    assert.equal(ready.type, 'ready');
+    assert.match(ready.proxyUrl, /^http:\/\/127\.0\.0\.1:\d+$/);
+
+    const proxyPort = Number(new URL(ready.proxyUrl).port);
+    const refused = await proxyHttpGet(
+      { address: () => ({ port: proxyPort }) },
+      `http://127.0.0.1:${blockedHttpPort}/runner-blocked`,
+      `127.0.0.1:${blockedHttpPort}`
+    );
+    assert.equal(refused.status, 403);
+
+    const closedLine = nextChildLine(lines, child);
+    child.stdin.write('{"command":"close"}\n');
+    const closedText = await closedLine;
+    const closed = JSON.parse(closedText);
+    assert.equal(closed.type, 'closed');
+    assert.equal(closed.report.blocked_request_count, 1);
+    assert.equal(closed.blocked_events.length, 1);
+    assert.equal(closed.blocked_events[0].reason, 'blocked-address');
+
+    const [exitCode, signal] = await once(child, 'exit');
+    observed.runner = {
+      ready,
+      report: closed.report,
+      blockedEvents: closed.blocked_events,
+      exitCode,
+      signal,
+      stderr
+    };
+    assert.equal(exitCode, 0);
+    assert.equal(signal, null);
+    assert.equal(await socketCanConnect(proxyPort), false);
+    assert.equal(stderr, '');
+  } finally {
+    lines.close();
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+  }
+});
+
+test('stdio EOF during startup cannot leave the proxy listener behind', { concurrency: false }, async () => {
+  const listenPort = await unusedLoopbackPort();
+  const child = spawn(process.execPath, [RUNNER_PATH], {
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => { stdout += chunk; });
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+
+  child.stdin.end(`${JSON.stringify({
+    blockedCidrs: BLOCKED_CIDRS,
+    listenPort,
+    connectTimeoutMs: 1000
+  })}\n`);
+  const [exitCode, signal] = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('runner did not exit after EOF')), 5000);
+    child.once('exit', (code, childSignal) => {
+      clearTimeout(timer);
+      resolve([code, childSignal]);
+    });
+  });
+
+  observed.runnerStartupEof = { listenPort, exitCode, signal, stdout, stderr };
+  assert.equal(exitCode, 0);
+  assert.equal(signal, null);
+  assert.equal(await socketCanConnect(listenPort), false);
+});
+
+test('withScreeningProxy tears down after a mid-navigation exception', { concurrency: false }, async (t) => {
+  if (!requireChromium(t)) return;
+  let capturedProxy;
+  let browser;
+  let navigation;
+  hangStarted = new Promise((resolve) => { hangStartedResolve = resolve; });
+
+  await assert.rejects(
+    withScreeningProxy(proxyOptions(), async (proxy) => {
+      capturedProxy = proxy;
+      browser = await launchChromium(proxy);
+      const page = await browser.newPage();
+      navigation = page.goto(`http://chat.allowed.test:${chatPort}/hang`, { timeout: 30000 }).catch((error) => error);
+      await hangStarted;
+      throw new Error('forced-mid-navigation-timeout');
+    }),
+    /forced-mid-navigation-timeout/
+  );
+
+  const port = capturedProxy.address().port;
+  const closedBeforeBrowser = capturedProxy.isClosed();
+  const connectableAfterThrow = await socketCanConnect(port);
+  const navigationResult = await navigation;
+  await browser.close();
+  observed.teardown = {
+    closedBeforeBrowser,
+    connectableAfterThrow,
+    navigationResult: navigationResult.message || String(navigationResult)
+  };
+  assert.equal(closedBeforeBrowser, true);
+  assert.equal(connectableAfterThrow, false);
+  hangStartedResolve = null;
+});

--- a/script/tests/screening_proxy_test.mjs
+++ b/script/tests/screening_proxy_test.mjs
@@ -392,6 +392,41 @@ test('strict public HTTPS preserves hostname/SNI while proxy pins the connection
   });
 });
 
+test('repeated strict HTTPS navigations survive CONNECT teardown races', {
+  concurrency: false,
+  timeout: 60000
+}, async (t) => {
+  if (!requireChromium(t)) return;
+  try {
+    await requireOutboundHttps();
+  } catch (error) {
+    t.skip(`outbound HTTPS unavailable: ${error.message}`);
+    return;
+  }
+
+  const statuses = [];
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    await withBrowser(proxyOptions(), async ({ browser }) => {
+      const context = await browser.newContext({ ignoreHTTPSErrors: false });
+      await context.route('**/*', async (route) => {
+        const fetched = await route.fetch({ maxRedirects: 0 });
+        await route.fulfill({ response: fetched });
+      });
+      const page = await context.newPage();
+      const response = await page.goto('https://example.com/', {
+        waitUntil: 'domcontentloaded',
+        timeout: 15000
+      });
+      statuses.push(response.status());
+      await page.screenshot({ type: 'png' });
+      await context.close();
+    });
+  }
+
+  observed.repeatedHttps = { attempts: statuses.length, statuses };
+  assert.deepEqual(statuses, new Array(10).fill(200));
+});
+
 test('plain HTTP allowed target works through the proxy', { concurrency: false }, async (t) => {
   if (!requireChromium(t)) return;
   const beforeRequests = chatRequestUrls.length;
@@ -995,6 +1030,101 @@ test('stdio EOF during startup cannot leave the proxy listener behind', { concur
   assert.equal(exitCode, 0);
   assert.equal(signal, null);
   assert.equal(await socketCanConnect(listenPort), false);
+});
+
+test('a DNS result released after close cannot start a connection', {
+  concurrency: false,
+  timeout: 3000
+}, async () => {
+  let releaseResolution;
+  let markResolutionStarted;
+  let connectAttempts = 0;
+  const resolutionStarted = new Promise((resolve) => { markResolutionStarted = resolve; });
+  const proxy = createScreeningProxy(proxyOptions({
+    resolve: async () => {
+      markResolutionStarted();
+      return new Promise((resolve) => { releaseResolution = resolve; });
+    },
+    connect: () => {
+      connectAttempts += 1;
+      throw new Error('connect must not run after close');
+    }
+  }));
+  await proxy.listen();
+
+  const request = http.get({
+    hostname: '127.0.0.1',
+    port: proxy.address().port,
+    path: 'http://delayed-resolution.test/resource',
+    headers: { host: 'delayed-resolution.test', connection: 'close' },
+    agent: false
+  });
+  request.on('error', () => {});
+  await resolutionStarted;
+  await proxy.close();
+  releaseResolution(['93.184.216.34']);
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  observed.delayedResolutionClose = { proxyClosed: proxy.isClosed(), connectAttempts };
+  assert.equal(proxy.isClosed(), true);
+  assert.equal(connectAttempts, 0);
+});
+
+test('close cancels staggered attempts before another socket starts', {
+  concurrency: false,
+  timeout: 3000
+}, async () => {
+  const attempts = [];
+  const pendingSockets = [];
+  let markFirstAttempt;
+  const firstAttemptStarted = new Promise((resolve) => { markFirstAttempt = resolve; });
+
+  class PendingConnectSocket extends EventEmitter {
+    setTimeout() { return this; }
+
+    destroy(error) {
+      if (this.destroyed) return this;
+      this.destroyed = true;
+      queueMicrotask(() => {
+        if (error) this.emit('error', error);
+        this.emit('close');
+      });
+      return this;
+    }
+  }
+
+  const proxy = createScreeningProxy(proxyOptions({
+    connectAttemptDelayMs: 250,
+    resolve: async () => ['198.51.100.10', '198.51.100.11'],
+    connect: (options) => {
+      attempts.push(options.host);
+      if (attempts.length === 1) markFirstAttempt();
+      const socket = new PendingConnectSocket();
+      pendingSockets.push(socket);
+      return socket;
+    }
+  }));
+  await proxy.listen();
+
+  const request = http.get({
+    hostname: '127.0.0.1',
+    port: proxy.address().port,
+    path: 'http://stagger-close.test/resource',
+    headers: { host: 'stagger-close.test', connection: 'close' },
+    agent: false
+  });
+  request.on('error', () => {});
+  await firstAttemptStarted;
+  await proxy.close();
+  await new Promise((resolve) => setTimeout(resolve, 350));
+
+  observed.staggerClose = {
+    proxyClosed: proxy.isClosed(),
+    attempts,
+    liveSockets: pendingSockets.filter((socket) => !socket.destroyed).length
+  };
+  assert.deepEqual(attempts, ['198.51.100.10']);
+  assert.equal(pendingSockets.every((socket) => socket.destroyed), true);
 });
 
 test('withScreeningProxy tears down after a mid-navigation exception', { concurrency: false }, async (t) => {

--- a/script/tests/test_web_chatbot_generator.py
+++ b/script/tests/test_web_chatbot_generator.py
@@ -1,5 +1,6 @@
 """Unit tests for the vendored Chromium WebChatbotGenerator auth support."""
 import asyncio
+import importlib.util
 import sys
 import unittest
 from pathlib import Path
@@ -8,6 +9,17 @@ from unittest.mock import AsyncMock, MagicMock
 _plugins = str(Path(__file__).resolve().parent.parent / "garak_plugins")
 if _plugins not in sys.path:
     sys.path.insert(0, _plugins)
+
+
+def _install_local_generator_module(module_name, filename):
+    spec = importlib.util.spec_from_file_location(module_name, Path(_plugins) / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+
+_install_local_generator_module("garak.generators._network_guard", "_network_guard.py")
+_install_local_generator_module("garak.generators._screening_proxy", "_screening_proxy.py")
 
 try:
     from web_chatbot import WebChatbotGenerator  # noqa: E402
@@ -49,7 +61,16 @@ class TestWebChatbotAuth(unittest.TestCase):
         gen.selectors = {"input_field": "#i", "response_container": "#r"}
         gen.auth = {"cookies": [{"name": "s", "value": "secret", "domain": "example.com"}],
                     "headers": {"Authorization": "Bearer t"}, "storage_state": None}
+        gen.network_guard = {"blocked_cidrs": ["127.0.0.0/8"]}
+        gen.screening_proxy = {
+            "modulePath": "/rails/app/services/browser_automation/screening_proxy_runner.cjs",
+            "blockedCidrs": ["127.0.0.0/8"],
+        }
         gen._playwright = None
+        gen._browser = None
+        gen._context = None
+        gen._page = None
+        gen._screening_proxy = None
 
         context = AsyncMock()
         context.new_page = AsyncMock(return_value=AsyncMock())
@@ -60,21 +81,112 @@ class TestWebChatbotAuth(unittest.TestCase):
         pw = AsyncMock()
         pw.chromium = chromium
 
+        screening_proxy = MagicMock()
+        screening_proxy.start = AsyncMock(return_value="http://127.0.0.1:45678")
+        screening_proxy.close = AsyncMock(return_value={"blocked_requests": [], "blocked_request_count": 0})
+
         import web_chatbot as mod
         original = mod.async_playwright
+        original_proxy = mod.ScreeningProxyProcess
         mod.async_playwright = lambda: MagicMock(start=AsyncMock(return_value=pw))
+        mod.ScreeningProxyProcess = MagicMock(return_value=screening_proxy)
         try:
             asyncio.run(gen._init_browser())
         finally:
             mod.async_playwright = original
+            mod.ScreeningProxyProcess = original_proxy
 
         chromium.launch.assert_awaited_once()
+        _, launch_kwargs = chromium.launch.call_args
+        self.assertEqual(launch_kwargs["proxy"], {"server": "http://127.0.0.1:45678"})
+        self.assertEqual(
+            launch_kwargs["args"],
+            ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+        )
         browser.new_context.assert_awaited_once()
         _, ctx_kwargs = browser.new_context.call_args
         self.assertEqual(ctx_kwargs["extra_http_headers"], {"Authorization": "Bearer t"})
         context.add_cookies.assert_awaited_once_with(
             [{"name": "s", "value": "secret", "domain": "example.com", "path": "/"}]
         )
+        context.route.assert_awaited_once()
+        screening_proxy.start.assert_awaited_once()
+
+    def test_init_failure_closes_proxy_and_partial_browser_resources(self):
+        gen = object.__new__(WebChatbotGenerator)
+        gen.url = "https://example.com/chat"
+        gen.browser_options = {"headless": True}
+        gen.wait_times = {"page_load": 10000, "chat_open": 5000}
+        gen.selectors = {"input_field": "#i", "response_container": "#r"}
+        gen.auth = {"cookies": [], "headers": {}, "storage_state": None}
+        gen.network_guard = {"blocked_cidrs": ["127.0.0.0/8"]}
+        gen.screening_proxy = {
+            "modulePath": "/rails/app/services/browser_automation/screening_proxy_runner.cjs",
+            "blockedCidrs": ["127.0.0.0/8"],
+        }
+        gen._playwright = None
+        gen._browser = None
+        gen._context = None
+        gen._page = None
+        gen._screening_proxy = None
+
+        page = AsyncMock()
+        page.goto = AsyncMock(side_effect=RuntimeError("navigation failed"))
+        context = AsyncMock()
+        context.new_page = AsyncMock(return_value=page)
+        browser = AsyncMock()
+        browser.new_context = AsyncMock(return_value=context)
+        chromium = MagicMock()
+        chromium.launch = AsyncMock(return_value=browser)
+        pw = AsyncMock()
+        pw.chromium = chromium
+        screening_proxy = MagicMock()
+        screening_proxy.start = AsyncMock(return_value="http://127.0.0.1:45678")
+        screening_proxy.close = AsyncMock(return_value={"blocked_requests": [], "blocked_request_count": 0})
+
+        import web_chatbot as mod
+        original = mod.async_playwright
+        original_proxy = mod.ScreeningProxyProcess
+        mod.async_playwright = lambda: MagicMock(start=AsyncMock(return_value=pw))
+        mod.ScreeningProxyProcess = MagicMock(return_value=screening_proxy)
+        try:
+            with self.assertRaisesRegex(RuntimeError, "navigation failed"):
+                asyncio.run(gen._init_browser())
+        finally:
+            mod.async_playwright = original
+            mod.ScreeningProxyProcess = original_proxy
+
+        page.close.assert_awaited_once()
+        context.close.assert_awaited_once()
+        browser.close.assert_awaited_once()
+        pw.stop.assert_awaited_once()
+        screening_proxy.close.assert_awaited_once()
+
+    def test_cleanup_timeout_on_page_does_not_skip_proxy_teardown(self):
+        gen = object.__new__(WebChatbotGenerator)
+        async def hang_during_close():
+            await asyncio.sleep(60)
+
+        page = MagicMock()
+        page.close = AsyncMock(side_effect=hang_during_close)
+        screening_proxy = MagicMock()
+        screening_proxy.close = AsyncMock(return_value={"blocked_requests": [], "blocked_request_count": 0})
+        gen._page = page
+        gen._context = None
+        gen._browser = None
+        gen._playwright = None
+        gen._screening_proxy = screening_proxy
+
+        import web_chatbot as mod
+        original_timeout = mod.RESOURCE_CLOSE_TIMEOUT_SECONDS
+        mod.RESOURCE_CLOSE_TIMEOUT_SECONDS = 0.01
+        try:
+            asyncio.run(gen._async_cleanup())
+        finally:
+            mod.RESOURCE_CLOSE_TIMEOUT_SECONDS = original_timeout
+
+        screening_proxy.close.assert_awaited_once()
+        self.assertIsNone(gen._screening_proxy)
 
 
 if __name__ == "__main__":

--- a/script/tests/test_web_chatbot_network_guard.py
+++ b/script/tests/test_web_chatbot_network_guard.py
@@ -11,6 +11,7 @@ import asyncio
 import importlib.util
 import unittest
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 PLUGIN_DIR = Path(__file__).resolve().parents[2] / "script" / "garak_plugins"
 
@@ -83,6 +84,17 @@ class TestNetworkGuardScreening(unittest.TestCase):
         self.assert_blocked("http://10.1.2.3/x", allow_loopback=True)
         self.assert_blocked("http://169.254.169.254/x", allow_loopback=True)
 
+    def test_rechecks_a_hostname_instead_of_reusing_an_old_dns_decision(self):
+        guard = NetworkGuard({"blocked_cidrs": BLOCKED_CIDRS})
+        guard._resolve = AsyncMock(side_effect=[[guard._parse_ip("93.184.216.34")],
+                                                [guard._parse_ip("127.0.0.1")]])
+
+        first = asyncio.run(guard.screen("http://resolution-change.test/first"))
+        second = asyncio.run(guard.screen("http://resolution-change.test/second"))
+
+        self.assertIsNone(first)
+        self.assertEqual(second, "blocked internal address")
+
 
 class TestNetworkGuardFailsClosed(unittest.TestCase):
     def test_missing_or_empty_config_refuses_to_construct(self):
@@ -100,6 +112,46 @@ class TestNetworkGuardFailsClosed(unittest.TestCase):
         # Truthy-but-not-True values must not enable it either.
         guard = NetworkGuard({"blocked_cidrs": BLOCKED_CIDRS, "allow_loopback": "yes"})
         self.assertFalse(guard.allow_loopback)
+
+
+class FakeRequest:
+    def __init__(self, url):
+        self.url = url
+
+
+class FakeRoute:
+    def __init__(self, url):
+        self.request = FakeRequest(url)
+        self.continued = False
+        self.aborted = None
+
+    async def continue_(self):
+        self.continued = True
+
+    async def abort(self, reason):
+        self.aborted = reason
+
+
+class TestNetworkGuardRouting(unittest.TestCase):
+    def test_allowed_request_continues_without_fetching_or_fulfilling(self):
+        guard = NetworkGuard({"blocked_cidrs": BLOCKED_CIDRS})
+        route = FakeRoute("http://93.184.216.34/resource")
+
+        asyncio.run(guard.handle(route))
+
+        self.assertTrue(route.continued)
+        self.assertIsNone(route.aborted)
+
+    def test_blocked_report_keeps_a_bounded_sample_and_full_count(self):
+        guard = NetworkGuard({"blocked_cidrs": BLOCKED_CIDRS, "report_limit": 3})
+
+        for index in range(5):
+            route = FakeRoute(f"http://127.0.0.{index + 1}/resource")
+            asyncio.run(guard.handle(route))
+            self.assertEqual(route.aborted, "blockedbyclient")
+
+        self.assertEqual(guard.blocked_count, 5)
+        self.assertEqual(len(guard.blocked), 3)
 
 
 if __name__ == "__main__":

--- a/script/tests/test_web_chatbot_screening_proxy.py
+++ b/script/tests/test_web_chatbot_screening_proxy.py
@@ -1,0 +1,128 @@
+"""Lifecycle and fail-closed tests for the web-chat screening proxy adapter."""
+
+import asyncio
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = ROOT / "script" / "garak_plugins"
+RUNNER_PATH = ROOT / "app" / "services" / "browser_automation" / "screening_proxy_runner.cjs"
+
+
+def _load(module_name, relative_path):
+    spec = importlib.util.spec_from_file_location(module_name, PLUGIN_DIR / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_proxy = _load("local_screening_proxy", "_screening_proxy.py")
+ScreeningProxyError = _proxy.ScreeningProxyError
+ScreeningProxyProcess = _proxy.ScreeningProxyProcess
+
+
+def proxy_config(**overrides):
+    config = {
+        "modulePath": str(RUNNER_PATH),
+        "blockedCidrs": ["127.0.0.0/8", "::1/128"],
+        "connectTimeoutMs": 1000,
+    }
+    config.update(overrides)
+    return config
+
+
+async def proxy_status(proxy_url, target_url):
+    from urllib.parse import urlsplit
+
+    endpoint = urlsplit(proxy_url)
+    reader, writer = await asyncio.open_connection(endpoint.hostname, endpoint.port)
+    writer.write(
+        (
+            f"GET {target_url} HTTP/1.1\r\n"
+            "Host: 127.0.0.1:9\r\n"
+            "Connection: close\r\n\r\n"
+        ).encode("ascii")
+    )
+    await writer.drain()
+    status_line = await asyncio.wait_for(reader.readline(), timeout=3)
+    writer.close()
+    await writer.wait_closed()
+    return status_line.decode("latin1").strip()
+
+
+async def can_connect(proxy_url):
+    from urllib.parse import urlsplit
+
+    endpoint = urlsplit(proxy_url)
+    try:
+        _reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(endpoint.hostname, endpoint.port), timeout=1
+        )
+    except (OSError, asyncio.TimeoutError):
+        return False
+    writer.close()
+    await writer.wait_closed()
+    return True
+
+
+class TestScreeningProxyProcess(unittest.IsolatedAsyncioTestCase):
+    async def test_real_runner_reports_a_refused_connection_and_closes(self):
+        proxy = ScreeningProxyProcess(proxy_config())
+        proxy_url = await proxy.start()
+
+        self.assertRegex(proxy_url, r"^http://127\.0\.0\.1:\d+$")
+        self.assertEqual(
+            await proxy_status(proxy_url, "http://127.0.0.1:9/blocked"),
+            "HTTP/1.1 403 Forbidden",
+        )
+
+        report = await proxy.close()
+
+        self.assertEqual(report["blocked_request_count"], 1)
+        self.assertEqual(proxy.blocked_events[0]["reason"], "blocked-address")
+        self.assertFalse(await can_connect(proxy_url))
+
+    async def test_async_context_manager_closes_after_callback_exception(self):
+        proxy = ScreeningProxyProcess(proxy_config())
+        proxy_url = None
+
+        with self.assertRaisesRegex(RuntimeError, "forced navigation failure"):
+            async with proxy:
+                proxy_url = proxy.url
+                raise RuntimeError("forced navigation failure")
+
+        self.assertIsNotNone(proxy_url)
+        self.assertFalse(await can_connect(proxy_url))
+        self.assertIsNotNone(proxy.process.returncode)
+
+    async def test_malformed_ready_endpoint_fails_closed_and_reaps_runner(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".cjs", delete=False) as runner:
+            runner.write(
+                "process.stdin.once('data', () => {\n"
+                "  console.log(JSON.stringify({type:'ready', proxyUrl:'http://0.0.0.0:1234'}));\n"
+                "});\n"
+            )
+            runner_path = runner.name
+        os.chmod(runner_path, 0o700)
+
+        proxy = ScreeningProxyProcess(proxy_config(modulePath=runner_path))
+        try:
+            with self.assertRaisesRegex(ScreeningProxyError, "invalid ready response"):
+                await proxy.start()
+            self.assertIsNotNone(proxy.process.returncode)
+        finally:
+            os.unlink(runner_path)
+
+    async def test_missing_or_invalid_config_refuses_to_start(self):
+        for config in (None, {}, {"modulePath": str(RUNNER_PATH), "blockedCidrs": []}):
+            with self.subTest(config=config):
+                with self.assertRaises(ScreeningProxyError):
+                    ScreeningProxyProcess(config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/services/browser_automation/network_guard_spec.rb
+++ b/spec/services/browser_automation/network_guard_spec.rb
@@ -149,3 +149,120 @@ RSpec.describe BrowserAutomation::PlaywrightService, "network guard wiring" do
     end
   end
 end
+
+RSpec.describe BrowserAutomation::PlaywrightService, "screening proxy wiring" do
+  let(:service) { described_class.instance }
+
+  def capture(result: { "success" => true })
+    script = nil
+    data = nil
+    allow(Open3).to receive(:capture3) do |env, _cmd, script_path|
+      script = File.read(script_path)
+      data = JSON.parse(File.read(env["PLAYWRIGHT_DATA_PATH"]))
+      [ result.to_json, "", double(success?: true) ]
+    end
+    yield
+    [ script, data ]
+  end
+
+  # Screening the request URL is not enough on its own. The browser resolves the
+  # host again, independently of the lookup the guard just validated, so a name
+  # that answers publicly for us and privately for the browser walks past the
+  # check. And a route handler never sees a redirect hop the browser follows
+  # internally, nor WebSocket traffic -- including a socket opened from a Worker.
+  #
+  # The screening proxy sits below all of that: it resolves each authority once,
+  # validates every answer, and connects to the address it approved, while the
+  # hostname stays in the CONNECT authority so TLS still verifies strictly.
+  {
+    "screenshot" => ->(s) { s.screenshot("https://example.com", "/tmp/x.png") },
+    "with_page" => ->(s) { s.with_page("https://example.com") },
+    "extract_page_structure" => ->(s) { s.extract_page_structure("https://example.com") },
+    "validate_webchat_config" => lambda do |s|
+      s.validate_webchat_config(
+        "https://example.com",
+        { "selectors" => { "input_field" => "#i", "response_container" => "#r" } }
+      )
+    end
+  }.each do |name, call|
+    it "#{name} launches the browser behind the screening proxy" do
+      script, data = capture { call.call(service) }
+
+      expect(data["screening_proxy"]).to be_present, "#{name} sent no proxy configuration"
+      expect(data["screening_proxy"]["blockedCidrs"]).to be_present
+      expect(data["screening_proxy"]["modulePath"]).to end_with("screening_proxy_runner.cjs")
+      expect(script).to include("withScreeningProxy")
+      expect(script).to include("proxy: { server:")
+    end
+  end
+
+  it "keeps report rendering unproxied, as it renders our own pages" do
+    # generate_pdf targets Scanner's own report URL on an address the blocklist
+    # covers. Screening it would stop the app rendering its own output.
+    script, data = capture(result: { "success" => true, "path" => "/tmp/r.pdf" }) do
+      service.generate_pdf("http://localhost:3000/reports/1", "/tmp/r.pdf")
+    end
+
+    expect(data["screening_proxy"]).to be_nil
+    expect(script).not_to include("withScreeningProxy")
+  end
+
+  it "generates scripts that parse" do
+    # These specs stub the subprocess, so no assertion on the data alone can
+    # catch a fault in the generated JavaScript -- an unbalanced callback or a
+    # symbol used before it is defined would still read as a passing test.
+    {
+      "screenshot" => ->(s) { s.screenshot("https://example.com", "/tmp/x.png") },
+      "extract_page_structure" => ->(s) { s.extract_page_structure("https://example.com") },
+      "with_page" => ->(s) { s.with_page("https://example.com") },
+    "validate_webchat_config" => lambda do |s|
+      s.validate_webchat_config(
+        "https://example.com",
+        { "selectors" => { "input_field" => "#i", "response_container" => "#r" } }
+      )
+    end,
+      "generate_pdf" => ->(s) { s.generate_pdf("http://localhost:3000/r", "/tmp/r.pdf") }
+    }.each do |name, call|
+      script = nil
+      allow(Open3).to receive(:capture3) do |_env, _cmd, script_path|
+        script = File.read(script_path)
+        [ { "success" => true, "path" => "/tmp/x" }.to_json, "", double(success?: true) ]
+      end
+      call.call(service)
+
+      Tempfile.create([ "generated", ".cjs" ]) do |file|
+        file.write(script)
+        file.flush
+        stdout, stderr, status = Open3.capture3("node", "--check", file.path)
+        expect(status).to be_success, "#{name} generated invalid JS: #{stderr}#{stdout}"
+      end
+    end
+  end
+
+  it "reports guard and proxy blocks in one shape" do
+    # The guard records {url, reason}; the proxy records plain URL strings and
+    # keeps its own total. Concatenating them raw hands callers a mixed-shape
+    # array and drops the proxy's count of what it truncated.
+    script, = capture { service.screenshot("https://example.com", "/tmp/x.png") }
+
+    expect(script).to include("__mergeBlocked")
+    expect(script).not_to include("__guard.blocked().concat")
+
+    expect(script).to include("reason: 'blocked by screening proxy'")
+    expect(script).to include("blocked_request_count"), "must carry the proxy's overflow count"
+  end
+
+  it "keeps TLS verification strict" do
+    script, = capture { service.screenshot("https://example.com", "/tmp/x.png") }
+
+    expect(script).not_to include("ignoreHTTPSErrors")
+  end
+
+  it "does not rewrite the navigated URL to an address" do
+    # Carrying the validated address in the URL would drop SNI and break every
+    # HTTPS host that requires it. The proxy carries it instead.
+    _script, data = capture { service.screenshot("https://example.com/chat", "/tmp/x.png") }
+
+    expect(data["url"]).to eq("https://example.com/chat")
+  end
+end

--- a/spec/services/browser_automation/network_guard_spec.rb
+++ b/spec/services/browser_automation/network_guard_spec.rb
@@ -256,6 +256,29 @@ RSpec.describe BrowserAutomation::PlaywrightService, "screening proxy wiring" do
     expect(script).to include("blocked_request_count"), "must carry the proxy's overflow count"
   end
 
+  it "drops both loopback families when localhost is permitted" do
+    # blocked_cidrs renders IPv6 canonically, so a literal "::1/128" comparison
+    # silently misses it. localhost resolves to both ::1 and 127.0.0.1 and the
+    # proxy refuses if ANY answer is blocked, so a half-match denies localhost
+    # outright -- which dev and test rely on.
+    allow(UrlSafetyValidator).to receive(:allow_localhost?).and_return(true)
+    _script, data = capture { service.screenshot("http://localhost:3000/", "/tmp/x.png") }
+    cidrs = data["screening_proxy"]["blockedCidrs"]
+
+    expect(cidrs.any? { |c| c.start_with?("127.") }).to be(false), "IPv4 loopback still blocked"
+    expect(cidrs.any? { |c| IPAddr.new(c) == IPAddr.new("::1") rescue false }).to be(false), "IPv6 loopback still blocked"
+    expect(cidrs.any? { |c| c.start_with?("169.254.") }).to be(true), "link-local must stay blocked"
+  end
+
+  it "keeps both loopback families blocked when localhost is not permitted" do
+    allow(UrlSafetyValidator).to receive(:allow_localhost?).and_return(false)
+    _script, data = capture { service.screenshot("https://example.com/", "/tmp/x.png") }
+    cidrs = data["screening_proxy"]["blockedCidrs"]
+
+    expect(cidrs.any? { |c| c.start_with?("127.") }).to be(true)
+    expect(cidrs.any? { |c| (IPAddr.new(c) == IPAddr.new("::1") rescue false) }).to be(true)
+  end
+
   it "keeps TLS verification strict" do
     script, = capture { service.screenshot("https://example.com", "/tmp/x.png") }
 

--- a/spec/services/browser_automation/network_guard_spec.rb
+++ b/spec/services/browser_automation/network_guard_spec.rb
@@ -245,8 +245,12 @@ RSpec.describe BrowserAutomation::PlaywrightService, "screening proxy wiring" do
     # array and drops the proxy's count of what it truncated.
     script, = capture { service.screenshot("https://example.com", "/tmp/x.png") }
 
-    expect(script).to include("__mergeBlocked")
-    expect(script).not_to include("__guard.blocked().concat")
+    # Assert the helper is CALLED, not merely defined. Reverting the call site to
+    # __guard.blocked() leaves the definition in place, so a containment check on
+    # the name alone passes while every proxy-only block is silently discarded --
+    # and those are exactly the blocks the proxy exists to catch.
+    expect(script).to include("blocked_requests: __mergeBlocked(__guard, proxy)")
+    expect(script).not_to match(/blocked_requests: __guard\.blocked\(\)/)
 
     expect(script).to include("reason: 'blocked by screening proxy'")
     expect(script).to include("blocked_request_count"), "must carry the proxy's overflow count"

--- a/spec/services/run_garak_scan_spec.rb
+++ b/spec/services/run_garak_scan_spec.rb
@@ -701,8 +701,10 @@ RSpec.describe RunGarakScan, type: :service do
         config = JSON.parse(File.read(file_path))
         expect(config).to have_key('web_chatbot')
         expect(config['web_chatbot']).to have_key('WebChatbotGenerator')
-        expect(config['web_chatbot']['WebChatbotGenerator']).to have_key('url')
-        expect(config['web_chatbot']['WebChatbotGenerator']['url']).to eq('https://example.com/chat')
+        generator = config['web_chatbot']['WebChatbotGenerator']
+        expect(generator).to have_key('url')
+        expect(generator['url']).to eq('https://example.com/chat')
+        expect(generator['screening_proxy']).to eq(BrowserAutomation::NetworkGuard.proxy_payload)
       end
 
       it 'handles web_config as JSON string' do


### PR DESCRIPTION
Screens browser connections at the transport layer, closing three gaps the request-level guard cannot reach.

## Why a route handler is not enough

`NetworkGuard` screens the URL of each request it is handed, which is the right check — but three kinds of egress never reach it:

| Egress | `context.route()` | `routeWebSocket()` | Screening proxy |
|---|---|---|---|
| Redirect hop the browser follows internally | ✗ never invoked | — | ✓ |
| DNS rebinding after the check | ✗ browser re-resolves | — | ✓ |
| `ws://` / `wss://` | ✗ not intercepted | ✓ main frame + iframe | ✓ |
| WebSocket opened from a **Worker** | ✗ | ✗ zero events | ✓ |

Each row was measured against real Chromium with local servers, not inferred. The rebinding case is the sharpest: the browser performs its own lookup and never inherits the guard's, so a name answering publicly for the guard and privately for the browser reaches the internal address with the guard reporting nothing.

## What this adds

A screening proxy that every tenant-facing browser launch runs behind. It resolves each authority once, validates every returned address against the same `UrlSafetyValidator` blocklist, and connects to the address it approved — while the hostname stays in the CONNECT authority, so TLS still verifies strictly against the real host.

Because it owns the connection, it refuses a redirect hop before any TCP to the internal address. The **Python** guard's redirect walker is removed as redundant; the **Ruby** `GUARD_JS` walker is deliberately kept, so a request refused at the route layer never reaches the proxy at all. The two layers screen independently rather than one relying on the other.

Connections are attempted across the validated addresses with a stagger, so a blackholed first address cannot consume the whole navigation budget, and only addresses that passed validation are ever tried.

The garak generator runs behind the same proxy through a small Python adapter, so the scan path and the Rails path enforce one policy from one blocklist.

`generate_pdf` stays unproxied on purpose: it renders our own report URL on an address the blocklist covers, and screening it would stop the app rendering its own output. Asserted in the specs so it reads as intentional.

## Verification

- RSpec `3178` examples, 0 failures
- `screening_proxy_test.mjs` `27` tests, 0 failures — strict public HTTPS, blocked authority before TCP, rebinding, Worker WS/WSS, allowlisted chat socket, malformed CONNECT/Upgrade, post-close teardown
- Python tests OK
- RuboCop clean, Brakeman 0 warnings

Specs run `node --check` over every generated Playwright script. The scripts are built as strings, so a data-level assertion cannot catch an unbalanced callback or a symbol used before definition — both occurred while writing this and were caught only by that check.

Two runtime regressions found by review and fixed here, with red/green evidence: CONNECT tunnels forwarded an upstream error into a peer socket with no `error` listener, making Node exit on `EPIPE` (~4 of 10 HTTPS navigations failed; now 50 consecutive succeed), and `close()` left in-flight DNS and stagger timers able to open a connection after shutdown (delayed-DNS connect attempts 1 → 0).

## Known limitations

- **Proxy authentication**: the listener binds to loopback without credentials. Every request through it is screened, so it is not an SSRF bypass, but another local process could consume egress or pollute per-scan reporting. Per-launch credentials are the production fix.
- The proxy honours the blocklist and a per-launch set of validated addresses; it does not currently receive an operator allowlist of internal hostnames.
