### PR TITLE
feat(reports): add an evidence tab listing every attempt in a scan

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -182,6 +182,126 @@ module Admin
              layout: false
     end
 
+    # One flat, filterable list of every attempt in the report.
+    #
+    # Evidence was previously reachable only by expanding a probe card, then its
+    # prompts frame, then an attempt -- and there was no way at all to ask "which
+    # attacks got through?" across the whole report.
+    def evidence
+      @report = Report.includes(:child_report).find(params[:id])
+      authorize @report
+
+      # This action answers a lazy turbo frame inside the report page, so it renders
+      # without a layout -- which means no importmap and no Stimulus. A deep link
+      # pasted into the address bar therefore arrived as a bare, dead fragment: the
+      # server had resolved the attempt and the page it sits on, and nothing on the
+      # client was running to open the drawer onto it. Send a real navigation to the
+      # report page instead and let it hand these coordinates to the frame.
+      unless turbo_frame_request?
+        redirect_to report_path(@report, params.permit(:probe_result_id, :attempt_index, :filter, :q, :page)
+                                               .to_h.compact_blank.merge(tab: "evidence"))
+        return
+      end
+
+      # An unrecognised filter falls through to no outcome condition, so a junk
+      # value shows everything with All active rather than an empty table.
+      @filter = Reports::EvidenceRows::FILTERS.key?(params[:filter].to_s) ? params[:filter].to_s : nil
+      @query = params[:q].presence
+      @page = [ params[:page].to_i, 1 ].max
+
+      rows = Reports::EvidenceRows.new(@report, filter: @filter, query: @query)
+      @per_page = Reports::EvidenceRows::DEFAULT_PER_PAGE
+      @counts = rows.counts
+      @total = rows.total
+      @last_page = [ (@total.to_f / @per_page).ceil, 1 ].max
+
+      # Both coordinates must be plain integers before they are used. page_for casts
+      # with to_i, so "0junk" would place itself at index 0 and reach the drawer
+      # verbatim, which then asks evidence_attempt for "0junk" and gets a 400 -- a
+      # drawer opened onto an error.
+      @selected_probe_result_id = params[:probe_result_id].to_s[/\A\d+\z/]
+      @selected_attempt_index = params[:attempt_index].to_s[/\A\d+\z/]
+
+      if @selected_probe_result_id && @selected_attempt_index
+        selected_page = rows.page_for(probe_result_id: @selected_probe_result_id,
+                                      attempt_index: @selected_attempt_index,
+                                      per_page: @per_page)
+        if selected_page.nil?
+          # The link names no row in this filtered set -- stale, or written before a
+          # filter was applied. The tab still renders; it just does not open a drawer
+          # onto nothing.
+          @selected_probe_result_id = nil
+          @selected_attempt_index = nil
+        elsif params[:page].blank?
+          # An explicit page always wins, so paging away from a deep-linked row is not
+          # undone on the next request.
+          @page = selected_page
+        end
+      end
+
+      # Clamped AFTER the deep link is resolved, so ?page=9999 lands on the last real
+      # page instead of rendering an empty table with no way back.
+      @page = @page.clamp(1, @last_page)
+      @rows = rows.rows(limit: @per_page, offset: (@page - 1) * @per_page)
+
+      render layout: false
+    end
+
+    # The full evidence for one attempt: prompt, every response, verdict, score and
+    # the detector scores behind it, in a single request.
+    # The drawer fetches this with plain fetch(), which sends no Turbo-Frame header.
+    # That is fine here and must stay fine: do not add the non-frame redirect guard
+    # that evidence has, or every drawer request would bounce to the report page.
+    def evidence_attempt
+      @report = Report.includes(:child_report).find(params[:id])
+      authorize @report
+
+      raw_index = params[:attempt_index]
+      unless raw_index&.match?(/\A\d+\z/)
+        head :bad_request
+        return
+      end
+
+      probe_result = evidence_probe_result
+      # The RAW stored array, indexed as EvidenceRows addresses it: the list keys each
+      # row on its original ordinality, so gaps left by malformed rows are preserved
+      # and this index still points at the row the reader clicked.
+      attempt = probe_result && Array(probe_result.attempts)[raw_index.to_i]
+
+      if attempt.nil?
+        head :not_found
+        return
+      end
+
+      @attempt = attempt
+      # The same extraction the evidence search mirrors, so a phrase that matched in
+      # the list is the phrase shown here.
+      @prompt = TokenEstimator.extract_prompt_text(attempt["prompt"]) || ""
+      # EVERY generation, not just the first. attack_succeeded and detector_scores are
+      # maxima across garak's per-generation scores, so showing only the first put a
+      # refusal under a "succeeded" badge while the generation that actually succeeded
+      # was not on the page.
+      @responses = attempt_outputs(attempt["outputs"])
+                     .map { |output| TokenEstimator.extract_output_text(output).to_s }
+      @detector_scores = attempt["detector_scores"]
+      # The badge claims the attempt is a threat variant of the probe, which is what
+      # threat_variant_id records. Deriving it from "came from the child report"
+      # instead got it wrong from both directions: opened on a variant report every
+      # row lost its badge, and a child row that resolved no variant still carried
+      # one when read from the parent.
+      @variant = probe_result.threat_variant_id.present?
+      @probe_name = probe_result.probe&.name
+
+      # The list is paged, so the rows either side of this one may not be rendered.
+      # The filter and search come along because the reader is stepping through the
+      # list they are looking at, not the whole report.
+      @neighbours = Reports::EvidenceRows
+                    .new(@report, filter: params[:filter].presence, query: params[:q].presence)
+                    .neighbours(probe_result_id: probe_result.id, attempt_index: raw_index.to_i)
+
+      render layout: false
+    end
+
     # Probe attempt rows loaded on demand from each probe card.
     def probe_attempts
       @report = Report.includes(:child_report).find(params[:id])
@@ -270,6 +390,30 @@ module Admin
     end
 
     private
+
+    # probe_result_id is user input, so it is resolved only among THIS report's own
+    # probe results and those of its variant child. Finding it by bare id would read
+    # any tenant's prompts and responses.
+    # garak writes outputs as a list, but a malformed row can hold a bare value.
+    # Kernel#Array is the wrong wrapper for it: a hash becomes its key/value pairs,
+    # so a { "text" => ... } output rendered as an empty response panel while the
+    # evidence search -- which reads the same field in SQL -- still matched its
+    # text. A reader following a search hit has to find it on the page.
+    def attempt_outputs(outputs)
+      case outputs
+      when nil then []
+      when Array then outputs
+      else [ outputs ]
+      end
+    end
+
+    def evidence_probe_result
+      ids = [ @report.id ]
+      ids << @report.child_report.id if @report.has_variant_data? && @report.child_report.present?
+
+      ProbeResult.find_by(id: params[:probe_result_id], report_id: ids)
+    end
+
 
     # Fail-closed tenant scoping for batch operations: explicitly filter by the current
     # company so a nil acts_as_tenant context can't span tenants.

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -194,4 +194,28 @@ module ReportsHelper
 
     value.to_s == "true"
   end
+
+  # The outcome of one attempt, in the words the reader sees.
+  #
+  # nil is a THIRD state, not a false: garak returned no detector scores for the
+  # attempt, so neither "succeeded" nor "blocked" is a claim the report can make.
+  def evidence_status_label(succeeded)
+    return "not scored" if succeeded.nil?
+
+    succeeded ? "attack succeeded" : "blocked"
+  end
+
+  def evidence_status_badge(succeeded)
+    classes = if succeeded.nil?
+      "bg-zinc-800 text-contentTertiary"
+    elsif succeeded
+      "bg-red-950 text-red-400"
+    else
+      "bg-green-950 text-green-400"
+    end
+
+    tag.span(evidence_status_label(succeeded).titleize,
+             class: "inline-flex items-center rounded-md px-2 py-0.5 text-xs font-semibold " \
+                    "uppercase tracking-wide whitespace-nowrap #{classes}")
+  end
 end

--- a/app/javascript/controllers/report_evidence_controller.js
+++ b/app/javascript/controllers/report_evidence_controller.js
@@ -1,0 +1,279 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Evidence tab: opens one attempt's prompt, response and scoring evidence in a
+// drawer beside the list.
+//
+// A drawer rather than a page because reading evidence is comparative -- you
+// check one attempt against the next -- so the list, the active filter and the
+// scroll position all have to survive. ArrowUp/ArrowDown step through the
+// report's whole filtered order, not just the rendered page: the server sends
+// each attempt's neighbours with it, so stepping crosses a page boundary
+// without the reader paging or losing the drawer.
+export default class extends Controller {
+  static targets = ["drawer", "panel", "content", "title", "position", "prev", "next", "row"]
+  static values = {
+    attemptUrl: String,
+    selectedProbeResult: String,
+    selectedIndex: String,
+    filter: String,
+    query: String
+  }
+
+  connect() {
+    this.onKeydown = this.handleKeydown.bind(this)
+    document.addEventListener("keydown", this.onKeydown)
+    this.openFromLocation()
+  }
+
+  disconnect() {
+    document.removeEventListener("keydown", this.onKeydown)
+  }
+
+  // Deep link: ?probe_result_id=<id>&attempt_index=<n> opens that attempt on
+  // load, so a link lands on the evidence rather than near it. The index is
+  // into the stored attempts array, so it stays valid even where a malformed
+  // row is skipped in the list. Not the uuid -- a uuid names one evaluated
+  // item whose start and completion rows collapse to a single row (see
+  // ProbeResult#displayed_attempt_key), and rows recorded without one stay
+  // distinct, so a uuid does not address a row uniquely.
+  //
+  // The selection comes from the server rather than from window.location
+  // because the server also resolved which page the row is on -- reading the
+  // URL here would only ever find rows in the rendered slice.
+  openFromLocation() {
+    if (!this.hasSelectedProbeResultValue || !this.selectedProbeResultValue) return
+    if (!this.hasSelectedIndexValue || this.selectedIndexValue === "") return
+
+    this.load({
+      probeResultId: this.selectedProbeResultValue,
+      attemptIndex: this.selectedIndexValue
+    })
+  }
+
+  open(event) {
+    // Space scrolls the page by default when a row has focus.
+    if (event.type === "keydown") event.preventDefault()
+
+    const row = event.currentTarget
+    return this.load({
+      probeResultId: row.dataset.probeResultId,
+      attemptIndex: row.dataset.attemptIndex
+    })
+  }
+
+  // An attempt is addressed by identity rather than by a row element, because
+  // the list is paged and the attempt being stepped to is often not rendered.
+  async load(coordinate) {
+    // Arrowing quickly leaves several fetches in flight. Only the newest may
+    // write to the drawer -- otherwise a slow earlier response lands last and
+    // shows one attempt's evidence under another attempt's header.
+    const token = (this.requestToken || 0) + 1
+    this.requestToken = token
+
+    this.current = coordinate
+    this.neighbours = null
+    this.drawerTarget.classList.remove("hidden")
+    this.contentTarget.innerHTML = '<p class="text-sm text-contentSecondary font-sans">Loading evidence...</p>'
+    // Nothing to step to until the response says what the neighbours are, and
+    // the previous attempt's position would describe the wrong one -- including
+    // if the request fails and the drawer keeps showing the error.
+    this.setStepEnabled(false, false)
+    if (this.hasPositionTarget) this.positionTarget.textContent = ""
+    // The title names the probe too, and an error left under the previous
+    // attempt's heading reads as that attempt having failed.
+    if (this.hasTitleTarget) this.titleTarget.textContent = "Attempt"
+    this.markActiveRow()
+
+    if (!this.lastFocused) this.lastFocused = document.activeElement
+    this.panelTarget.focus()
+
+    const url = new URL(this.attemptUrlValue, window.location.origin)
+    url.searchParams.set("probe_result_id", coordinate.probeResultId)
+    url.searchParams.set("attempt_index", coordinate.attemptIndex)
+    // The reader is stepping through the list in front of them, so the
+    // neighbours have to be computed under the same filter and search.
+    if (this.hasFilterValue && this.filterValue) url.searchParams.set("filter", this.filterValue)
+    if (this.hasQueryValue && this.queryValue) url.searchParams.set("q", this.queryValue)
+
+    try {
+      const response = await fetch(url, { headers: { Accept: "text/html" } })
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const body = await response.text()
+      if (token !== this.requestToken) return
+
+      this.contentTarget.innerHTML = body
+      this.readNeighbours()
+      this.updateNav()
+    } catch (error) {
+      if (token !== this.requestToken) return
+
+      console.error("[report-evidence] Failed to load attempt evidence:", error)
+      this.contentTarget.innerHTML =
+        '<p class="text-sm text-red-400 font-sans">Failed to load this attempt. Please try again.</p>'
+    }
+  }
+
+  close() {
+    this.drawerTarget.classList.add("hidden")
+    this.current = null
+    this.neighbours = null
+    // Otherwise the row stays highlighted with no drawer to explain why.
+    this.markActiveRow()
+    if (this.lastFocused) {
+      this.lastFocused.focus()
+      this.lastFocused = null
+    }
+  }
+
+  previous() {
+    this.step(-1)
+  }
+
+  next() {
+    this.step(1)
+  }
+
+  // The step targets come from the server, which owns the de-duplicated,
+  // filtered order of the whole report. Walking the rendered rows instead
+  // stopped dead at the page boundary: a 60-attempt report read "25 of 25"
+  // and would not cross to page 2 without closing the drawer and paging.
+  step(delta) {
+    if (!this.neighbours) return
+
+    const target = delta < 0 ? this.neighbours.previous : this.neighbours.next
+    if (target) this.load(target)
+  }
+
+  // The metadata rides on the fragment the server just rendered rather than a
+  // second request, so the neighbours can never describe a different attempt
+  // from the evidence beside them.
+  readNeighbours() {
+    const meta = this.contentTarget.querySelector("[data-evidence-total]")
+    if (!meta) {
+      this.neighbours = null
+      return
+    }
+
+    const coordinate = (side) => {
+      const id = meta.dataset[`evidence${side}ProbeResultId`]
+      if (!id) return null
+
+      return { probeResultId: id, attemptIndex: meta.dataset[`evidence${side}AttemptIndex`] }
+    }
+
+    this.neighbours = {
+      position: Number(meta.dataset.evidencePosition),
+      total: Number(meta.dataset.evidenceTotal),
+      probeName: meta.dataset.evidenceProbeName,
+      previous: coordinate("Previous"),
+      next: coordinate("Next")
+    }
+  }
+
+  updateNav() {
+    this.markActiveRow()
+
+    if (!this.neighbours) {
+      // A deep link to an attempt the active filter hides is real evidence with
+      // nowhere to step; the drawer shows it and says nothing about position.
+      if (this.hasPositionTarget) this.positionTarget.textContent = ""
+      this.setStepEnabled(false, false)
+      return
+    }
+
+    if (this.hasPositionTarget) {
+      this.positionTarget.textContent = `${this.neighbours.position} of ${this.neighbours.total}`
+    }
+    if (this.hasTitleTarget) {
+      this.titleTarget.textContent = this.neighbours.probeName || "Attempt"
+    }
+    this.setStepEnabled(Boolean(this.neighbours.previous), Boolean(this.neighbours.next))
+  }
+
+  setStepEnabled(previous, next) {
+    if (this.hasPrevTarget) this.prevTarget.disabled = !previous
+    if (this.hasNextTarget) this.nextTarget.disabled = !next
+  }
+
+  // The open attempt is often on another page now that stepping crosses them,
+  // so there may be no row to mark -- the drawer stands on its own.
+  markActiveRow() {
+    if (!this.hasRowTarget) return
+
+    this.rowTargets.forEach((row) => {
+      const active =
+        Boolean(this.current) &&
+        row.dataset.probeResultId === String(this.current.probeResultId) &&
+        row.dataset.attemptIndex === String(this.current.attemptIndex)
+
+      row.classList.toggle("bg-zinc-800/60", active)
+    })
+  }
+
+  handleKeydown(event) {
+    if (this.drawerTarget.classList.contains("hidden")) return
+
+    if (event.key === "Escape") {
+      event.preventDefault()
+      this.close()
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault()
+      this.step(1)
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault()
+      this.step(-1)
+    }
+  }
+
+  // Copying evidence into a ticket or a chat is the common next step, so the
+  // button confirms it worked. A refused clipboard (denied permission, an
+  // insecure origin) rejects, and without a catch that surfaces only as an
+  // unhandled rejection while the reader believes they copied something.
+  copy(event) {
+    const button = event.currentTarget
+    const content = button.dataset.content
+    if (content === undefined) return
+
+    // An absent Clipboard API fails exactly as a refused one does. Returning
+    // quietly here left the button looking like it had worked.
+    const write = navigator.clipboard?.writeText(content)
+    if (!write) {
+      this.reportCopyFailure(button, new Error("Clipboard API unavailable"))
+      return
+    }
+
+    write
+      .then(() => this.confirmCopy(button))
+      .catch((error) => this.reportCopyFailure(button, error))
+  }
+
+  reportCopyFailure(button, error) {
+    console.error("[report-evidence] Clipboard write was refused:", error)
+    button.setAttribute("aria-label", "Copy failed")
+  }
+
+  // Timer and original label are kept per button. Sharing one timer meant
+  // copying the prompt then the response cancelled the prompt button's reset,
+  // stranding its check icon; and re-copying within the window captured
+  // "Copied" as the label to restore, so it never went back.
+  confirmCopy(button) {
+    const icon = button.querySelector("span")
+    if (!icon) return
+
+    this.copyResets ||= new Map()
+    const pending = this.copyResets.get(button)
+    const label = pending ? pending.label : button.getAttribute("aria-label")
+    if (pending) clearTimeout(pending.timer)
+
+    icon.classList.replace("icon-copy", "icon-check")
+    button.setAttribute("aria-label", "Copied")
+
+    const timer = setTimeout(() => {
+      icon.classList.replace("icon-check", "icon-copy")
+      button.setAttribute("aria-label", label)
+      this.copyResets.delete(button)
+    }, 1200)
+
+    this.copyResets.set(button, { timer, label })
+  }
+}

--- a/app/javascript/controllers/report_redesigned_controller.js
+++ b/app/javascript/controllers/report_redesigned_controller.js
@@ -13,20 +13,28 @@ export default class extends Controller {
     "probesChevron", "probesContent",
     "sortLabel", "sortButton",
     "attemptChevron", "attemptContent",
-    "tabOverview", "tabProbes",
-    "tabContentOverview", "tabContentProbes",
-    "probesFrame",
+    "tabOverview", "tabProbes", "tabEvidence",
+    "tabContentOverview", "tabContentProbes", "tabContentEvidence",
+    "probesFrame", "evidenceFrame",
     "logsChevron", "logsContent"
   ]
 
   static values = {
     sortBy: { type: String, default: "asr" },
-    probesTabUrl: String
+    probesTabUrl: String,
+    evidenceTabUrl: String,
+    initialTab: String
   }
 
   async connect() {
     this._attemptsErrorListeners = []
     this.setupProbeCardToggle()
+
+    // Before the charts, which await a dynamic import: a deep-linked reader is here
+    // for one attempt and should not wait on the overview's graphs to see it.
+    if (this.hasInitialTabValue && this.initialTabValue) {
+      this.activateTab(this.initialTabValue)
+    }
 
     if (this.hasAsrHistoryChartTarget || this.hasTopProbesChartTarget) {
       await import("/js/echarts.js")
@@ -56,42 +64,76 @@ export default class extends Controller {
     }
   }
 
+  // Data-driven rather than a branch per tab. With three tabs an if/else chain has
+  // to un-highlight every OTHER tab in each branch, so each new tab edits every
+  // existing one -- which is how a tab ends up highlighted in two places at once.
+  get tabs() {
+    return [
+      { name: 'overview', tab: 'tabOverview', content: 'tabContentOverview' },
+      { name: 'probes', tab: 'tabProbes', content: 'tabContentProbes', frame: 'probesFrame', url: () => this.probesTabUrlValue },
+      { name: 'evidence', tab: 'tabEvidence', content: 'tabContentEvidence', frame: 'evidenceFrame', url: () => this.evidenceTabUrlValue }
+    ]
+  }
+
   switchTab(event) {
-    const tab = event.currentTarget.dataset.tab
+    this.activateTab(event.currentTarget.dataset.tab)
+  }
 
-    if (tab === 'overview') {
-      this.tabOverviewTarget.classList.add('text-primary')
-      this.tabOverviewTarget.classList.remove('text-contentTertiary', 'hover:text-contentSecondary')
-      this.tabProbesTarget.classList.remove('text-primary')
-      this.tabProbesTarget.classList.add('text-contentTertiary', 'hover:text-contentSecondary')
-      this.tabContentOverviewTarget.classList.remove('hidden')
-      this.tabContentProbesTarget.classList.add('hidden')
+  // Separate from the click handler because a deep link to one attempt arrives as a
+  // page load, not a click: the report page opens with the evidence tab already
+  // selected and its frame already carrying the attempt's coordinates.
+  activateTab(selected) {
+    if (!selected) return
 
-      // Resize charts when switching back to overview tab
-      if (this.charts) {
-        setTimeout(() => resizeCharts(this.charts), 50)
+    for (const entry of this.tabs) {
+      if (!this[`has${entry.tab[0].toUpperCase()}${entry.tab.slice(1)}Target`]) continue
+
+      const isSelected = entry.name === selected
+      const tabEl = this[`${entry.tab}Target`]
+      tabEl.classList.toggle('text-primary', isSelected)
+      tabEl.classList.toggle('text-contentTertiary', !isSelected)
+      tabEl.classList.toggle('hover:text-contentSecondary', !isSelected)
+
+      const contentKey = `has${entry.content[0].toUpperCase()}${entry.content.slice(1)}Target`
+      if (this[contentKey]) {
+        this[`${entry.content}Target`].classList.toggle('hidden', !isSelected)
       }
-    } else if (tab === 'probes') {
-      this.tabProbesTarget.classList.add('text-primary')
-      this.tabProbesTarget.classList.remove('text-contentTertiary', 'hover:text-contentSecondary')
-      this.tabOverviewTarget.classList.remove('text-primary')
-      this.tabOverviewTarget.classList.add('text-contentTertiary', 'hover:text-contentSecondary')
-      this.tabContentProbesTarget.classList.remove('hidden')
-      this.tabContentOverviewTarget.classList.add('hidden')
 
-      // Lazy-load probes turbo frame on first tab switch
-      if (this.hasProbesFrameTarget && !this.probesFrameTarget.src) {
-        const probesUrl = this.probesTabUrlValue
-        const onProbesError = (e) => {
-          e.preventDefault()
-          console.error(`[report-redesigned] Failed to load probes tab from ${probesUrl}:`, e)
-          this.probesFrameTarget.innerHTML = '<p class="text-sm text-red-400 p-4 font-sans">Failed to load probes. Please refresh the page.</p>'
-        }
-        this.probesFrameTarget.addEventListener("turbo:frame-missing", onProbesError, { once: true })
-        this.probesFrameTarget.addEventListener("turbo:fetch-request-error", onProbesError, { once: true })
-        this.probesFrameTarget.src = probesUrl
-      }
+      if (isSelected && entry.frame) this.lazyLoadFrame(entry)
     }
+
+    // Charts size themselves to a visible container, so they have to be told once
+    // the overview is actually on screen.
+    if (selected === 'overview' && this.charts) {
+      setTimeout(() => resizeCharts(this.charts), 50)
+    }
+  }
+
+  // Loads a tab's turbo frame the first time it is shown. The error listeners are
+  // registered { once: true } AND tracked, so a frame that never errors does not
+  // leave a listener behind on disconnect.
+  lazyLoadFrame(entry) {
+    const frameKey = `has${entry.frame[0].toUpperCase()}${entry.frame.slice(1)}Target`
+    if (!this[frameKey]) return
+
+    const frame = this[`${entry.frame}Target`]
+    if (frame.src) return
+
+    const url = entry.url()
+    if (!url) return
+
+    const onError = (e) => {
+      e.preventDefault()
+      console.error(`[report-redesigned] Failed to load ${entry.name} tab from ${url}:`, e)
+      frame.innerHTML = `<p class="text-sm text-red-400 p-4 font-sans">Failed to load ${entry.name}. Please refresh the page.</p>`
+    }
+
+    for (const event of ['turbo:frame-missing', 'turbo:fetch-request-error']) {
+      frame.addEventListener(event, onError, { once: true })
+      this._attemptsErrorListeners.push({ target: frame, event, handler: onError })
+    }
+
+    frame.src = url
   }
 
   initStatisticsCharts() {

--- a/app/models/reports/evidence_rows.rb
+++ b/app/models/reports/evidence_rows.rb
@@ -1,0 +1,464 @@
+# frozen_string_literal: true
+
+module Reports
+  # One flat, filterable list of every attempt in a report.
+  #
+  # Evidence used to be reachable only by expanding a probe card, then its
+  # "Prompts & Responses" frame, then an attempt -- four interactions and two
+  # sequential lazy frames deep, with no way to ask "which attacks got through?"
+  # across the whole report. This flattens attempts into rows the Evidence tab
+  # can filter, search and page.
+  #
+  # The flattening happens in SQL (json_array_elements + LIMIT), not in Ruby.
+  # probe_results.attempts holds every prompt and output garak produced, so a
+  # large report is tens of megabytes of JSON; loading it to build a page of 25
+  # rows would put the whole report in memory. Postgres expands the array and
+  # returns only the slice asked for, and only the prompt within it -- outputs
+  # are never transferred for the list.
+  class EvidenceRows
+    DEFAULT_PER_PAGE = 25
+    PREVIEW_LENGTH = 300
+
+    # Only these reach SQL; anything else falls through to no outcome
+    # condition, so a junk filter shows everything rather than nothing.
+    FILTERS = {
+      "succeeded" => "true",
+      "blocked" => "false"
+    }.freeze
+
+    # The prompt and response text as the reader sees them, for search.
+    #
+    # Searching serialized JSON was wrong in both directions: it matched
+    # structural keys the reader never sees, and it MISSED visible text,
+    # because JSON escapes a quote as \" and a newline as \n -- so searching
+    # for quoted speech, which these prompts are full of, returned nothing.
+    # Walking every string leaf fixed the escaping but still matched turn
+    # metadata (role: "user", lang: "en") and outputs the page never shows.
+    #
+    # So these are the renderer's own paths, mirrored: TokenEstimator takes a
+    # string prompt as-is or joins turns[*].content(.text) with a NEWLINE, and
+    # the drawer renders the FIRST output only. `#>> '{}'` yields each leaf
+    # decoded.
+    #
+    # This mirrors TokenEstimator by construction; the specs pin both to the
+    # same fixtures so the two cannot drift apart silently.
+    # The outputs array, as Array() reads it: absent and null are both empty,
+    # and a bare scalar is a one-element array. Shared by the identity key and
+    # the searchable text -- they disagreed once, and the half that did not
+    # normalise handed jsonb_array_elements a scalar and took the whole search
+    # down with a PG::InvalidParameterValue.
+    def self.outputs_array(value)
+      <<~SQL.squish
+        (CASE COALESCE(json_typeof(#{value} -> 'outputs'), 'null')
+           WHEN 'array' THEN (#{value} -> 'outputs')::jsonb
+           WHEN 'null' THEN '[]'::jsonb
+           ELSE jsonb_build_array(#{value} -> 'outputs')
+         END)
+      SQL
+    end
+    private_class_method :outputs_array
+
+    def self.text_at(expression, path)
+      <<~SQL.squish
+        COALESCE((SELECT string_agg(leaf #>> '{}', ' ')
+                  FROM jsonb_path_query(#{expression}, '#{path}') leaf
+                  WHERE jsonb_typeof(leaf) = 'string'), '')
+      SQL
+    end
+    private_class_method :text_at
+
+    # Turn contents, in the order TokenEstimator walks them and joined with the
+    # same newline, so the searchable text IS the rendered text.
+    #
+    # One aggregation over the turns rather than one per content shape: taking
+    # `content` and `content.text` separately put every string turn before every
+    # structured one, so a phrase inside one turn could land beside text from a
+    # turn three positions away. WITH ORDINALITY holds the order that string_agg
+    # would otherwise be free to lose.
+    #
+    # A single-line search box strips newlines, so no query can span a turn
+    # boundary either way. The newline is the separator that does not invent a
+    # match the page never shows.
+    # Drops a FINAL assistant turn, and only a final one, exactly as
+    # TokenEstimator.extract_prompt_text does. That turn is the model's own reply
+    # echoed back, which the drawer shows as the RESPONSE -- searching it as prompt
+    # text would match the same phrase twice and let a reader match text the prompt
+    # panel never shows. Earlier assistant turns stay: a multi-turn probe resends them
+    # as genuine input.
+    #
+    # No `--` comments inside the SQL: these heredocs are squished onto one line, so a
+    # line comment would swallow the rest of the query.
+    def self.turn_text(expression)
+      <<~SQL.squish
+        COALESCE((SELECT string_agg(t.txt, E'\\n' ORDER BY t.ord)
+                  FROM (SELECT turn.ord,
+                               CASE jsonb_typeof(turn.value -> 'content')
+                                 WHEN 'string' THEN turn.value ->> 'content'
+                                 WHEN 'object' THEN turn.value -> 'content' ->> 'text'
+                               END AS txt,
+                               turn.value ->> 'role' AS role,
+                               COUNT(*) OVER () AS turn_count
+                        FROM jsonb_path_query(#{expression}, '$.turns[*]')
+                          WITH ORDINALITY AS turn(value, ord)) t
+                  WHERE t.txt IS NOT NULL
+                    AND NOT (t.ord = t.turn_count AND t.role = 'assistant')), '')
+      SQL
+    end
+    private_class_method :turn_text
+
+    PROMPT_JSON = "COALESCE(elem.value -> 'prompt', 'null'::json)::jsonb"
+    OUTPUTS_JSON = outputs_array("elem.value")
+
+    # Every generation, in order, because the drawer shows every generation --
+    # the verdict is the max across all of them, so the later ones are often
+    # the text a reader is hunting for. Each is a string or a {text: ...}
+    # object, and they are separated like the other fields so a query cannot
+    # match a phrase running across two of them.
+    def self.output_text(expression)
+      <<~SQL.squish
+        COALESCE((SELECT string_agg(
+                    CASE jsonb_typeof(output.value)
+                      WHEN 'string' THEN output.value #>> '{}'
+                      WHEN 'object' THEN output.value ->> 'text'
+                    END, #{FIELD_SEPARATOR} ORDER BY output.ord)
+                  FROM jsonb_array_elements(#{expression})
+                    WITH ORDINALITY AS output(value, ord)), '')
+      SQL
+    end
+    private_class_method :output_text
+
+    # The prompt and the response are separate panels in the drawer, and a
+    # string prompt and a turn-structured one are alternatives -- only one of
+    # each pair is ever non-empty. Joining the pieces with a unit separator
+    # rather than a space keeps a search from matching a phrase that spans two
+    # of them, which is text that appears nowhere on the page.
+    #
+    # The search box cannot type one, but a URL can percent-encode it, so the
+    # query is stripped of it rather than trusted to lack it.
+    FIELD_SEPARATOR = "E'\\x1f'"
+    SEPARATOR_CHARACTER = "\u001f"
+
+    SEARCHABLE_TEXT = "(#{[
+      text_at(PROMPT_JSON, '$'),
+      turn_text(PROMPT_JSON),
+      output_text(OUTPUTS_JSON)
+    ].join(" || #{FIELD_SEPARATOR} || ")})".freeze
+
+    Row = Struct.new(
+      :probe_result_id, :attempt_index, :uuid, :probe_name, :probe_guid,
+      :detector_name, :succeeded, :score, :prompt_preview, :variant,
+      keyword_init: true
+    ) do
+      def status
+        return "unknown" if succeeded.nil?
+
+        succeeded ? "succeeded" : "blocked"
+      end
+    end
+
+    def initialize(report, filter: nil, query: nil)
+      @report = report
+      @filter = FILTERS[filter.to_s]
+      @query = query.to_s.delete(SEPARATOR_CHARACTER).strip.presence
+    end
+
+    def rows(limit: DEFAULT_PER_PAGE, offset: 0)
+      sql = <<~SQL.squish
+        SELECT pr.id AS probe_result_id,
+               pr.threat_variant_id AS threat_variant_id,
+               elem.ord - 1 AS attempt_index,
+               elem.value ->> 'uuid' AS uuid,
+               elem.value ->> 'attack_succeeded' AS attack_succeeded,
+               elem.value -> 'notes' ->> 'score_percentage' AS score,
+               elem.value -> 'prompt' AS prompt,
+               p.name AS probe_name,
+               p.guid AS probe_guid,
+               d.name AS detector_name
+        #{from_clause}
+        ORDER BY (pr.report_id <> :report_id), pr.id, elem.first_ord
+        LIMIT :limit OFFSET :offset
+      SQL
+
+      select(sql, limit: limit.to_i, offset: offset.to_i).map { |record| build_row(record) }
+    end
+
+    # Totals for the filter chips. Deliberately ignores the outcome filter --
+    # the chips have to keep showing what the other chips would select -- but
+    # honours the search, so the numbers agree with the table beneath them.
+    def counts
+      @counts ||= compute_counts
+    end
+
+    # Which page a deep-linked attempt falls on, or nil when it is not in the
+    # filtered set. A deep link has to work on a report with thousands of
+    # attempts, where the row is rarely on the first page.
+    #
+    # Identified by probe result and index rather than uuid: garak assigns one
+    # uuid per evaluated item and emits a row per generation reusing it (see
+    # ProbeResult.displayed_attempt_key), so a uuid can match several attempts and
+    # a link would always open the first generation.
+    def page_for(probe_result_id:, attempt_index:, per_page: DEFAULT_PER_PAGE)
+      return nil if probe_result_id.blank? || attempt_index.blank?
+
+      sql = <<~SQL.squish
+        SELECT page FROM (
+          SELECT pr.id AS probe_result_id,
+                 elem.ord - 1 AS attempt_index,
+                 ((ROW_NUMBER() OVER (ORDER BY (pr.report_id <> :report_id), pr.id, elem.first_ord) - 1)
+                   / :per_page) + 1 AS page
+          #{from_clause}
+        ) positioned
+        WHERE positioned.probe_result_id = :probe_result_id
+          AND positioned.attempt_index = :attempt_index
+        LIMIT 1
+      SQL
+
+      select(sql, per_page: per_page.to_i,
+                  probe_result_id: probe_result_id.to_i,
+                  attempt_index: attempt_index.to_i).first&.fetch("page")&.to_i
+    end
+
+    # The attempts either side of one row, and its position in the whole
+    # filtered set.
+    #
+    # The drawer steps from one attempt to the next, and the list is paged:
+    # stepping through the rendered rows stopped at the page boundary, where a
+    # 60-attempt report read "25 of 25" and would go no further. The server
+    # already owns the de-duplicated, filtered ordering, so it is what answers
+    # which attempt comes next -- the client then follows an identity rather
+    # than a row that may not be rendered.
+    #
+    # nil when the row is not in the filtered set at all (a deep link to an
+    # attempt the active filter hides): there is no neighbour to offer, and
+    # stepping to an arbitrary one would be worse than not stepping.
+    def neighbours(probe_result_id:, attempt_index:)
+      sql = <<~SQL.squish
+        WITH ordered AS (
+          SELECT pr.id AS probe_result_id,
+                 elem.ord - 1 AS attempt_index,
+                 ROW_NUMBER() OVER (ORDER BY (pr.report_id <> :report_id), pr.id, elem.first_ord) AS position,
+                 COUNT(*) OVER () AS total
+          #{from_clause}
+        ), anchor AS (
+          SELECT position, total FROM ordered
+          WHERE probe_result_id = :probe_result_id AND attempt_index = :attempt_index
+          LIMIT 1
+        )
+        SELECT anchor.position, anchor.total,
+               prev.probe_result_id AS prev_probe_result_id, prev.attempt_index AS prev_attempt_index,
+               nxt.probe_result_id  AS next_probe_result_id, nxt.attempt_index  AS next_attempt_index
+        FROM anchor
+        LEFT JOIN ordered prev ON prev.position = anchor.position - 1
+        LEFT JOIN ordered nxt  ON nxt.position  = anchor.position + 1
+      SQL
+
+      record = select(sql, probe_result_id: probe_result_id.to_i,
+                           attempt_index: attempt_index.to_i).first
+      return nil unless record
+
+      {
+        position: record["position"].to_i,
+        total: record["total"].to_i,
+        previous: coordinate(record, "prev"),
+        next: coordinate(record, "next")
+      }
+    end
+
+    # Size of the filtered set, for paging.
+    #
+    # Derived from #counts rather than its own aggregate: both expand every
+    # attempt in the report, so running them separately re-parsed the whole
+    # attempts payload a second time on every tab load, filter and page.
+    def total
+      case filter
+      when "true" then counts[:succeeded]
+      when "false" then counts[:blocked]
+      else counts[:all]
+      end
+    end
+
+    private
+
+    attr_reader :report, :filter, :query
+
+    def compute_counts
+      sql = <<~SQL.squish
+        SELECT COUNT(*) AS all_count,
+               COUNT(*) FILTER (WHERE elem.value ->> 'attack_succeeded' = 'true') AS succeeded_count,
+               COUNT(*) FILTER (WHERE elem.value ->> 'attack_succeeded' = 'false') AS blocked_count
+        #{from_clause(apply_filter: false)}
+      SQL
+
+      record = select(sql).first
+      {
+        all: record["all_count"].to_i,
+        succeeded: record["succeeded_count"].to_i,
+        blocked: record["blocked_count"].to_i
+      }
+    end
+
+    # One row per evaluated ITEM, mirroring ProbeResult.dedupe_key.
+    #
+    # garak writes each item twice -- attempt start and attempt completion --
+    # and both copies carry the output text. Every other rendering path
+    # collapses that pair through ProbeResult#displayed_attempts; expanding
+    # pr.attempts directly bypassed it, so the flat list showed each
+    # prompt/response twice and the chip counts doubled with it.
+    #
+    # Identity is the uuid when garak recorded one. Without a uuid it is the
+    # prompt AND the outputs: two genuinely different responses to one prompt
+    # would share a prompt-only key, and a dropped response can be a bypass.
+    #
+    # Blank is not a uuid. Ruby asks `uuid.present?`, so a whitespace-only value
+    # falls through to the prompt; testing it for <> '' instead collapsed two
+    # different prompts onto one row.
+    #
+    # Ruby's blank? is [[:space:]] over UTF-8, which is wider than the ASCII set
+    # Postgres BTRIM defaults to -- a non-breaking space is blank to Rails and
+    # not to a bare trim. The characters are listed so the two agree exactly
+    # rather than nearly.
+    #
+    # Outputs go through outputs_array before being keyed, so the identity
+    # reads them exactly as Array() does. Keying the raw JSON split rows that
+    # Ruby collapses.
+    #
+    # One shape is deliberately NOT mirrored: Array() on a Hash yields its
+    # pairs, so Ruby cannot tell {"text" => "x"} from [["text", "x"]]. That is
+    # an accident of Array(), not a rule worth reproducing, and garak emits
+    # neither -- outputs is an array of strings or of {text: ...} objects.
+
+    # Ruby String#blank? is /\A[[:space:]]*\z/ over UTF-8. These are the
+    # characters that matches, as a Postgres escape string.
+    BLANK_CHARACTERS = "E'" \
+      "\\u0009\\u000a\\u000b\\u000c\\u000d\\u0020\\u0085\\u00a0\\u1680" \
+      "\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200a" \
+      "\\u2028\\u2029\\u202f\\u205f\\u3000'"
+
+    # Identity for de-duplication, mirroring ProbeResult.displayed_attempt_key.
+    #
+    # garak writes each evaluated item twice -- attempt start and completion -- reusing
+    # one uuid, so the uuid IS the item identity and collapsing on it is right.
+    #
+    # A row WITHOUT a usable uuid is deliberately left DISTINCT, keyed on its own
+    # position. A lifecycle duplicate always shares a uuid, so a row lacking one cannot
+    # be one; collapsing such rows on prompt-and-response would drop a genuine repeated
+    # answer, and a dropped response can be a successful attack. That is the same rule
+    # ProbeResult applies in Ruby, and the two must not disagree about how many rows
+    # exist.
+    #
+    # The uuid branch requires a JSON STRING, not merely something that renders as
+    # non-empty text. `->> 'uuid'` turns false into 'false' and [] into '[]', so a
+    # type-blind check would treat several malformed rows as one item and silently
+    # merge them. Anything that is not a nonblank string takes the ordinal path.
+    DEDUPE_KEY = <<~SQL.squish
+      CASE WHEN json_typeof(e.value -> 'uuid') = 'string'
+                AND BTRIM(e.value ->> 'uuid', #{BLANK_CHARACTERS}) <> ''
+           THEN 'uuid:' || (e.value ->> 'uuid')
+           ELSE 'ord:' || e.ord::text
+      END
+    SQL
+
+    # WITH ORDINALITY gives each attempt its position within its own probe
+    # result, which is how evidence_attempt addresses it -- a flattened row is
+    # useless without it. The ordinality is taken BEFORE de-duplication and
+    # before malformed rows are dropped, so a surviving row still indexes the
+    # stored array (gaps included), exactly as
+    # ProbeResult#displayed_attempts reports it.
+    #
+    # Two ordinals, because the surviving row and its position are different
+    # questions. `ord` is the LAST copy -- the completion one, carrying the
+    # detector's verdict, and the index the drawer resolves. `first_ord` is the
+    # earliest copy, and the list is ordered by it, because
+    # displayed_attempts orders by first appearance: two items whose lifecycle
+    # rows interleave would otherwise come out reversed from the probe card.
+    def from_clause(apply_filter: true)
+      clause = +<<~SQL.squish
+        FROM probe_results pr
+        CROSS JOIN LATERAL (
+          SELECT DISTINCT ON (keyed.dedupe_key)
+                 keyed.value,
+                 keyed.ord,
+                 MIN(keyed.ord) OVER (PARTITION BY keyed.dedupe_key) AS first_ord
+          FROM (
+            SELECT e.value, e.ord, #{DEDUPE_KEY} AS dedupe_key
+            FROM json_array_elements(COALESCE(pr.attempts, '[]'::json))
+              WITH ORDINALITY AS e(value, ord)
+            WHERE json_typeof(e.value) = 'object'
+          ) keyed
+          ORDER BY keyed.dedupe_key, keyed.ord DESC
+        ) AS elem(value, ord, first_ord)
+        LEFT JOIN probes p ON p.id = pr.probe_id
+        LEFT JOIN detectors d ON d.id = pr.detector_id
+        WHERE pr.report_id IN (:report_ids)
+      SQL
+
+      clause << " AND elem.value ->> 'attack_succeeded' = :filter" if apply_filter && filter
+      clause << " AND #{SEARCHABLE_TEXT} ILIKE :query" if query
+      clause
+    end
+
+    # A variant parent holds only the main attempts; the variant attempts live
+    # on its child report. Both belong in a list that claims to show every
+    # attempt in the run.
+    def report_ids
+      @report_ids ||= [ report.id, (report.child_report&.id if report.has_variant_data?) ].compact
+    end
+
+    def select(sql, extra = {})
+      binds = { report_id: report.id, report_ids: report_ids }
+      binds[:filter] = filter if filter
+      # sanitize_sql_like escapes % and _ so a searched wildcard is literal text
+      # rather than a pattern that quietly matches everything.
+      binds[:query] = "%#{ActiveRecord::Base.sanitize_sql_like(query)}%" if query
+
+      ProbeResult.connection.select_all(
+        ActiveRecord::Base.sanitize_sql_array([ sql, binds.merge(extra) ])
+      )
+    end
+
+    def coordinate(record, side)
+      id = record["#{side}_probe_result_id"]
+      return nil if id.nil?
+
+      { probe_result_id: id, attempt_index: record["#{side}_attempt_index"].to_i }
+    end
+
+    def build_row(record)
+      Row.new(
+        probe_result_id: record["probe_result_id"],
+        attempt_index: record["attempt_index"].to_i,
+        uuid: record["uuid"],
+        probe_name: record["probe_name"],
+        probe_guid: record["probe_guid"],
+        detector_name: record["detector_name"],
+        succeeded: parse_boolean(record["attack_succeeded"]),
+        score: record["score"]&.to_f,
+        prompt_preview: preview(record["prompt"]),
+        variant: record["threat_variant_id"].present?
+      )
+    end
+
+    # nil is a third state, not a false: garak returned no detector scores for
+    # this attempt, so neither "succeeded" nor "blocked" is a claim we can make.
+    def parse_boolean(value)
+      return nil if value.nil?
+
+      value == "true"
+    end
+
+    # garak emits prompts as bare strings and as turn structures; the list must
+    # show text either way rather than a Hash inspection.
+    def preview(raw)
+      return "" if raw.blank?
+
+      parsed = begin
+        JSON.parse(raw)
+      rescue JSON::ParserError
+        raw
+      end
+
+      text = TokenEstimator.extract_prompt_text(parsed).to_s
+      text.length > PREVIEW_LENGTH ? "#{text[0, PREVIEW_LENGTH - 1]}…" : text
+    end
+  end
+end

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -21,6 +21,14 @@ class ReportPolicy < TenantScopedPolicy
     true
   end
 
+  def evidence?
+    true
+  end
+
+  def evidence_attempt?
+    true
+  end
+
   def attempt_content?
     true
   end

--- a/app/services/reports/process.rb
+++ b/app/services/reports/process.rb
@@ -326,9 +326,12 @@ module Reports
       probe_classname = data["probe_classname"]
       report_data[probe_classname] ||= {}
       report_data[probe_classname]["attempts"] ||= []
-      attack_succeeded = attempt_attack_succeeded(data["detector_results"])
+      detector_results = data["detector_results"]
+      attack_succeeded = attempt_attack_succeeded(detector_results)
+      detector_scores = attempt_detector_scores(detector_results)
       data = data.slice(*ATTEMPT_KEYS)
       data["attack_succeeded"] = attack_succeeded
+      data["detector_scores"] = detector_scores unless detector_scores.nil?
       report_data[probe_classname]["attempts"] << data
 
       score = data.dig("notes", "score_percentage")
@@ -339,6 +342,32 @@ module Reports
       current_score = report_data[probe_classname]["stats"]["max_score"] || 0
       max_score = score > current_score ? score : current_score
       report_data[probe_classname]["stats"]["max_score"] = max_score
+    end
+
+    # The MAXIMUM score each detector gave this attempt, or nil when garak recorded
+    # no detector results for it.
+    #
+    # A maximum across generations, not a per-generation figure: one attempt can hold
+    # several outputs and garak scores each, but only this scalar is stored. So the
+    # drawer can say a detector reached 0.8 on this attempt; it cannot say WHICH
+    # response earned it, and no caller should imply otherwise.
+    #
+    # The raw detector_results blob deliberately stays out of storage -- it repeats a
+    # float per output, and the attempts column already carries every prompt and
+    # response. This is the derived summary the evidence drawer renders, so a reader
+    # can see which detector drove the verdict rather than only the verdict.
+    #
+    # An EMPTY hash is a real answer -- detectors ran and produced no numeric value --
+    # and is stored as one. Only missing or malformed detector_results yields nil,
+    # which the drawer reports as never recorded. Collapsing the two would tell a
+    # reader that a report this very code had just processed predates score capture.
+    def attempt_detector_scores(detector_results)
+      return nil unless detector_results.is_a?(Hash)
+
+      detector_results.each_with_object({}) do |(name, values), acc|
+        numeric = Array(values).flatten.compact.map(&:to_f)
+        acc[name] = numeric.max if numeric.any?
+      end
     end
 
     # True when any detector flagged any output as a successful attack

--- a/app/views/admin/reports/_evidence_row.html.erb
+++ b/app/views/admin/reports/_evidence_row.html.erb
@@ -1,0 +1,35 @@
+<%
+  row = local_assigns[:row]
+  succeeded = row.succeeded
+%>
+<tr class="border-t border-zinc-800 cursor-pointer hover:bg-zinc-800/40 focus:outline-none focus-visible:bg-zinc-800/60"
+    tabindex="0"
+    role="button"
+    aria-label="Open evidence for <%= row.probe_name || 'attempt' %>, <%= evidence_status_label(succeeded) %>"
+    data-report-evidence-target="row"
+    data-probe-result-id="<%= row.probe_result_id %>"
+    data-attempt-index="<%= row.attempt_index %>"
+    data-uuid="<%= row.uuid %>"
+    data-action="click->report-evidence#open keydown.enter->report-evidence#open keydown.space->report-evidence#open">
+  <td class="px-4 py-2 border-l-2 <%= succeeded.nil? ? 'border-l-transparent' : (succeeded ? 'border-l-red-400' : 'border-l-green-400') %>">
+    <%= evidence_status_badge(succeeded) %>
+  </td>
+  <td class="px-4 py-2">
+    <% if row.score %>
+      <span class="rounded-md bg-blue-500/20 px-2 py-0.5 text-xs font-semibold text-blue-300 tabular-nums">
+        <%= number_to_percentage(row.score, precision: 0) %>
+      </span>
+    <% else %>
+      <span class="text-xs text-contentTertiary">—</span>
+    <% end %>
+  </td>
+  <td class="px-4 py-2 whitespace-nowrap">
+    <span class="text-sm text-white font-medium"><%= row.probe_name || "Unknown Probe" %></span>
+    <% if row.variant %>
+      <span class="ml-2 rounded-md bg-purple-950 px-2 py-0.5 text-xs text-purple-400" title="Industry-specific variant of the probe">Variant</span>
+    <% end %>
+  </td>
+  <td class="px-4 py-2">
+    <span class="block max-w-md truncate font-mono text-xs text-contentTertiary"><%= row.prompt_preview %></span>
+  </td>
+</tr>

--- a/app/views/admin/reports/_show_v2.html.erb
+++ b/app/views/admin/reports/_show_v2.html.erb
@@ -3,7 +3,10 @@
 <% end %>
 <div id="pdf-status-<%= report.id %>" style="display: none;"></div>
 
-<div class="min-h-screen" data-controller="report-redesigned pdf-download" data-pdf-download-report-id-value="<%= report.id %>" data-report-redesigned-probes-tab-url-value="<%= probes_tab_report_path(report) %>">
+<%# A deep link to one attempt lands here, not on the frame endpoint, so the page
+    boots with Stimulus and then hands these coordinates to the evidence frame. %>
+<% evidence_params = params.permit(:probe_result_id, :attempt_index, :filter, :q, :page).to_h.compact_blank %>
+<div class="min-h-screen" data-controller="report-redesigned pdf-download" data-pdf-download-report-id-value="<%= report.id %>" data-report-redesigned-probes-tab-url-value="<%= probes_tab_report_path(report) %>" data-report-redesigned-evidence-tab-url-value="<%= evidence_report_path(report, evidence_params) %>"<%= " data-report-redesigned-initial-tab-value=\"evidence\"".html_safe if params[:tab] == "evidence" %>>
   <%= render partial: 'admin/reports/report_header', locals: { report: report } %>
 
   <%# Tab Navigation %>
@@ -23,6 +26,14 @@
       data-tab="probes"
       data-report-redesigned-target="tabProbes">
       Probes
+    </button>
+    <button
+      type="button"
+      class="px-3 pb-4 text-xl font-sans font-medium transition-colors text-contentTertiary hover:text-contentSecondary cursor-pointer"
+      data-action="click->report-redesigned#switchTab"
+      data-tab="evidence"
+      data-report-redesigned-target="tabEvidence">
+      Evidence
     </button>
   </nav>
 
@@ -63,6 +74,19 @@
       <turbo-frame id="report-probes-tab" data-report-redesigned-target="probesFrame">
         <div class="flex items-center justify-center py-16">
           <span class="text-sm text-contentSecondary font-sans">Loading probes...</span>
+        </div>
+      </turbo-frame>
+    </div>
+  </div>
+
+  <%# Evidence Tab Content -- every attempt in the report, flat and filterable.
+      Lazy, like the probes frame: a report with thousands of attempts must not pay
+      for the list until a reader asks for it. %>
+  <div class="pb-6 hidden" data-report-redesigned-target="tabContentEvidence">
+    <div class="mx-auto">
+      <turbo-frame id="report-evidence-tab" data-report-redesigned-target="evidenceFrame">
+        <div class="flex items-center justify-center py-16">
+          <span class="text-sm text-contentSecondary font-sans">Loading evidence...</span>
         </div>
       </turbo-frame>
     </div>

--- a/app/views/admin/reports/evidence.html.erb
+++ b/app/views/admin/reports/evidence.html.erb
@@ -1,0 +1,129 @@
+<%#
+  The Evidence tab: every attempt in the report as one filterable list.
+
+  Rows carry only a truncated prompt; the full prompt, response and detector
+  scores load into the drawer when a row is opened, so a report with thousands
+  of attempts costs one page of rows rather than every attempt's text.
+%>
+<%= turbo_frame_tag "report-evidence-tab" do %>
+  <div data-controller="report-evidence"
+       data-report-evidence-attempt-url-value="<%= evidence_attempt_report_path(@report) %>"
+       data-report-evidence-selected-probe-result-value="<%= @selected_probe_result_id %>"
+       data-report-evidence-selected-index-value="<%= @selected_attempt_index %>"
+       data-report-evidence-filter-value="<%= @filter %>"
+       data-report-evidence-query-value="<%= @query %>">
+
+    <div class="flex flex-wrap items-center gap-3 py-4">
+      <div class="flex flex-wrap gap-2" role="group" aria-label="Filter attempts by outcome">
+        <% [ [ "all", "All", @counts[:all] ],
+             [ "succeeded", "Attack succeeded", @counts[:succeeded] ],
+             [ "blocked", "Blocked", @counts[:blocked] ] ].each do |value, label, count| %>
+          <% active = (@filter || "all") == value %>
+          <%= link_to evidence_report_path(@report, filter: value, q: @query),
+                      data: { turbo_frame: "report-evidence-tab" },
+                      aria: { pressed: active.to_s },
+                      class: "no-underline inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm font-sans transition-colors #{active ? 'bg-white text-black font-semibold' : 'border border-zinc-700 text-contentSecondary hover:text-white hover:border-zinc-500'}" do %>
+            <%= label %>
+            <span class="tabular-nums opacity-75"><%= number_with_delimiter(count) %></span>
+          <% end %>
+        <% end %>
+      </div>
+
+      <%= form_with url: evidence_report_path(@report), method: :get,
+                    data: { turbo_frame: "report-evidence-tab" },
+                    class: "ml-auto" do |f| %>
+        <%= f.hidden_field :filter, value: @filter %>
+        <%= f.search_field :q, value: @query,
+                           placeholder: "Search prompts and responses",
+                           aria: { label: "Search prompts and responses" },
+                           class: "input-base w-72 text-sm" %>
+      <% end %>
+    </div>
+
+    <% if @rows.empty? %>
+      <p class="py-16 text-center text-sm text-contentSecondary font-sans">
+        No attempts match this filter.
+      </p>
+    <% else %>
+      <div class="overflow-x-auto rounded-lg border border-zinc-700">
+        <table class="w-full font-sans">
+          <thead>
+            <tr class="bg-zinc-800/50 text-left">
+              <th scope="col" class="px-4 py-2 text-xs uppercase tracking-wider text-contentTertiary font-semibold">Outcome</th>
+              <th scope="col" class="px-4 py-2 text-xs uppercase tracking-wider text-contentTertiary font-semibold">Score</th>
+              <th scope="col" class="px-4 py-2 text-xs uppercase tracking-wider text-contentTertiary font-semibold">Probe</th>
+              <th scope="col" class="px-4 py-2 text-xs uppercase tracking-wider text-contentTertiary font-semibold">Prompt</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @rows.each do |row| %>
+              <%= render partial: "admin/reports/evidence_row", locals: { row: row } %>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <% pages = (@total.to_f / @per_page).ceil %>
+      <% if pages > 1 %>
+        <nav class="flex items-center justify-between py-4 text-sm font-sans" aria-label="Evidence pages">
+          <span class="text-contentTertiary tabular-nums">
+            Page <%= @page %> of <%= pages %> · <%= number_with_delimiter(@total) %> attempts
+          </span>
+          <div class="flex gap-2">
+            <% if @page > 1 %>
+              <%= link_to "Previous", evidence_report_path(@report, filter: @filter, q: @query, page: @page - 1),
+                          data: { turbo_frame: "report-evidence-tab" },
+                          class: "no-underline rounded-md border border-zinc-700 px-3 py-1 text-contentSecondary hover:text-white" %>
+            <% end %>
+            <% if @page < pages %>
+              <%= link_to "Next", evidence_report_path(@report, filter: @filter, q: @query, page: @page + 1),
+                          data: { turbo_frame: "report-evidence-tab" },
+                          class: "no-underline rounded-md border border-zinc-700 px-3 py-1 text-contentSecondary hover:text-white" %>
+            <% end %>
+          </div>
+        </nav>
+      <% end %>
+    <% end %>
+
+    <%# Drawer: populated from evidence_attempt when a row is opened. %>
+    <div class="fixed inset-0 z-40 hidden"
+         data-report-evidence-target="drawer"
+         role="dialog"
+         aria-modal="true"
+         aria-label="Attempt evidence">
+      <div class="absolute inset-0 bg-black/50"
+           data-action="click->report-evidence#close"></div>
+      <aside class="absolute inset-y-0 right-0 w-full max-w-xl bg-backgroundPrimary border-l border-zinc-700 flex flex-col"
+             tabindex="-1"
+             data-report-evidence-target="panel">
+        <div class="flex items-center gap-3 border-b border-zinc-700 px-4 py-3">
+          <span class="text-base text-white font-sans" data-report-evidence-target="title">Attempt</span>
+          <div class="ml-auto flex items-center gap-2">
+            <span class="text-xs text-contentTertiary tabular-nums" data-report-evidence-target="position"></span>
+            <button type="button"
+                    class="btn-base px-2 py-1"
+                    aria-label="Previous attempt"
+                    data-report-evidence-target="prev"
+                    data-action="click->report-evidence#previous">
+              <span class="icon icon-sm icon-chevron-up"></span>
+            </button>
+            <button type="button"
+                    class="btn-base px-2 py-1"
+                    aria-label="Next attempt"
+                    data-report-evidence-target="next"
+                    data-action="click->report-evidence#next">
+              <span class="icon icon-sm icon-chevron-down"></span>
+            </button>
+            <button type="button"
+                    class="btn-base px-2 py-1"
+                    aria-label="Close evidence"
+                    data-action="click->report-evidence#close">
+              <span class="icon icon-sm icon-close"></span>
+            </button>
+          </div>
+        </div>
+        <div class="flex-1 overflow-y-auto p-4" data-report-evidence-target="content"></div>
+      </aside>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/reports/evidence_attempt.html.erb
+++ b/app/views/admin/reports/evidence_attempt.html.erb
@@ -1,0 +1,124 @@
+<%
+  succeeded = @attempt["attack_succeeded"]
+  score = @attempt.dig("notes", "score_percentage")
+%>
+
+<%#- Evidence is escaped, never sanitized: sanitize() would delete a <script>
+    the probe actually sent, hiding part of the payload from the person
+    assessing it. Escaping shows the text exactly as sent, and keeps a quote
+    from breaking out of data-content into the drawer's innerHTML. -%>
+<%#- The drawer's stepping data. The list is paged, so the attempt before or
+    after this one is often not a rendered row; these name it outright. Absent
+    when the attempt is not in the filtered set at all, which is a deep link to
+    a row the active filter hides -- there is nowhere to step. -%>
+<div class="flex flex-col gap-4 font-sans"
+     data-evidence-probe-name="<%= @probe_name %>"
+     <%= tag.attributes(
+           "data-evidence-position": @neighbours[:position],
+           "data-evidence-total": @neighbours[:total]
+         ) if @neighbours %>
+     <%= tag.attributes(
+           "data-evidence-previous-probe-result-id": @neighbours[:previous][:probe_result_id],
+           "data-evidence-previous-attempt-index": @neighbours[:previous][:attempt_index]
+         ) if @neighbours && @neighbours[:previous] %>
+     <%= tag.attributes(
+           "data-evidence-next-probe-result-id": @neighbours[:next][:probe_result_id],
+           "data-evidence-next-attempt-index": @neighbours[:next][:attempt_index]
+         ) if @neighbours && @neighbours[:next] %>>
+  <%# Verdict, score and detector all sit with the prompt and response rather
+      than on a header the reader has to scroll back to. %>
+  <div class="flex flex-wrap items-center gap-3 rounded-lg border border-zinc-800 bg-zinc-800/40 px-3 py-2">
+    <%= evidence_status_badge(succeeded) %>
+    <% if score.present? %>
+      <span class="rounded-md bg-blue-500/20 px-2 py-0.5 text-xs font-semibold text-blue-300 tabular-nums">
+        Score <%= number_to_percentage(score.to_f, precision: 0) %>
+      </span>
+    <% end %>
+    <% if @variant %>
+      <span class="rounded-md bg-purple-950 px-2 py-0.5 text-xs text-purple-400">Variant</span>
+    <% end %>
+    <span class="text-xs text-contentTertiary">attempt <%= @attempt["uuid"] %></span>
+  </div>
+
+  <div class="flex flex-col gap-2">
+    <div class="flex items-center gap-2">
+      <h4 class="text-xs uppercase tracking-wider text-contentTertiary font-semibold">Prompt</h4>
+      <button type="button"
+              class="text-contentTertiary hover:text-white transition-colors"
+              data-action="click->report-evidence#copy"
+              data-content="<%= @prompt %>"
+              aria-label="Copy prompt">
+        <span class="icon icon-sm icon-copy"></span>
+      </button>
+    </div>
+    <div class="rounded-lg bg-zinc-800/50 p-3 max-h-64 overflow-y-auto">
+      <pre class="m-0 whitespace-pre-wrap font-mono text-sm text-zinc-300"><%= @prompt %></pre>
+    </div>
+  </div>
+
+  <%# Every generation garak produced for this prompt. The verdict above is the
+      max across all of them, so any one of them can be the one that succeeded;
+      showing only the first made the evidence contradict the badge beside it. %>
+  <% if @responses.empty? %>
+    <div class="flex flex-col gap-2">
+      <h4 class="text-xs uppercase tracking-wider text-contentTertiary font-semibold">Target response</h4>
+      <div class="rounded-lg bg-zinc-800/50 p-3">
+        <span class="text-sm italic text-contentTertiary">[No response generated]</span>
+      </div>
+    </div>
+  <% end %>
+
+  <% @responses.each_with_index do |response, index| %>
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center gap-2">
+        <h4 class="text-xs uppercase tracking-wider text-contentTertiary font-semibold">Target response</h4>
+        <% if @responses.size > 1 %>
+          <span class="text-xs text-contentTertiary tabular-nums"><%= index + 1 %> of <%= @responses.size %></span>
+        <% end %>
+        <button type="button"
+                class="text-contentTertiary hover:text-white transition-colors"
+                data-action="click->report-evidence#copy"
+                data-content="<%= response %>"
+                aria-label="Copy response<%= " #{index + 1}" if @responses.size > 1 %>">
+          <span class="icon icon-sm icon-copy"></span>
+        </button>
+      </div>
+      <div class="rounded-lg bg-zinc-800/50 p-3 max-h-64 overflow-y-auto">
+        <% if response.present? %>
+          <pre class="m-0 whitespace-pre-wrap font-mono text-sm text-zinc-300"><%= response %></pre>
+        <% else %>
+          <span class="text-sm italic text-contentTertiary">[No response generated]</span>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="flex flex-col gap-2">
+    <h4 class="text-xs uppercase tracking-wider text-contentTertiary font-semibold">Scoring evidence</h4>
+    <% if @detector_scores.present? %>
+      <% @detector_scores.each do |detector_name, detector_score| %>
+        <div class="flex items-center justify-between gap-4 rounded-lg border border-zinc-800 bg-zinc-800/40 px-3 py-2">
+          <span class="font-mono text-xs text-contentSecondary"><%= detector_name %></span>
+          <span class="rounded-md bg-blue-500/20 px-2 py-0.5 text-xs font-semibold text-blue-300 tabular-nums">
+            <%= format("%.2f", detector_score.to_f) %>
+          </span>
+        </div>
+      <% end %>
+    <% elsif @detector_scores %>
+      <%# An empty hash means this attempt WAS scored and no detector produced a
+          value -- a different fact from never having been recorded, and saying
+          the wrong one misdescribes the run to an assessor. %>
+      <p class="rounded-lg border border-dashed border-zinc-700 px-3 py-2 text-sm text-contentTertiary">
+        No detector produced a score for this attempt.
+      </p>
+    <% else %>
+      <%# Scans run before per-attempt detector scores existed cannot show them.
+          Saying so beats an empty section that reads as "no detector fired". %>
+      <p class="rounded-lg border border-dashed border-zinc-700 px-3 py-2 text-sm text-contentTertiary">
+        Detector evidence wasn't recorded for this attempt. Scans run before this
+        was captured kept only the final verdict, so the per-detector scores
+        can't be shown here.
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,8 @@ Rails.application.routes.draw do
         get :asr_history
         get :top_probes
         get :probes_tab
+        get :evidence
+        get :evidence_attempt
         get :probe_attempts
         get :progress
         get :attempt_content

--- a/script/tests/javascript_controller_tests.mjs
+++ b/script/tests/javascript_controller_tests.mjs
@@ -771,6 +771,255 @@ function testReportRedesignedControllerListenerCleanup() {
   }
 }
 
+function loadReportEvidenceController(context = {}) {
+  const transformed = loadControllerSource(
+    "report_evidence_controller.js",
+    "ReportEvidenceController"
+  )
+
+  const base = {
+    Controller: class {},
+    console: { error() {} },
+    document: { addEventListener() {}, removeEventListener() {}, activeElement: null },
+    window: { location: { origin: "http://test.local" } },
+    URL,
+    setTimeout(callback) { callback() },
+    clearTimeout() {},
+    Map,
+    Error,
+    Number,
+    Boolean,
+    String,
+    ...context
+  }
+
+  const ControllerClass = vm.runInNewContext(
+    `${transformed}\nReportEvidenceController`,
+    base
+  )
+
+  return { ControllerClass }
+}
+
+function evidenceControllerWith(fetchImpl) {
+  const { ControllerClass } = loadReportEvidenceController({ fetch: fetchImpl })
+  const controller = new ControllerClass()
+
+  controller.drawerTarget = { classList: classListWith("hidden") }
+  controller.panelTarget = { focus() {} }
+  controller.contentTarget = {
+    innerHTML: "",
+    // No neighbour metadata: these cases are about which body wins, not stepping.
+    querySelector() { return null }
+  }
+  controller.hasPositionTarget = false
+  controller.hasTitleTarget = false
+  controller.hasPrevTarget = false
+  controller.hasNextTarget = false
+  controller.hasRowTarget = false
+  controller.hasFilterValue = false
+  controller.hasQueryValue = false
+  controller.attemptUrlValue = "/reports/1/evidence_attempt"
+  controller.lastFocused = { focus() {} }
+
+  return controller
+}
+
+// Arrowing down a list faster than the network answers leaves several fetches in
+// flight. If a slow earlier one is allowed to write, the drawer ends up showing
+// one attempt's prompt and response under a different attempt's header -- the
+// exact confusion this tab exists to remove, made worse by looking authoritative.
+async function testReportEvidenceIgnoresAStaleResponse() {
+  const pending = []
+  const controller = evidenceControllerWith(() =>
+    new Promise((resolve) => {
+      pending.push(resolve)
+    })
+  )
+
+  const first = controller.load({ probeResultId: "1", attemptIndex: "0" })
+  const second = controller.load({ probeResultId: "1", attemptIndex: "1" })
+
+  // The newest request answers first, then the stale one lands.
+  pending[1]({ ok: true, text: async () => "SECOND ATTEMPT" })
+  await second
+  assert.equal(controller.contentTarget.innerHTML, "SECOND ATTEMPT")
+
+  pending[0]({ ok: true, text: async () => "FIRST ATTEMPT" })
+  await first
+
+  assert.equal(
+    controller.contentTarget.innerHTML,
+    "SECOND ATTEMPT",
+    "a superseded response must not overwrite the drawer"
+  )
+}
+
+// The same ordering rule has to hold for failures. A stale rejection writing its
+// error banner would tell the reader the attempt they are looking at failed to
+// load, while its evidence is sitting on screen underneath.
+async function testReportEvidenceIgnoresAStaleFailure() {
+  const pending = []
+  const controller = evidenceControllerWith(() =>
+    new Promise((resolve, reject) => {
+      pending.push({ resolve, reject })
+    })
+  )
+
+  const first = controller.load({ probeResultId: "1", attemptIndex: "0" })
+  const second = controller.load({ probeResultId: "1", attemptIndex: "1" })
+
+  pending[1].resolve({ ok: true, text: async () => "SECOND ATTEMPT" })
+  await second
+
+  pending[0].reject(new Error("network down"))
+  await first
+
+  assert.equal(
+    controller.contentTarget.innerHTML,
+    "SECOND ATTEMPT",
+    "a superseded failure must not replace live evidence with an error"
+  )
+}
+
+// Every lazily loaded tab frame goes through one shared path, so the evidence tab
+// has to inherit the cleanup the attempts frame already had: listeners registered
+// { once: true } never fire on the happy path, and an untracked one outlives the
+// controller.
+function testReportRedesignedEvidenceFrameLoadsLazilyAndCleansUp() {
+  const { ControllerClass } = loadReportRedesignedController()
+  const addCalls = []
+  const removeCalls = []
+  const evidenceFrame = {
+    src: "",
+    innerHTML: "",
+    addEventListener(type, callback, options) {
+      addCalls.push({ type, callback, options })
+    },
+    removeEventListener(type, callback) {
+      removeCalls.push({ type, callback })
+    }
+  }
+  const controller = new ControllerClass()
+
+  controller.element = { addEventListener() {}, querySelector() { return null } }
+  controller.hasAsrHistoryChartTarget = false
+  controller.hasTopProbesChartTarget = false
+  if (typeof controller.connect === "function") controller.connect()
+
+  const tabEl = () => ({ classList: classListWith() })
+  controller.hasTabOverviewTarget = true
+  controller.tabOverviewTarget = tabEl()
+  controller.hasTabContentOverviewTarget = true
+  controller.tabContentOverviewTarget = { classList: classListWith() }
+  controller.hasTabProbesTarget = false
+  controller.hasTabEvidenceTarget = true
+  controller.tabEvidenceTarget = tabEl()
+  controller.hasTabContentEvidenceTarget = true
+  controller.tabContentEvidenceTarget = { classList: classListWith("hidden") }
+  controller.hasEvidenceFrameTarget = true
+  controller.evidenceFrameTarget = evidenceFrame
+  controller.evidenceTabUrlValue = "/reports/1/evidence"
+
+  controller.switchTab({ currentTarget: { dataset: { tab: "evidence" } } })
+
+  assert.equal(controller.tabContentEvidenceTarget.classList.contains("hidden"), false)
+  assert.equal(evidenceFrame.src, "/reports/1/evidence")
+  assert.deepEqual(
+    addCalls.map((call) => call.type).sort(),
+    ["turbo:fetch-request-error", "turbo:frame-missing"]
+  )
+  assert.ok(addCalls.every((call) => call.options && call.options.once === true))
+
+  // Switching back and forth must not re-fetch a frame that already loaded, nor
+  // stack a second pair of listeners on it.
+  controller.switchTab({ currentTarget: { dataset: { tab: "overview" } } })
+  controller.switchTab({ currentTarget: { dataset: { tab: "evidence" } } })
+
+  assert.equal(addCalls.length, 2, "a loaded frame should not re-register listeners")
+
+  controller.disconnect()
+
+  assert.deepEqual(
+    removeCalls.map((call) => call.type).sort(),
+    ["turbo:fetch-request-error", "turbo:frame-missing"],
+    "disconnect should remove the evidence frame's error listeners"
+  )
+  for (const removeCall of removeCalls) {
+    assert.ok(
+      addCalls.find((a) => a.type === removeCall.type && a.callback === removeCall.callback),
+      `removeEventListener for ${removeCall.type} should match the registered handler`
+    )
+  }
+}
+
+// A deep link to one attempt arrives as a page load, not a click, so the tab it
+// names has to open without one. This is the only path that reaches
+// report-evidence#openFromLocation -- if connect() stops activating the tab, the
+// link silently lands on the overview and the drawer never opens.
+function testReportRedesignedActivatesTheInitialTabOnConnect() {
+  const { ControllerClass } = loadReportRedesignedController()
+  const evidenceFrame = {
+    src: "",
+    innerHTML: "",
+    addEventListener() {},
+    removeEventListener() {}
+  }
+  const controller = new ControllerClass()
+
+  controller.element = { addEventListener() {}, querySelector() { return null } }
+  controller.hasAsrHistoryChartTarget = false
+  controller.hasTopProbesChartTarget = false
+  controller.hasTabOverviewTarget = true
+  controller.tabOverviewTarget = { classList: classListWith("text-primary") }
+  controller.hasTabContentOverviewTarget = true
+  controller.tabContentOverviewTarget = { classList: classListWith() }
+  controller.hasTabProbesTarget = false
+  controller.hasTabEvidenceTarget = true
+  controller.tabEvidenceTarget = { classList: classListWith() }
+  controller.hasTabContentEvidenceTarget = true
+  controller.tabContentEvidenceTarget = { classList: classListWith("hidden") }
+  controller.hasEvidenceFrameTarget = true
+  controller.evidenceFrameTarget = evidenceFrame
+  controller.evidenceTabUrlValue = "/reports/1/evidence?probe_result_id=2&attempt_index=3"
+  controller.hasInitialTabValue = true
+  controller.initialTabValue = "evidence"
+
+  controller.connect()
+
+  assert.equal(controller.tabContentEvidenceTarget.classList.contains("hidden"), false,
+    "connect should open the tab the deep link names")
+  assert.equal(controller.tabContentOverviewTarget.classList.contains("hidden"), true)
+  assert.equal(controller.tabEvidenceTarget.classList.contains("text-primary"), true)
+  assert.equal(evidenceFrame.src, "/reports/1/evidence?probe_result_id=2&attempt_index=3",
+    "the frame should be loaded with the deep link's coordinates")
+}
+
+// Without a deep link nothing may move: the report still opens on the overview.
+function testReportRedesignedLeavesTheDefaultTabAloneWithoutADeepLink() {
+  const { ControllerClass } = loadReportRedesignedController()
+  const controller = new ControllerClass()
+
+  controller.element = { addEventListener() {}, querySelector() { return null } }
+  controller.hasAsrHistoryChartTarget = false
+  controller.hasTopProbesChartTarget = false
+  controller.hasTabOverviewTarget = true
+  controller.tabOverviewTarget = { classList: classListWith("text-primary") }
+  controller.hasTabContentOverviewTarget = true
+  controller.tabContentOverviewTarget = { classList: classListWith() }
+  controller.hasTabEvidenceTarget = true
+  controller.tabEvidenceTarget = { classList: classListWith() }
+  controller.hasTabContentEvidenceTarget = true
+  controller.tabContentEvidenceTarget = { classList: classListWith("hidden") }
+  controller.hasEvidenceFrameTarget = false
+  controller.hasInitialTabValue = false
+
+  controller.connect()
+
+  assert.equal(controller.tabContentEvidenceTarget.classList.contains("hidden"), true)
+  assert.equal(controller.tabContentOverviewTarget.classList.contains("hidden"), false)
+}
+
 function testLogViewerController() {
   const { ControllerClass } = loadLogViewerController()
 
@@ -1746,6 +1995,11 @@ testDebugTabsController()
 testDebugStreamFilterController()
 testReportRedesignedController()
 testReportRedesignedControllerListenerCleanup()
+testReportRedesignedEvidenceFrameLoadsLazilyAndCleansUp()
+testReportRedesignedActivatesTheInitialTabOnConnect()
+testReportRedesignedLeavesTheDefaultTabAloneWithoutADeepLink()
+await testReportEvidenceIgnoresAStaleResponse()
+await testReportEvidenceIgnoresAStaleFailure()
 testLogViewerController()
 testThreatVariantsController()
 testWebchatAuthController()

--- a/spec/models/reports/evidence_rows_spec.rb
+++ b/spec/models/reports/evidence_rows_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The Evidence tab reads attempts through SQL while the drawer reads them through
+# Ruby. Wherever the two answer the same question they must agree, or the list will
+# show a row whose drawer says something else -- which is the confusion this feature
+# exists to remove.
+RSpec.describe Reports::EvidenceRows do
+  let(:company) { create(:company) }
+  let(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company) } }
+  let(:report) do
+    ActsAsTenant.with_tenant(company) { create(:report, :completed, company: company, target: target) }
+  end
+
+  def probe_result_with(attempts, probe_name: "P")
+    ActsAsTenant.with_tenant(company) do
+      create(:probe_result, report: report, probe: create(:probe, name: probe_name), attempts: attempts)
+    end
+  end
+
+  def lifecycle_pair(uuid:, text:, prompt: "how is it made?")
+    [
+      { "uuid" => uuid, "prompt" => prompt, "outputs" => [ text ], "attack_succeeded" => nil },
+      { "uuid" => uuid, "prompt" => prompt, "outputs" => [ text ], "attack_succeeded" => true }
+    ]
+  end
+
+  describe "agreement with ProbeResult#displayed_attempts" do
+    it "returns one row per displayed attempt, in the same order" do
+      # The probe card and the evidence list must not disagree about how many
+      # attempts a run has, nor about which came first.
+      pr = probe_result_with(lifecycle_pair(uuid: "a", text: "one") +
+                             lifecycle_pair(uuid: "b", text: "two"))
+
+      rows = described_class.new(report.reload).rows
+
+      expect(rows.map(&:uuid)).to eq(pr.displayed_attempts.map { |a| a["uuid"] })
+    end
+
+    it "collapses interleaved lifecycle rows without reordering them" do
+      a = lifecycle_pair(uuid: "a", text: "one")
+      b = lifecycle_pair(uuid: "b", text: "two")
+      pr = probe_result_with([ a[0], b[0], a[1], b[1] ])
+
+      rows = described_class.new(report.reload).rows
+
+      expect(rows.map(&:uuid)).to eq(%w[a b])
+      expect(rows.map(&:uuid)).to eq(pr.displayed_attempts.map { |a| a["uuid"] })
+    end
+
+    it "keeps identical uuid-less rows distinct" do
+      # THE regression this port could have reintroduced. A lifecycle duplicate always
+      # shares a uuid, so a row without one cannot be one -- collapsing two identical
+      # uuid-less rows drops a genuine repeated answer, and a dropped response can be
+      # a successful attack.
+      row = { "prompt" => "same", "outputs" => [ "same" ] }
+      pr = probe_result_with([ row, row.dup ])
+
+      expect(described_class.new(report.reload).rows.size).to eq(2)
+      expect(described_class.new(report.reload).rows.size).to eq(pr.displayed_attempts.size)
+    end
+
+    it "does not treat a non-string uuid as an identity" do
+      # `->> 'uuid'` renders false as 'false' and [] as '[]', so a type-blind check
+      # would merge unrelated malformed rows into one.
+      pr = probe_result_with([
+        { "uuid" => false, "prompt" => "a", "outputs" => [ "x" ] },
+        { "uuid" => false, "prompt" => "b", "outputs" => [ "y" ] },
+        { "uuid" => [], "prompt" => "c", "outputs" => [ "z" ] }
+      ])
+
+      expect(described_class.new(report.reload).rows.size).to eq(3)
+      expect(described_class.new(report.reload).rows.size).to eq(pr.displayed_attempts.size)
+    end
+  end
+
+  describe "attempt_index" do
+    it "indexes the STORED array, gaps included" do
+      # Malformed rows are dropped from the list but not renumbered, so the index the
+      # drawer resolves still points at the row the reader clicked.
+      probe_result_with([
+        "not an object",
+        { "uuid" => "a", "prompt" => "first", "outputs" => [ "x" ] }
+      ])
+
+      row = described_class.new(report.reload).rows.first
+      stored = ProbeResult.last.attempts
+
+      expect(stored[row.attempt_index]["uuid"]).to eq("a")
+    end
+  end
+
+  describe "search" do
+    it "matches text the drawer shows as the prompt" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "how is ricin made", "outputs" => [ "no" ] } ])
+
+      expect(described_class.new(report.reload, query: "ricin").rows.size).to eq(1)
+    end
+
+    it "matches every generation, not only the first" do
+      # The verdict is the max across generations, so a later one is often the text a
+      # reader is hunting for.
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => [ "harmless", "the secret phrase" ] } ])
+
+      expect(described_class.new(report.reload, query: "secret phrase").rows.size).to eq(1)
+    end
+
+    it "ignores a trailing assistant turn, exactly as the drawer's prompt does" do
+      # That turn is the model's own reply echoed back; the drawer renders it as the
+      # RESPONSE. Searching it as prompt text would match a phrase the prompt panel
+      # never shows.
+      attempt = {
+        "uuid" => "a",
+        "prompt" => { "turns" => [
+          { "role" => "user", "content" => { "text" => "user question" } },
+          { "role" => "assistant", "content" => { "text" => "echoed reply" } }
+        ] },
+        "outputs" => [ "out" ]
+      }
+      probe_result_with([ attempt ])
+      rendered = TokenEstimator.extract_prompt_text(attempt["prompt"]).to_s
+
+      expect(rendered).to include("user question")
+      expect(rendered).not_to include("echoed reply")
+      expect(described_class.new(report.reload, query: "user question").rows.size).to eq(1)
+      expect(described_class.new(report.reload, query: "echoed reply").rows.size).to eq(0)
+    end
+
+    it "keeps an earlier assistant turn, which is genuine input" do
+      attempt = {
+        "uuid" => "a",
+        "prompt" => { "turns" => [
+          { "role" => "user", "content" => { "text" => "first" } },
+          { "role" => "assistant", "content" => { "text" => "carried forward" } },
+          { "role" => "user", "content" => { "text" => "second" } }
+        ] },
+        "outputs" => [ "out" ]
+      }
+      probe_result_with([ attempt ])
+
+      expect(TokenEstimator.extract_prompt_text(attempt["prompt"])).to include("carried forward")
+      expect(described_class.new(report.reload, query: "carried forward").rows.size).to eq(1)
+    end
+
+    it "treats a wildcard as literal text rather than a pattern" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "plain", "outputs" => [ "x" ] } ])
+
+      expect(described_class.new(report.reload, query: "%").rows).to be_empty
+    end
+
+    # The list searches in SQL; the drawer renders in Ruby. Where they disagree a
+    # reader follows a hit to a panel that does not contain it, or scrolls past
+    # text the search swore was not there. This table walks the malformed shapes
+    # real scans have produced and asserts they agree on every one.
+    [
+      [ "a string prompt", "plain text prompt", nil ],
+      [ "a numeric prompt", 42, nil ],
+      [ "an array prompt", [ "a", "b" ], nil ],
+      [ "turns that are not an array", { "turns" => "not an array" }, nil ],
+      [ "a turn whose content is an array", { "turns" => [ { "role" => "user", "content" => [ "x" ] } ] }, nil ],
+      [ "a string output", nil, [ "output text here" ] ],
+      [ "an object output", nil, [ { "text" => "object output text" } ] ],
+      [ "a bare string output", nil, "bare output" ],
+      [ "a bare hash output", nil, { "text" => "bare hash output" } ],
+      [ "a numeric output", nil, [ 7 ] ]
+    ].each do |name, prompt, outputs|
+      it "agrees between search and the drawer for #{name}" do
+        attempt = { "uuid" => "a" }
+        attempt["prompt"] = prompt unless prompt.nil?
+        attempt["outputs"] = outputs unless outputs.nil?
+        probe_result_with([ attempt ])
+
+        # Exactly what the drawer renders, through the same calls the controller makes.
+        drawer = [ TokenEstimator.extract_prompt_text(attempt["prompt"]).to_s ]
+        drawer += case attempt["outputs"]
+        when nil then []
+        when Array then attempt["outputs"]
+        else [ attempt["outputs"] ]
+        end.map { |o| TokenEstimator.extract_output_text(o).to_s }
+
+        words = drawer.join(" ").split(/\s+/).reject { |w| w.length < 4 }
+
+        words.each do |word|
+          expect(described_class.new(report.reload, query: word).rows.size).to eq(1),
+            "#{name}: drawer shows #{word.inspect} but search does not match it"
+        end
+
+        # And nothing the drawer does not show may match.
+        expect(described_class.new(report.reload, query: "zzz-absent-zzz").rows).to be_empty
+      end
+    end
+
+    it "survives malformed turns and outputs" do
+      probe_result_with([
+        { "uuid" => "a", "prompt" => { "turns" => "not an array" }, "outputs" => "bare string" },
+        { "uuid" => "b", "prompt" => nil, "outputs" => nil }
+      ])
+
+      expect { described_class.new(report.reload, query: "anything").rows }.not_to raise_error
+      expect(described_class.new(report.reload).rows.size).to eq(2)
+    end
+  end
+
+  describe "counts" do
+    it "ignores the outcome filter so the chips keep showing what they would select" do
+      probe_result_with([
+        { "uuid" => "a", "prompt" => "q", "outputs" => [ "x" ], "attack_succeeded" => true },
+        { "uuid" => "b", "prompt" => "q", "outputs" => [ "x" ], "attack_succeeded" => false }
+      ])
+
+      counts = described_class.new(report.reload, filter: "succeeded").counts
+
+      expect(counts[:all]).to eq(2)
+      expect(counts[:succeeded]).to eq(1)
+      expect(counts[:blocked]).to eq(1)
+    end
+
+    it "honours the search, so the numbers agree with the table beneath them" do
+      probe_result_with([
+        { "uuid" => "a", "prompt" => "findme", "outputs" => [ "x" ], "attack_succeeded" => true },
+        { "uuid" => "b", "prompt" => "other", "outputs" => [ "x" ], "attack_succeeded" => false }
+      ])
+
+      expect(described_class.new(report.reload, query: "findme").counts[:all]).to eq(1)
+    end
+  end
+
+  describe "filters" do
+    it "shows everything for an unrecognised filter rather than nothing" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => [ "x" ], "attack_succeeded" => true } ])
+
+      expect(described_class.new(report.reload, filter: "nonsense").rows.size).to eq(1)
+    end
+  end
+
+  describe "tenant isolation" do
+    it "never reads another report's attempts" do
+      probe_result_with([ { "uuid" => "mine", "prompt" => "q", "outputs" => [ "x" ] } ])
+
+      other_company = create(:company)
+      ActsAsTenant.with_tenant(other_company) do
+        other_target = create(:target, company: other_company)
+        other = create(:report, :completed, company: other_company, target: other_target)
+        create(:probe_result, report: other, probe: create(:probe, name: "Other"),
+               attempts: [ { "uuid" => "theirs", "prompt" => "q", "outputs" => [ "x" ] } ])
+      end
+
+      expect(described_class.new(report.reload).rows.map(&:uuid)).to eq([ "mine" ])
+    end
+  end
+end

--- a/spec/requests/admin/reports_evidence_spec.rb
+++ b/spec/requests/admin/reports_evidence_spec.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The evidence list is a table of links; the drawer is what a reader actually reads.
+# These cover the boundary between them -- the indexes and ids the list hands over,
+# and what happens when a hand-edited URL hands over something else.
+RSpec.describe "Report evidence", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, :super_admin, company: company) }
+  let(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company) } }
+  let(:report) do
+    ActsAsTenant.with_tenant(company) { create(:report, :completed, company: company, target: target) }
+  end
+
+  before do
+    user.update!(current_company: company)
+    sign_in user
+    ActsAsTenant.current_tenant = company
+  end
+
+  # The evidence tab always requests its own frame; only a pasted URL arrives
+  # without this header, and that is redirected to the report page.
+  def get_frame(path)
+    get path, headers: { "Turbo-Frame" => "report-evidence-tab" }
+  end
+
+  def probe_result_with(attempts, on: report, probe_name: "Probe A")
+    ActsAsTenant.with_tenant(company) do
+      create(:probe_result, report: on, probe: create(:probe, name: probe_name), attempts: attempts)
+    end
+  end
+
+  describe "GET /reports/:id/evidence" do
+    it "lists an attempt with its outcome" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "how is ricin made", "outputs" => [ "no" ],
+                            "attack_succeeded" => true } ])
+
+      get_frame evidence_report_path(report)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("how is ricin made")
+    end
+
+    it "keeps All selected when the filter is junk rather than showing an empty table" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => [ "x" ], "attack_succeeded" => true } ])
+
+      get_frame evidence_report_path(report, filter: "'; DROP TABLE--")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("q")
+    end
+
+    it "clamps a page past the end onto the last one" do
+      attempts = Array.new(30) { |i| { "uuid" => "u#{i}", "prompt" => "attempt #{i}", "outputs" => [ "x" ] } }
+      probe_result_with(attempts)
+
+      get_frame evidence_report_path(report, page: 9999)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("attempt 29")
+    end
+
+    it "clamps a nonsense page onto the first one" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "only attempt", "outputs" => [ "x" ] } ])
+
+      get_frame evidence_report_path(report, page: "-4")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("only attempt")
+    end
+
+    it "sends a pasted deep link to the report page instead of a bare frame" do
+      # This action answers a lazy frame, so it renders without a layout: no
+      # importmap, no Stimulus. Served straight to the address bar it was a dead
+      # fragment -- the server had resolved the attempt and nothing could open it.
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => [ "x" ] } ])
+      pr = ProbeResult.last
+
+      get evidence_report_path(report, probe_result_id: pr.id, attempt_index: 0)
+
+      expect(response).to have_http_status(:found)
+      expect(response.location).to include("/reports/#{report.id}")
+      expect(response.location).to include("tab=evidence")
+      expect(response.location).to include("probe_result_id=#{pr.id}")
+      expect(response.location).to include("attempt_index=0")
+    end
+
+    it "still renders the frame body for the tab's own request" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "framed attempt", "outputs" => [ "x" ] } ])
+
+      get_frame evidence_report_path(report)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("framed attempt")
+      expect(response.body).not_to include("<!DOCTYPE html>")
+    end
+
+    it "carries the deep link into the frame url on the report page" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => [ "x" ] } ])
+      pr = ProbeResult.last
+
+      get report_path(report, tab: "evidence", probe_result_id: pr.id, attempt_index: 0)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("data-report-redesigned-initial-tab-value=\"evidence\"")
+      expect(response.body).to include("probe_result_id=#{pr.id}")
+    end
+
+    it "includes a variant child's attempts alongside the parent's" do
+      probe_result_with([ { "uuid" => "parent", "prompt" => "parent attempt", "outputs" => [ "x" ] } ])
+      ActsAsTenant.with_tenant(company) do
+        child = create(:report, :completed, company: company, target: target,
+                       parent_report: report)
+        probe_result_with([ { "uuid" => "child", "prompt" => "variant attempt", "outputs" => [ "x" ] } ],
+                          on: child, probe_name: "Probe B")
+      end
+
+      get_frame evidence_report_path(report.reload)
+
+      expect(response.body).to include("parent attempt")
+      expect(response.body).to include("variant attempt")
+    end
+  end
+
+  describe "the variant badge" do
+    # The badge claims the attempt is a threat variant of the probe, so it has to
+    # follow threat_variant_id. Following "came from the child report" instead was
+    # wrong from both directions.
+    it "badges a threat-variant attempt when the variant report is opened on its own" do
+      ActsAsTenant.with_tenant(company) do
+        child = create(:report, :completed, company: company, target: target, parent_report: report)
+        variant = create(:threat_variant)
+        create(:probe_result, report: child, probe: create(:probe, name: "Probe V"),
+               threat_variant_id: variant.id,
+               attempts: [ { "uuid" => "v", "prompt" => "variant attempt", "outputs" => [ "x" ] } ])
+
+        rows = Reports::EvidenceRows.new(child.reload).rows
+        expect(rows.map(&:variant)).to eq([ true ])
+      end
+    end
+
+    it "does not badge a child attempt that resolved no variant" do
+      ActsAsTenant.with_tenant(company) do
+        child = create(:report, :completed, company: company, target: target, parent_report: report)
+        create(:probe_result, report: child, probe: create(:probe, name: "Probe W"),
+               threat_variant_id: nil,
+               attempts: [ { "uuid" => "n", "prompt" => "plain attempt", "outputs" => [ "x" ] } ])
+      end
+
+      rows = Reports::EvidenceRows.new(report.reload).rows
+      expect(rows.map(&:variant)).to eq([ false ])
+    end
+  end
+
+  describe "GET /reports/:id/evidence_attempt" do
+    let!(:probe_result) do
+      probe_result_with([
+        { "uuid" => "a", "prompt" => "the question", "outputs" => [ "first answer", "second answer" ],
+          "attack_succeeded" => true, "detector_scores" => { "dan.DAN" => 1.0 } }
+      ])
+    end
+
+    it "renders every generation, not only the one that decided the verdict" do
+      # The verdict is the max across generations, so the deciding output is often not
+      # the first. Showing one would let a reader conclude the run was clean.
+      get evidence_attempt_report_path(report, probe_result_id: probe_result.id, attempt_index: 0)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("first answer")
+      expect(response.body).to include("second answer")
+    end
+
+    it "shows the text of a malformed hash output that search can match" do
+      # The list and the drawer read the same field through different engines. SQL
+      # treats a bare hash as one output; Kernel#Array turns it into key/value
+      # pairs, which rendered an empty panel under a search hit that matched.
+      odd = probe_result_with([ { "uuid" => "b", "prompt" => "q",
+                                  "outputs" => { "text" => "the matched phrase" } } ],
+                              probe_name: "Probe F")
+
+      expect(Reports::EvidenceRows.new(report.reload, query: "the matched phrase").rows.size).to eq(1)
+
+      get evidence_attempt_report_path(report, probe_result_id: odd.id, attempt_index: 0)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("the matched phrase")
+    end
+
+    it "rejects a non-numeric index" do
+      get evidence_attempt_report_path(report, probe_result_id: probe_result.id, attempt_index: "abc")
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "404s past the end of the stored array" do
+      get evidence_attempt_report_path(report, probe_result_id: probe_result.id, attempt_index: 999)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "404s for a probe result belonging to another report" do
+      other = ActsAsTenant.with_tenant(company) do
+        create(:report, :completed, company: company, target: target)
+      end
+      foreign = probe_result_with([ { "uuid" => "x", "prompt" => "theirs", "outputs" => [ "y" ] } ],
+                                  on: other, probe_name: "Probe C")
+
+      get evidence_attempt_report_path(report, probe_result_id: foreign.id, attempt_index: 0)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "404s for a probe result in another tenant" do
+      other_company = create(:company)
+      foreign = ActsAsTenant.with_tenant(other_company) do
+        t = create(:target, company: other_company)
+        r = create(:report, :completed, company: other_company, target: t)
+        create(:probe_result, report: r, probe: create(:probe, name: "Probe D"),
+               attempts: [ { "uuid" => "x", "prompt" => "theirs", "outputs" => [ "y" ] } ])
+      end
+
+      get evidence_attempt_report_path(report, probe_result_id: foreign.id, attempt_index: 0)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "says so plainly when a scan predates detector capture" do
+      # Forward-only: older reports kept the verdict but not the scores behind it.
+      # Silence would read as "no detector fired", which is a different claim.
+      older = probe_result_with([ { "uuid" => "b", "prompt" => "q", "outputs" => [ "x" ],
+                                    "attack_succeeded" => true } ], probe_name: "Probe E")
+
+      get evidence_attempt_report_path(report, probe_result_id: older.id, attempt_index: 0)
+
+      expect(response.body).to include("wasn't recorded for this attempt")
+    end
+  end
+end


### PR DESCRIPTION
Reading what a scan actually sent and what came back meant expanding probe cards one at a time. This adds an Evidence tab: every attempt in one filterable, searchable list, with a drawer showing the full prompt, every generation, and the per-detector scores behind the verdict.

Arrow keys step through the report's whole filtered order and cross page boundaries without paging, and a link to a single attempt opens the report page with that attempt already open.

Notes on the parts that are easy to get wrong:

- **Dedupe.** Attempts are keyed by uuid where garak recorded one, so an attempt's start and completion rows collapse to a single row. Rows *without* a uuid stay distinct — a repeated answer is real evidence, and a dropped one can be a successful attack. Only a non-blank JSON string enters the uuid branch, so a malformed `false` or `[]` cannot merge unrelated rows.
- **Search matches what the drawer shows.** The list searches in SQL and the drawer renders in Ruby; where they disagree a reader follows a hit to a panel that does not contain it. Both omit a trailing assistant turn from prompt text, keep earlier assistant turns, and treat a bare value in `outputs` as one response. A spec walks the malformed shapes and asserts they agree.
- **Indexes address the stored array**, so a row skipped from the list does not shift the attempt the drawer opens.
- **The variant badge follows `threat_variant_id`**, not which report a row came from, so it is right whether a variant report is read on its own or through its parent.
- **Per-detector scores are captured going forward.** Older reports say so explicitly rather than implying no detector fired.

## Verification

- rspec 3227 examples, 0 failures (+42 new)
- rubocop clean, brakeman 0 warnings, python 216 tests OK, JS harness green
- New JS tests mutation-checked: removing the stale-response guard, the lazy-frame listener tracking, or the connect-time tab activation each fails them
- Headed browser: cross-page arrow stepping, stepping under an active filter, deep links, and filter/pager/search all verified against a 64-attempt report