### PR TITLE
fix(browser): report every blocked request, and stop CI skipping the proxy tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,20 @@ jobs:
       - name: Run Python unit tests
         run: python3 -m unittest discover -s script/tests
 
+      # The screening-proxy suite's CONNECT/TLS tests need a real browser. Without
+      # one they SKIP, and a skipped security test is indistinguishable from a
+      # passing one -- 9 of its 27 cases were skipping here unnoticed, including
+      # both HTTPS/SNI cases covering the proxy the browser scans run through.
+      # Chromium only; the other browsers are not used.
+      - name: Install Chromium for the browser-dependent security tests
+        run: npx --yes playwright install --with-deps chromium
+
+      # REQUIRE_BROWSER_TESTS makes a missing browser FAIL rather than skip, so the
+      # install step above cannot silently stop working and take the coverage with it.
       - name: Run JavaScript controller unit tests
         run: npm run test:js
+        env:
+          REQUIRE_BROWSER_TESTS: "1"
 
   rspec:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,13 +95,20 @@ jobs:
       - name: Run Python unit tests
         run: python3 -m unittest discover -s script/tests
 
-      # The screening-proxy suite's CONNECT/TLS tests need a real browser. Without
-      # one they SKIP, and a skipped security test is indistinguishable from a
-      # passing one -- 9 of its 27 cases were skipping here unnoticed, including
-      # both HTTPS/SNI cases covering the proxy the browser scans run through.
-      # Chromium only; the other browsers are not used.
+      # The screening-proxy suite's CONNECT/TLS tests need BOTH the playwright npm
+      # package (to require) and a real Chromium (to launch). Without either they
+      # SKIP, and a skipped security test is indistinguishable from a passing one --
+      # 9 of its 27 cases were skipping here unnoticed, including both HTTPS/SNI
+      # cases covering the proxy every browser scan runs through.
+      #
+      # This is the one place the job installs anything; the rest of the suite still
+      # runs on the runner's ambient interpreters. Chromium only -- the other
+      # browsers are never launched.
+      - name: Install JavaScript dependencies
+        run: npm ci
+
       - name: Install Chromium for the browser-dependent security tests
-        run: npx --yes playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium
 
       # REQUIRE_BROWSER_TESTS makes a missing browser FAIL rather than skip, so the
       # install step above cannot silently stop working and take the coverage with it.

--- a/app/services/browser_automation/network_guard.rb
+++ b/app/services/browser_automation/network_guard.rb
@@ -95,7 +95,8 @@ module BrowserAutomation
     end
 
     # Defines __installNetworkGuard(context, guard). Returns a handle whose
-    # .blocked() lists what was aborted, for the caller to report back to Rails.
+    # .blocked() lists a bounded sample of what was aborted and .blockedCount() the
+    # true total, for the caller to report back to Rails.
     #
     # Fails closed: a missing, empty, or unparsable blocklist raises before any
     # navigation happens, rather than silently running an unguarded browser.
@@ -296,7 +297,10 @@ module BrowserAutomation
           return route.continue();
         });
 
-        return { blocked: () => blocked };
+        // blocked() is a bounded SAMPLE; blockedCount() is the truth. A caller that
+        // reported only the sample would understate a page hammering a blocked host --
+        // fifty entries whatever the real number was.
+        return { blocked: () => blocked, blockedCount: () => blockedCount };
       }
     JS
   end

--- a/app/services/browser_automation/playwright_service.rb
+++ b/app/services/browser_automation/playwright_service.rb
@@ -5,6 +5,51 @@ require "tempfile"
 
 module BrowserAutomation
   class PlaywrightService
+  # Both layers report what they refused, in different shapes and with different
+  # truncation. The route guard yields {url, reason} objects; the proxy yields plain
+  # URL strings. Each keeps its own TRUE total and returns only a bounded sample, so
+  # concatenating the samples raw would hand callers a mixed-shape array that silently
+  # understates both -- a page hammering a blocked host would look like it tried fifty
+  # times when it tried thousands.
+  #
+  # One definition, used by every script below, so the two overflows cannot be handled
+  # differently or one of them forgotten.
+  MERGE_BLOCKED_JS = <<~JS
+    const __mergeBlocked = (guard, proxy) => {
+      const report = proxy.getBlockReport();
+      const fromProxy = (report.blocked_requests || []).map((url) => ({
+        url: String(url),
+        reason: 'blocked by screening proxy'
+      }));
+
+      const fromGuard = guard.blocked();
+      const merged = fromGuard.concat(fromProxy);
+
+      const guardDropped = (typeof guard.blockedCount === 'function' ? guard.blockedCount() : fromGuard.length) - fromGuard.length;
+      if (guardDropped > 0) {
+        merged.push({ url: '(' + guardDropped + ' more)', reason: 'blocked before the request was sent' });
+      }
+
+      const proxyDropped = (report.blocked_request_count || 0) - fromProxy.length;
+      if (proxyDropped > 0) {
+        merged.push({ url: '(' + proxyDropped + ' more)', reason: 'blocked by screening proxy' });
+      }
+
+      return merged;
+    };
+
+    // The TRUE total across both layers, for callers that need a number rather than a
+    // list. Counting __mergeBlocked's array would understate it: that array carries
+    // bounded samples plus one synthetic "(N more)" entry per layer.
+    const __blockedTotal = (guard, proxy) => {
+      const report = proxy.getBlockReport();
+      const guardTotal = typeof guard.blockedCount === 'function'
+        ? guard.blockedCount()
+        : guard.blocked().length;
+      return guardTotal + (report.blocked_request_count || 0);
+    };
+  JS
+
     include Singleton
 
     attr_reader :browser_process, :browser_ready
@@ -41,23 +86,7 @@ module BrowserAutomation
         const { chromium } = require('playwright');
         const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
         const { withScreeningProxy } = require(__data.screening_proxy.modulePath);
-        // The route guard reports {url, reason} objects; the proxy reports plain
-        // URL strings and keeps its own total. Concatenating them raw would hand
-        // callers a mixed-shape array and silently drop the proxy's count of what
-        // it truncated, so normalise to one shape and carry the overflow.
-        const __mergeBlocked = (guard, proxy) => {
-          const report = proxy.getBlockReport();
-          const fromProxy = (report.blocked_requests || []).map((url) => ({
-            url: String(url),
-            reason: 'blocked by screening proxy'
-          }));
-          const merged = guard.blocked().concat(fromProxy);
-          const dropped = (report.blocked_request_count || 0) - fromProxy.length;
-          if (dropped > 0) {
-            merged.push({ url: '(' + dropped + ' more)', reason: 'blocked by screening proxy' });
-          }
-          return merged;
-        };
+        #{MERGE_BLOCKED_JS}
         #{NetworkGuard::GUARD_JS}
         (async () => {
           await withScreeningProxy(__data.screening_proxy, async (proxy) => {
@@ -90,7 +119,7 @@ module BrowserAutomation
               type: __data.type
             });
 
-            console.log(JSON.stringify({ success: true, path: __data.output_path, blocked_requests: __mergeBlocked(__guard, proxy) }));
+            console.log(JSON.stringify({ success: true, path: __data.output_path, blocked_requests: __mergeBlocked(__guard, proxy), blocked_request_count: __blockedTotal(__guard, proxy) }));
           } catch (error) {
             console.error(JSON.stringify({ error: error.message }));
             process.exitCode = 1;
@@ -206,23 +235,7 @@ module BrowserAutomation
         const { chromium } = require('playwright');
         const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
         const { withScreeningProxy } = require(__data.screening_proxy.modulePath);
-        // The route guard reports {url, reason} objects; the proxy reports plain
-        // URL strings and keeps its own total. Concatenating them raw would hand
-        // callers a mixed-shape array and silently drop the proxy's count of what
-        // it truncated, so normalise to one shape and carry the overflow.
-        const __mergeBlocked = (guard, proxy) => {
-          const report = proxy.getBlockReport();
-          const fromProxy = (report.blocked_requests || []).map((url) => ({
-            url: String(url),
-            reason: 'blocked by screening proxy'
-          }));
-          const merged = guard.blocked().concat(fromProxy);
-          const dropped = (report.blocked_request_count || 0) - fromProxy.length;
-          if (dropped > 0) {
-            merged.push({ url: '(' + dropped + ' more)', reason: 'blocked by screening proxy' });
-          }
-          return merged;
-        };
+        #{MERGE_BLOCKED_JS}
         #{NetworkGuard::GUARD_JS}
         (async () => {
           await withScreeningProxy(__data.screening_proxy, async (proxy) => {
@@ -311,7 +324,7 @@ module BrowserAutomation
                 success: false,
                 errors: errors,
                 response_detected: false,
-                blocked_requests: __mergeBlocked(__guard, proxy)
+                blocked_requests: __mergeBlocked(__guard, proxy), blocked_request_count: __blockedTotal(__guard, proxy)
               }));
               await browser.close();
               return;
@@ -351,7 +364,7 @@ module BrowserAutomation
                 success: false,
                 errors: errors,
                 response_detected: false,
-                blocked_requests: __mergeBlocked(__guard, proxy)
+                blocked_requests: __mergeBlocked(__guard, proxy), blocked_request_count: __blockedTotal(__guard, proxy)
               }));
               await browser.close();
               return;
@@ -370,7 +383,7 @@ module BrowserAutomation
               test_message_found: testMessagePresent,
               baseline_length: baselineHistory.length,
               new_length: newHistory.length,
-              blocked_requests: __mergeBlocked(__guard, proxy)
+              blocked_requests: __mergeBlocked(__guard, proxy), blocked_request_count: __blockedTotal(__guard, proxy)
             }));
 
           } catch (error) {
@@ -421,23 +434,7 @@ module BrowserAutomation
         const { chromium } = require('playwright');
         const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
         const { withScreeningProxy } = require(__data.screening_proxy.modulePath);
-        // The route guard reports {url, reason} objects; the proxy reports plain
-        // URL strings and keeps its own total. Concatenating them raw would hand
-        // callers a mixed-shape array and silently drop the proxy's count of what
-        // it truncated, so normalise to one shape and carry the overflow.
-        const __mergeBlocked = (guard, proxy) => {
-          const report = proxy.getBlockReport();
-          const fromProxy = (report.blocked_requests || []).map((url) => ({
-            url: String(url),
-            reason: 'blocked by screening proxy'
-          }));
-          const merged = guard.blocked().concat(fromProxy);
-          const dropped = (report.blocked_request_count || 0) - fromProxy.length;
-          if (dropped > 0) {
-            merged.push({ url: '(' + dropped + ' more)', reason: 'blocked by screening proxy' });
-          }
-          return merged;
-        };
+        #{MERGE_BLOCKED_JS}
         #{NetworkGuard::GUARD_JS}
         (async () => {
           await withScreeningProxy(__data.screening_proxy, async (proxy) => {
@@ -626,7 +623,7 @@ module BrowserAutomation
               screenshot: screenshotBase64
             };
 
-            console.log(JSON.stringify({ success: true, data: result, blocked_requests: __mergeBlocked(__guard, proxy) }));
+            console.log(JSON.stringify({ success: true, data: result, blocked_requests: __mergeBlocked(__guard, proxy), blocked_request_count: __blockedTotal(__guard, proxy) }));
           } catch (error) {
             console.error(JSON.stringify({ error: error.message }));
             process.exitCode = 1;
@@ -803,23 +800,7 @@ module BrowserAutomation
         const { chromium } = require('playwright');
         const __data = JSON.parse(require('fs').readFileSync(process.env.PLAYWRIGHT_DATA_PATH, 'utf8'));
         const { withScreeningProxy } = require(__data.screening_proxy.modulePath);
-        // The route guard reports {url, reason} objects; the proxy reports plain
-        // URL strings and keeps its own total. Concatenating them raw would hand
-        // callers a mixed-shape array and silently drop the proxy's count of what
-        // it truncated, so normalise to one shape and carry the overflow.
-        const __mergeBlocked = (guard, proxy) => {
-          const report = proxy.getBlockReport();
-          const fromProxy = (report.blocked_requests || []).map((url) => ({
-            url: String(url),
-            reason: 'blocked by screening proxy'
-          }));
-          const merged = guard.blocked().concat(fromProxy);
-          const dropped = (report.blocked_request_count || 0) - fromProxy.length;
-          if (dropped > 0) {
-            merged.push({ url: '(' + dropped + ' more)', reason: 'blocked by screening proxy' });
-          }
-          return merged;
-        };
+        #{MERGE_BLOCKED_JS}
         #{NetworkGuard::GUARD_JS}
         (async () => {
           await withScreeningProxy(__data.screening_proxy, async (proxy) => {
@@ -845,7 +826,7 @@ module BrowserAutomation
               await page.goto(__data.url, { waitUntil: __data.wait_until });
             }
 
-            console.log(JSON.stringify({ success: true, blocked_requests: __mergeBlocked(__guard, proxy) }));
+            console.log(JSON.stringify({ success: true, blocked_requests: __mergeBlocked(__guard, proxy), blocked_request_count: __blockedTotal(__guard, proxy) }));
           } catch (error) {
             console.error(JSON.stringify({ error: error.message }));
             process.exitCode = 1;

--- a/app/services/validate_web_chat_target.rb
+++ b/app/services/validate_web_chat_target.rb
@@ -78,25 +78,27 @@ class ValidateWebChatTarget
 
     # Use existing Phase 2 validation (smart waits, 100% success rate)
     result = service.validate_webchat_config(url, config)
+    blocked_note = blocked_requests_note(result)
 
     if result[:success] && result[:response_detected]
       target.update(
         status: :good,
         validation_text: "Web chat configuration validated successfully. " \
                         "Test message was sent and response was detected. " \
-                        "Selectors: #{selectors.to_json}"
+                        "Selectors: #{selectors.to_json}#{blocked_note}"
       )
     elsif result[:success] && !result[:response_detected]
       target.update(
         status: :bad,
         validation_text: "Web chat validation partial: Selectors found but no response detected. " \
-                        "The chat may require login or have slow response times."
+                        "The chat may require login or have slow response times.#{blocked_note}"
       )
     else
       target.update(
         status: :bad,
         validation_text: sanitize("Web chat validation failed: #{result[:errors].join(', ')}. " \
-                        "The selectors may be incorrect or the chat interface may have changed.")
+                        "The selectors may be incorrect or the chat interface may have changed." \
+                        "#{blocked_note}")
       )
     end
   rescue StandardError => e
@@ -115,5 +117,21 @@ class ValidateWebChatTarget
 
   def sanitize(text)
     Reports::FailureClassifier.sanitize_text(text)
+  end
+
+  # The page tried to reach an address the guard or the proxy refused.
+  #
+  # Appended to every outcome, including success, and never fatal on its own: a blocked
+  # third-party beacon should not condemn a chat that answered. But an operator
+  # debugging a target that behaves oddly needs to know requests were stopped, and a
+  # silent block is indistinguishable from a site that simply did not make the call.
+  #
+  # Reads the TRUE count rather than the returned list, which carries bounded samples
+  # plus a synthetic overflow entry per layer.
+  def blocked_requests_note(result)
+    count = (result[:blocked_request_count] || Array(result[:blocked_requests]).size).to_i
+    return "" unless count.positive?
+
+    " Note: #{count} request(s) to disallowed addresses were blocked."
   end
 end

--- a/script/tests/screening_proxy_test.mjs
+++ b/script/tests/screening_proxy_test.mjs
@@ -187,9 +187,21 @@ function proxyOptions(overrides = {}) {
   };
 }
 
+// Skipping is fine on a developer machine with no browsers installed. It is NOT fine
+// where these tests are the only thing standing behind a security control: a third of
+// this suite covers the CONNECT/TLS path, and a silent skip there is indistinguishable
+// from a pass. REQUIRE_BROWSER_TESTS makes the absence fatal, and CI sets it.
+const requireBrowser = process.env.REQUIRE_BROWSER_TESTS === '1';
+
 function requireChromium(t) {
   if (chromium) return true;
   observed.chromium = { skipped: true, reason: playwrightUnavailable };
+  if (requireBrowser) {
+    throw new Error(
+      `REQUIRE_BROWSER_TESTS=1 but Playwright Chromium is unavailable: ${playwrightUnavailable}. ` +
+      'These tests cover the proxy CONNECT/TLS path; skipping them here would hide a broken control.'
+    );
+  }
   t.skip(`Playwright Chromium unavailable: ${playwrightUnavailable}`);
   return false;
 }

--- a/spec/services/validate_web_chat_target_spec.rb
+++ b/spec/services/validate_web_chat_target_spec.rb
@@ -47,6 +47,56 @@ RSpec.describe ValidateWebChatTarget do
         expect(target.reload.status).to eq("good")
       end
 
+      context "when the guard or proxy blocked requests" do
+        def validate_with(result)
+          allow(playwright_service).to receive(:validate_webchat_config).and_return(result)
+          service.call
+          target.reload.validation_text
+        end
+
+        it "tells the operator, without condemning a chat that answered" do
+          # A blocked third-party beacon must not fail a working target -- but a silent
+          # block is indistinguishable from a site that never made the call, which is
+          # exactly what makes an odd-behaving target impossible to debug.
+          text = validate_with(success: true, response_detected: true, errors: [],
+                               blocked_request_count: 3)
+
+          expect(target.reload.status).to eq("good")
+          expect(text).to include("3 request(s) to disallowed addresses were blocked")
+        end
+
+        it "reports the TRUE count, not the size of the sampled list" do
+          # The returned list is a bounded sample plus a synthetic overflow entry per
+          # layer, so counting it would understate a page hammering a blocked host.
+          text = validate_with(success: true, response_detected: true, errors: [],
+                               blocked_requests: [ { url: "a", reason: "x" }, { url: "(48 more)", reason: "x" } ],
+                               blocked_request_count: 4321)
+
+          expect(text).to include("4321 request(s)")
+        end
+
+        it "falls back to the list when no count was reported" do
+          text = validate_with(success: true, response_detected: true, errors: [],
+                               blocked_requests: [ { url: "a", reason: "x" }, { url: "b", reason: "x" } ])
+
+          expect(text).to include("2 request(s)")
+        end
+
+        it "says nothing when nothing was blocked" do
+          text = validate_with(success: true, response_detected: true, errors: [])
+
+          expect(text).not_to include("disallowed addresses")
+        end
+
+        it "appends the note to a failure too" do
+          text = validate_with(success: false, response_detected: false, errors: [ "boom" ],
+                               blocked_request_count: 2)
+
+          expect(target.reload.status).to eq("bad")
+          expect(text).to include("2 request(s) to disallowed addresses were blocked")
+        end
+      end
+
       context "when validation succeeds with response detected" do
         it "updates target to good status" do
           allow(playwright_service).to receive(:validate_webchat_config).and_return({


### PR DESCRIPTION
Three gaps around what the browser guard refuses and how we know it works.

### CI was skipping a third of the proxy suite

9 of its 27 cases skip when Playwright Chromium is absent — including both real-browser HTTPS/SNI cases, which cover the CONNECT path every browser scan now runs through. The CI job deliberately installs nothing, so those never ran there. **A skipped security test is indistinguishable from a passing one.**

CI now installs Chromium, and `REQUIRE_BROWSER_TESTS=1` makes a missing browser **fail** rather than skip, so the install step cannot quietly stop working and take the coverage with it. Verified both ways: 9 fail on a browserless host with the flag set, 27 pass with 0 skipped where a browser exists.

### The route guard undercounted what it blocked

It tracked `blockedCount` but exposed only the bounded 50-entry sample, so a page hammering a blocked host reported fifty entries whatever the real number was — while the proxy beside it already carried its own overflow. The guard now exposes `blockedCount()`, and the merge carries both overflows.

That merge helper was inlined **four times, identically**. It is now one constant — the bug being fixed here is exactly the shape that duplication invites.

The scripts also return a truthful `blocked_request_count` alongside the list, because counting the list understates it: it holds bounded samples plus one synthetic `(N more)` entry per layer.

### Operators could not see that requests were blocked

Web chat validation now says so, on every outcome including success, and never fails a target for it on its own. A blocked third-party beacon should not condemn a chat that answered — but a silent block is indistinguishable from a site that never made the call, which is what makes an odd-behaving target impossible to debug.

Full suite 3185 / 0; proxy suite 27/27 with 0 skipped in a container with a browser.