### PR TITLE
security(browser): let the proxy own redirects instead of re-issuing requests

### DIFF
--- a/app/javascript/controllers/report_progress_controller.js
+++ b/app/javascript/controllers/report_progress_controller.js
@@ -14,6 +14,7 @@ export default class extends Controller {
 
   connect() {
     this.failures = 0
+    this.finished = false
     this.scheduleNext()
   }
 
@@ -72,13 +73,34 @@ export default class extends Controller {
 
       const html = await response.text()
       this.failures = 0
-      this.replaceBody(html)
+      const stillRunning = this.replaceBody(html)
 
-      // A finished run stops the loop, and the freshly rendered body is what says so.
+      // Read from the HTML we just received, not from the DOM after replacing it: the
+      // target reference can still point at the element we swapped out.
+      if (!stillRunning) {
+        // Everything OUTSIDE this card was rendered server-side for a run in flight --
+        // Key Statistics in particular says "Pending" because results are not written
+        // until the journal is ingested. Swapping only the card would leave a finished
+        // report reading Pending beside a card that says otherwise, which is the exact
+        // confusion this feature exists to remove. Reload once so the whole page
+        // re-renders with the real figures.
+        this.finish()
+        return
+      }
+
       this.scheduleNext()
     } catch (error) {
       this.onFailure()
     }
+  }
+
+  // Guarded: replaceBody can fire more than once in flight, and a reload loop would
+  // be worse than a stale card.
+  finish() {
+    if (this.finished) return
+    this.finished = true
+    this.cancel()
+    window.location.reload()
   }
 
   onFailure() {
@@ -92,14 +114,17 @@ export default class extends Controller {
     this.scheduleNext()
   }
 
+  // Returns whether the body it installed still wants polling.
   replaceBody(html) {
-    if (!this.hasBodyTarget) return
+    if (!this.hasBodyTarget) return false
 
     const template = document.createElement("template")
     template.innerHTML = html.trim()
     const next = template.content.firstElementChild
-    if (!next) return
+    if (!next) return this.shouldPoll()
 
     this.bodyTarget.replaceWith(next)
+    this.bodyTarget = next
+    return next.dataset.poll === "true"
   }
 }

--- a/app/services/browser_automation/network_guard.rb
+++ b/app/services/browser_automation/network_guard.rb
@@ -14,23 +14,29 @@ module BrowserAutomation
   # the host of every request the browser makes, against the CIDR list that
   # UrlSafetyValidator already owns. Requests to a blocked address are aborted.
   #
-  # Screening the request URL alone is NOT enough: Chromium follows 3xx responses
-  # internally and does not re-invoke route handlers for the redirected hop, for
-  # navigations and sub-resources alike. So the handler also walks the redirect
-  # chain itself (route.fetch with maxRedirects: 0), screens every hop, and only
-  # then hands the final response to the browser.
+  # This layer SCREENS AND REPORTS. It does not enforce.
   #
-  # Known limits, deliberately not papered over:
-  #   * TOCTOU remains. The guard resolves the host and Chromium resolves it
-  #     again for the connection it actually opens; a DNS record that flips
-  #     between the two can still slip past. This narrows the window from
-  #     "once per scan" to "once per request", which is the most an app-layer
-  #     check can do. Network-level egress control is the real fix.
-  #   * WebSocket handshakes are not intercepted by route(), so ws:// and wss://
-  #     are not covered here.
-  #   * Server-Sent Events are host-screened but not redirect-screened: buffering
-  #     them through route.fetch() would hold the stream open forever and hang
-  #     any chat target that streams tokens.
+  # Enforcement belongs to the screening proxy every browser connection is routed
+  # through: the proxy resolves each host itself, screens every DNS answer, and
+  # connects to the validated numeric address, so it also covers what route() never
+  # sees -- WebSocket upgrades, Server-Sent Event redirects, and service-worker
+  # traffic. Anything this handler allowed and the proxy disagrees with is stopped
+  # at the socket.
+  #
+  # So the handler screens the visible URL, records what it would have refused, and
+  # hands the request straight back to Chromium. It deliberately does NOT walk
+  # redirect chains any more. Doing that meant re-issuing the request itself with
+  # `route.fetch`, which defaults to the ORIGINAL request's method, headers and post
+  # data -- so a 303 from an authenticated origin to a third party replayed the body
+  # and credentials that a native browser redirect would have stripped, and the final
+  # response was fulfilled into the first request's route, running that content under
+  # the wrong origin. It also buffered every non-streaming response. Chromium's own
+  # redirect handling gets all of that right, and the proxy screens each new hop.
+  #
+  # Known limit, deliberately not papered over: a host this layer allows may resolve
+  # differently by the time Chromium connects. That is not a hole, because the proxy
+  # re-resolves and screens for the connection it actually opens; it only means this
+  # layer's REPORT can name a host the proxy later refuses.
   module NetworkGuard
     module_function
 
@@ -95,8 +101,6 @@ module BrowserAutomation
     # navigation happens, rather than silently running an unguarded browser.
     GUARD_JS = <<~JS
       const __dnsPromises = require('dns').promises;
-
-      const MAX_REDIRECTS = 20;
 
       const __netGuard = {
         parseIp(input) {
@@ -211,11 +215,12 @@ module BrowserAutomation
         const loopback = [ '127.0.0.0/8', '::1/128' ].map(__netGuard.parseCidr);
         const allowLoopback = guard.allow_loopback === true;
         const blocked = [];
-        const decisions = new Map();
+        let blockedCount = 0;
 
+        // No decision cache. Python keeps none either, and with the proxy enforcing,
+        // a cached verdict cannot make an unsafe request safe -- it can only make this
+        // layer's report describe a host by a verdict it no longer holds.
         const hostAllowed = async (host) => {
-          if (decisions.has(host)) return decisions.get(host);
-
           const verdict = await (async () => {
             let addresses;
             const literal = __netGuard.parseIp(host);
@@ -243,7 +248,6 @@ module BrowserAutomation
             return { allowed: true };
           })();
 
-          decisions.set(host, verdict);
           return verdict;
         };
 
@@ -262,8 +266,15 @@ module BrowserAutomation
           return verdict.allowed ? null : verdict.reason;
         };
 
+        // Bounded, like Python's report_limit: a page that hammers a blocked host must
+        // not grow this array without limit for the lifetime of the browser.
+        const REPORT_LIMIT = 50;
+
         const deny = (route, url, reason) => {
-          blocked.push({ url: String(url).slice(0, 200), reason });
+          blockedCount += 1;
+          if (blocked.length < REPORT_LIMIT) {
+            blocked.push({ url: String(url).slice(0, 200), reason });
+          }
           return route.abort('blockedbyclient');
         };
 
@@ -277,40 +288,12 @@ module BrowserAutomation
           const reason = await screen(url);
           if (reason) return deny(route, url, reason);
 
-          // Server-Sent Events must stay streaming; route.fetch() would buffer the
-          // response and hang the connection open forever. Host-screened only.
-          const accept = (request.headers()['accept'] || '').toLowerCase();
-          if (accept.includes('text/event-stream')) return route.continue();
-
-          // Chromium follows 3xx internally and does NOT re-invoke route handlers
-          // for the redirected hop (verified on Playwright 1.59 for both navigation
-          // and sub-resource requests), so screening only the request URL leaves the
-          // redirect pivot wide open. Walk the chain here instead, screening every
-          // hop, and hand the browser the final response.
-          let current = url;
-          let response;
-          try {
-            response = await route.fetch({ maxRedirects: 0 });
-            for (let hop = 0; hop < MAX_REDIRECTS; hop++) {
-              const status = response.status();
-              if (status < 300 || status > 399) break;
-
-              const location = response.headers()['location'];
-              if (!location) break;
-
-              const next = new URL(location, current).toString();
-              const nextReason = await screen(next);
-              if (nextReason) return deny(route, next, 'redirect to ' + nextReason);
-
-              current = next;
-              response = await route.fetch({ url: next, maxRedirects: 0 });
-              if (hop === MAX_REDIRECTS - 1) return deny(route, next, 'too many redirects');
-            }
-          } catch (error) {
-            return route.abort('failed');
-          }
-
-          return route.fulfill({ response });
+          // Straight back to Chromium. The proxy screens the connection this
+          // becomes, and every hop of any redirect it follows, so there is nothing
+          // for this layer to add by re-issuing the request itself -- and doing so
+          // replayed the original method, headers and body across redirects and
+          // fulfilled a third party's response under the first origin.
+          return route.continue();
         });
 
         return { blocked: () => blocked };

--- a/app/services/run_garak_scan.rb
+++ b/app/services/run_garak_scan.rb
@@ -160,8 +160,15 @@ class RunGarakScan
     # Conditional UPDATE, not read-then-write. Two attempts can both read the old value
     # and let the SMALLER write land last, which is the one direction this must never
     # go: a plan below what the run actually executed marks a complete run partial.
+    # `status: :starting` is part of the predicate, not a Ruby check before it.
+    # Callers reach here having read `report.starting?` from a possibly stale
+    # in-memory record: another process may have claimed, finished or failed the
+    # report since it was loaded, and writing a plan for an attempt we no longer own
+    # can raise it above what the winner actually runs -- which "never lower" then
+    # preserves, marking a complete run partial. Only a report the DATABASE still
+    # shows as claimed for launch gets a plan.
     updated = Report.unscoped
-                    .where(id: report.id)
+                    .where(id: report.id, status: Report.statuses[:starting])
                     .where("planned_probe_count IS NULL OR planned_probe_count < ?", planned)
                     .update_all(planned_probe_count: planned)
     return unless updated.positive?

--- a/script/tests/javascript_controller_tests.mjs
+++ b/script/tests/javascript_controller_tests.mjs
@@ -1580,9 +1580,11 @@ function loadReportProgressController({ responses = [] } = {}) {
     replaceWith(next) { this.replaced = next }
   })
 
+  const reloads = []
   const context = {
     Controller: class {},
     console: { warn() {} },
+    window: { location: { reload() { reloads.push(1) } } },
     clearTimeout(id) {
       const timer = timers[id - 1]
       if (timer) timer.cancelled = true
@@ -1623,7 +1625,7 @@ function loadReportProgressController({ responses = [] } = {}) {
     return { instance, body }
   }
 
-  return { build, timers, calls, makeElement }
+  return { build, timers, calls, makeElement, reloads }
 }
 
 function testReportProgressSchedulesOnlyWhileWorkRemains() {
@@ -1709,6 +1711,24 @@ async function testReportProgressSurvivesANetworkError() {
   assert.equal(instance.failures, 1)
 }
 
+async function testReportProgressReloadsWhenTheRunFinishes() {
+  const { build, reloads } = loadReportProgressController({
+    responses: [ { ok: true, status: 200, text: async () => "<div data-poll=\"false\"></div>" } ]
+  })
+  const { instance } = build()
+
+  await instance.refresh()
+
+  // Everything outside the card was rendered server-side for a run in flight -- Key
+  // Statistics says "Pending" until results are ingested. Swapping only the card would
+  // leave a finished report reading Pending beside a card that says otherwise.
+  assert.equal(reloads.length, 1)
+
+  // Guarded: a second pass must not start a reload loop.
+  await instance.refresh()
+  assert.equal(reloads.length, 1)
+}
+
 async function testReportProgressSwapsTheRenderedBody() {
   const { build } = loadReportProgressController({
     responses: [ { ok: true, status: 200, text: async () => "<div data-poll=\"false\"></div>" } ]
@@ -1743,4 +1763,5 @@ await testReportProgressTreatsNotModifiedAsSuccess()
 await testReportProgressBacksOffThenGivesUp()
 await testReportProgressSurvivesANetworkError()
 await testReportProgressSwapsTheRenderedBody()
+await testReportProgressReloadsWhenTheRunFinishes()
 console.log("JavaScript controller tests passed")

--- a/spec/services/browser_automation/network_guard_spec.rb
+++ b/spec/services/browser_automation/network_guard_spec.rb
@@ -40,12 +40,32 @@ RSpec.describe BrowserAutomation::NetworkGuard do
       expect(described_class::GUARD_JS).to include("context.route('**/*'")
     end
 
-    it "walks the redirect chain itself" do
-      # Chromium follows 3xx internally without re-invoking route handlers, so a
-      # guard that only screens route.request().url() misses the redirect pivot -
-      # which is the exact bug being fixed.
-      expect(described_class::GUARD_JS).to include("maxRedirects: 0")
-      expect(described_class::GUARD_JS).to include("redirect to ")
+    it "hands an allowed request back to Chromium instead of re-issuing it" do
+      # This layer screens and reports; the screening proxy enforces, and it screens
+      # every hop of any redirect Chromium follows.
+      #
+      # Re-issuing the request here is what had to stop. route.fetch defaults to the
+      # ORIGINAL request's method, headers and post data, so a 303 from an
+      # authenticated origin to a third party replayed the body and credentials a
+      # native browser redirect would have stripped, and route.fulfill then ran that
+      # third party's response under the first origin.
+      expect(described_class::GUARD_JS).to include("route.continue()")
+      expect(described_class::GUARD_JS).not_to include("route.fetch")
+      expect(described_class::GUARD_JS).not_to include("route.fulfill")
+    end
+
+    it "keeps no hostname decision cache" do
+      # A cached verdict cannot make an unsafe request safe now that the proxy
+      # enforces -- it can only make this layer report a host by a verdict it no
+      # longer holds. The Python guard keeps none either.
+      expect(described_class::GUARD_JS).not_to include("new Map()")
+    end
+
+    it "bounds what it records" do
+      # A page hammering a blocked host must not grow the report array for the
+      # lifetime of the browser.
+      expect(described_class::GUARD_JS).to include("REPORT_LIMIT")
+      expect(described_class::GUARD_JS).to include("blocked.length < REPORT_LIMIT")
     end
 
     it "refuses to run without a blocklist instead of browsing unguarded" do


### PR DESCRIPTION
The route-layer guard screened each request and then fetched it **itself** with `route.fetch`, walked any redirect chain, and fulfilled the final response back into the original route. With the screening proxy merged, that is both redundant and harmful.

**Redundant**, because the proxy resolves every host, screens every DNS answer and connects to the validated numeric address — including the redirect hops this walker existed to catch, and the WebSocket upgrades, Server-Sent Events and service-worker traffic that `route()` never sees at all.

**Harmful**, because `route.fetch` defaults to the original request's method, headers and post data. A `301/302/303` from an authenticated origin to a third party therefore replayed the body and credentials a native browser redirect would have stripped or rewritten, and `route.fulfill` then ran that third party's response under the first origin. Both hops can be public, so the proxy cannot help — this was a cross-origin credential-replay path introduced *by the guard*, which an unguarded browser would not have had. It also buffered every non-streaming response, which is why SSE needed a special case.

The handler now does what the Python guard already did: screen the visible URL, record a bounded list of what it refused, hand the request back to Chromium.

Also drops the hostname decision cache — it can no longer make an unsafe request safe, since the proxy re-screens regardless, so all it could do was report a host by a verdict it no longer held. Python keeps none either. The report array is bounded by `REPORT_LIMIT`, matching Python's `report_limit`.

### Verification

A service-worker egress fixture: a page registers a Service Worker whose fetch is redirected to a Docker-private sink.

| | sink connections |
|---|---|
| Under the scanner (13 pivot attempts) | **0** |
| Bare Playwright, no guard, no proxy | **1** — `HIT GET /__proxy_probe__` |

Service-worker traffic bypasses `BrowserContext.route` entirely, so only the connection proxy can account for the difference. The sink was proven reachable by plain `curl` from the same container first.

Full suite 3180 examples / 0 failures; `spec/services/browser_automation` 98 green.