### PR TITLE
perf(scans): stop the new-scan form loading every threat variant

### DIFF
--- a/app/controllers/admin/scans_controller.rb
+++ b/app/controllers/admin/scans_controller.rb
@@ -254,12 +254,20 @@ module Admin
       @probe_categories = @probe_categories.sort.to_h
       @community_categories = @community_categories.sort.to_h
 
-      # Load threat variant industries with subindustries (engine-only model)
+      # Threat-variant picker data (engine-only models).
+      #
+      # The picker renders industry and subindustry names and one checkbox each.
+      # It never reads a variant, so the eager load of every variant and its
+      # probe built two object graphs that were then discarded.
       @threat_variant_industries = if defined?(ThreatVariantIndustry)
-        ThreatVariantIndustry.includes(threat_variant_subindustries: { threat_variants: :probe }).all
+        ThreatVariantIndustry.includes(:threat_variant_subindustries).all
       else
         []
       end
+
+      # Resolved once rather than per checkbox: the view asked
+      # scan.threat_variant_subindustries.include?(subindustry) for every row.
+      @selected_subindustry_ids = @scan&.persisted? ? @scan.threat_variant_subindustry_ids.to_set : Set.new
     end
   end
 end

--- a/app/views/admin/scans/_form.html.erb
+++ b/app/views/admin/scans/_form.html.erb
@@ -143,7 +143,9 @@
 
   <!-- Threat Variants Section (only when variant infrastructure is available) -->
   <% if @threat_variant_industries.present? %>
-    <%= render "threat_variants", f: f, scan: @scan, threat_variant_industries: @threat_variant_industries %>
+    <%= render "threat_variants", f: f, scan: @scan,
+          threat_variant_industries: @threat_variant_industries,
+          selected_subindustry_ids: @selected_subindustry_ids %>
   <% end %>
 
   <!-- Schedule Configuration -->

--- a/app/views/admin/scans/_threat_variants.html.erb
+++ b/app/views/admin/scans/_threat_variants.html.erb
@@ -87,14 +87,10 @@
            } %>
 
         <% threat_variant_industries.each do |industry| %>
-          <% industry_probe_ids = industry.threat_variant_subindustries
-               .flat_map { |sub| sub.threat_variants.pluck(:probe_id) }
-               .uniq %>
           <% industry_key = industry.name.downcase %>
           <% config = industry_configs[industry_key] || { icon: "📁", color: "blue" } %>
 
           <div class="industry-item border border-borderPrimary rounded-lg overflow-hidden hover:border-primary/50 transition-all"
-               data-probe-ids="<%= industry_probe_ids.join(',') %>"
                data-industry-id="<%= industry.id %>"
                data-industry-name="<%= industry.name %>"
                data-threat-variants-target="industryItem">
@@ -122,7 +118,7 @@
                     <div class="flex-1">
                       <h5 class="text-base font-semibold text-contentPrimary"><%= industry.name.humanize %></h5>
                       <p class="text-xs text-contentTertiary">
-                        <%= industry.threat_variant_subindustries.count %> specialized categories
+                        <%= industry.threat_variant_subindustries.size %> specialized categories
                       </p>
                     </div>
                   </div>
@@ -141,14 +137,12 @@
               <div class="p-4 border-t border-borderPrimary">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                   <% industry.threat_variant_subindustries.each do |subindustry| %>
-                    <% subindustry_probe_ids = subindustry.threat_variants.pluck(:probe_id).uniq %>
                     <div class="subindustry-item flex items-center gap-3 p-3 bg-backgroundSecondary rounded-md hover:bg-backgroundSecondary/80 transition-colors"
-                         data-probe-ids="<%= subindustry_probe_ids.join(',') %>"
                          data-industry-id="<%= industry.id %>"
                          data-industry-name="<%= industry.name %>"
                          data-subindustry-id="<%= subindustry.id %>"
                          data-threat-variants-target="subindustryItem">
-                      <% is_checked = scan.persisted? && scan.threat_variant_subindustries.include?(subindustry) %>
+                      <% is_checked = selected_subindustry_ids.include?(subindustry.id) %>
                       <%= check_box_tag "scan[threat_variant_subindustry_ids][]",
                           subindustry.id,
                           is_checked,

--- a/spec/requests/admin/scan_form_threat_variants_spec.rb
+++ b/spec/requests/admin/scan_form_threat_variants_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The scan form's variant picker renders one checkbox per subindustry, each
+# carrying the probe ids it selects. Those ids are all the form needs, so it
+# must not pay to load the variant rows or their probes to produce them.
+RSpec.describe "New scan form threat variants", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, :super_admin, company: company) }
+
+  before do
+    user.update!(current_company: company)
+    sign_in user
+    ActsAsTenant.current_tenant = company
+  end
+
+  def build_variants(industry_name, subindustries: 2, variants_each: 2)
+    industry = create(:threat_variant_industry, name: industry_name)
+    subindustries.times.map do |i|
+      sub = create(:threat_variant_subindustry, threat_variant_industry: industry,
+                   name: "#{industry_name}-sub-#{i}")
+      variants_each.times do |j|
+        create(:threat_variant, threat_variant_subindustry: sub,
+               probe: create(:probe), prompt: "#{industry_name} prompt #{i}-#{j}")
+      end
+      sub
+    end
+  end
+
+  it "renders a checkbox per subindustry" do
+    subs = build_variants("automotive")
+
+    get new_scan_path
+
+    expect(response).to have_http_status(:ok)
+    subs.each { |sub| expect(response.body).to include("data-subindustry-id=\"#{sub.id}\"") }
+  end
+
+  it "does not render probe ids the page never reads" do
+    # data-probe-ids was rendered on every industry and subindustry row and read
+    # by nothing -- no Stimulus controller, no script, no test. Producing it was
+    # the only reason the form loaded threat variants at all.
+    build_variants("mining")
+
+    get new_scan_path
+
+    expect(response.body).not_to include("data-probe-ids")
+  end
+
+  it "does not load threat variant rows to render the picker" do
+    # The picker renders names and checkboxes. Instantiating the variants -- and
+    # the probes behind them -- is work whose result is thrown away.
+    build_variants("energy", subindustries: 3, variants_each: 3)
+
+    loaded = 0
+    subscriber = ActiveSupport::Notifications.subscribe("instantiation.active_record") do |*, payload|
+      loaded += payload[:record_count].to_i if payload[:class_name] == "ThreatVariant"
+    end
+
+    get new_scan_path
+
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+    expect(loaded).to eq(0)
+  end
+
+  it "does not load the probes behind the variants either" do
+    build_variants("aviation", subindustries: 2, variants_each: 2)
+
+    loaded = 0
+    subscriber = ActiveSupport::Notifications.subscribe("instantiation.active_record") do |*, payload|
+      loaded += payload[:record_count].to_i if payload[:class_name] == "Probe"
+    end
+
+    get new_scan_path
+
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+    # The probe list has its own section that legitimately loads probes, so this
+    # asserts only that the variant picker adds none of its own.
+    expect(loaded).to eq(Probe.count)
+  end
+
+  it "still renders a checkbox for a subindustry with no variants" do
+    industry = create(:threat_variant_industry, name: "finance")
+    empty = create(:threat_variant_subindustry, threat_variant_industry: industry, name: "empty")
+
+    get new_scan_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("data-subindustry-id=\"#{empty.id}\"")
+  end
+
+  it "ticks the subindustries an existing scan already selected" do
+    subs = build_variants("healthcare")
+    scan = ActsAsTenant.with_tenant(company) do
+      create(:complete_scan, company: company).tap { |s| s.threat_variant_subindustries = [ subs.first ] }
+    end
+
+    get edit_scan_path(scan)
+
+    expect(response).to have_http_status(:ok)
+    checked = response.body[/<input[^>]*value="#{subs.first.id}"[^>]*>/]
+    expect(checked).to include("checked")
+  end
+
+  it "leaves the other subindustries unticked" do
+    subs = build_variants("retail")
+    scan = ActsAsTenant.with_tenant(company) do
+      create(:complete_scan, company: company).tap { |s| s.threat_variant_subindustries = [ subs.first ] }
+    end
+
+    get edit_scan_path(scan)
+
+    unchecked = response.body[/<input[^>]*value="#{subs.last.id}"[^>]*>/]
+    expect(unchecked).not_to include("checked")
+  end
+
+  it "ticks nothing on a brand new scan" do
+    build_variants("logistics")
+
+    get new_scan_path
+
+    expect(response.body.scan(/checked="checked"/).size).to eq(0)
+  end
+end


### PR DESCRIPTION
The threat-variant picker on the new-scan form renders industry and subindustry names with a checkbox each. To build a `data-probe-ids` attribute on every row it also eager-loaded every threat variant along with its probe, materializing two object graphs to produce a string.

Nothing reads that attribute — no Stimulus controller, no script, no test. Probe eligibility is driven by `data-variant-eligible` on the probe list instead, which is why selecting a variant-eligible probe is what enables the picker. So the attribute is gone and the load is now just industries and their subindustries.

On a dev dataset of 9 industries, 34 subindustries and 204 variants, the picker's data drops from **72.1ms to 5.2ms**. The selected subindustries are also resolved once into a Set rather than asking the scan for its association on every checkbox.

## Verification

- rspec 3235 examples, 0 failures (+8 new); rubocop clean; brakeman 0 warnings
- Three of the new specs fail on the old code: the dead attribute is gone, no `ThreatVariant` rows are instantiated, and no extra `Probe` rows are either
- Headed browser: 9 industries / 34 subindustries render as before, and selecting a variant-eligible probe still enables all 34 subindustry checkboxes and toggling still works