### PR TITLE
feat(reports): add a JSON export for reports

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -361,6 +361,64 @@ module Admin
       render layout: false
     end
 
+    # Downloads the whole report -- prompts, responses and per-attempt verdicts --
+    # as JSON.
+    #
+    # Spooled to a tempfile before any header goes out, rather than streamed
+    # straight to the response. Streaming would commit a 200 with the first chunk,
+    # before a single probe_result had been read, so anything failing part-way
+    # through would hand the reader a truncated file that still looked like a
+    # successful download. Buffering costs the wait but makes a failure a 500.
+    #
+    # Scoped explicitly by company as well as through policy_scope: tenancy is not
+    # required app-wide, so a nil ambient tenant makes the policy scope span every
+    # company. This action names the constraint rather than inheriting it.
+    def json_export
+      company = current_company
+      raise ActiveRecord::RecordNotFound if company.nil?
+
+      @report = policy_scope(Report).where(company_id: company.id).find(params[:id])
+      authorize @report, :json_export?
+
+      spool = Tempfile.new([ "report_export", ".json" ], binmode: true)
+      Reports::JsonExportPayload.new(@report).each { |chunk| spool.write(chunk) }
+      spool.flush
+      spool.rewind
+
+      filename = "report_#{@report.uuid}_#{@report.created_at.strftime('%Y-%m-%d')}.json"
+      # The export carries prompts and model responses, so it must not be held by
+      # a shared cache on the way to the reader.
+      response.headers["Cache-Control"] = "no-store"
+      send_file_headers! type: "application/json", disposition: "attachment", filename: filename
+      response.headers["Content-Length"] = spool.size.to_s
+      self.response_body = SpooledFileBody.new(spool)
+    end
+
+    # Streams the spooled file and removes it once the server is done with it,
+    # whether the download completed or the connection dropped. Rack calls close
+    # on the body in both cases; without it a failed download would leave the
+    # tempfile behind until the process exited.
+    class SpooledFileBody
+      CHUNK = 64 * 1024
+
+      def initialize(file)
+        @file = file
+      end
+
+      def each
+        while (chunk = @file.read(CHUNK))
+          yield chunk
+        end
+      end
+
+      def close
+        @file.close
+        @file.unlink
+      rescue IOError, Errno::ENOENT
+        nil
+      end
+    end
+
     def top_probes
       authorize @report
       # Get top 5 most vulnerable probes for this report

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -21,6 +21,10 @@ class ReportPolicy < TenantScopedPolicy
     true
   end
 
+  def json_export?
+    show?
+  end
+
   def evidence?
     true
   end

--- a/app/services/reports/json_export_payload.rb
+++ b/app/services/reports/json_export_payload.rb
@@ -1,0 +1,277 @@
+# frozen_string_literal: true
+
+module Reports
+  # Serializes a report to JSON for the "Export to JSON" download.
+  #
+  # The document is a list of RUNS, not a flat list of probes. A scan with
+  # threat variants executes twice -- a primary run and a variant child run --
+  # and each run has its own scores, its own detector totals and its own probe
+  # results. Flattening the child's attempts into the parent's probe rows loses
+  # facts that cannot be recovered downstream:
+  #
+  #   * a probe row would declare the parent's passed/total beside a list of
+  #     attempts drawn from both runs, so the counts and the evidence disagree
+  #   * the child's own passed/total and detector totals disappear
+  #   * a child probe_result whose probe has no parent counterpart vanishes
+  #     entirely, and the file still looks complete
+  #
+  # A consumer cannot rebuild those counts from the attempts, because the
+  # evaluated total is not the number of attempts shown -- provider filtering
+  # and partial processing move them apart. So each run is emitted whole and a
+  # consumer that wants the flat view the report page shows can build it with
+  # runs.flat_map { |r| r[:probe_results].flat_map { |p| p[:attempts] } }.
+  #
+  # Emitted as a sequence of chunks rather than one Hash so the whole document
+  # is never held in memory at once. This bounds the ActiveRecord ROWS held at
+  # once, not total memory: each row drags its full attempts jsonb along, and
+  # that is decoded the moment the row loads. BATCH_SIZE caps rows, not bytes.
+  #
+  # The caller is expected to spool this to a file before sending headers. Do
+  # not assign it straight to a Rack response body: the first chunk goes out
+  # before any probe_result has been read, so a failure part-way through would
+  # commit a 200 and then truncate, handing the reader a corrupt download that
+  # looks like a success.
+  class JsonExportPayload
+    include Enumerable
+
+    SCHEMA_VERSION = 1
+
+    # How many probe_result ROWS are held at once. See the class comment for
+    # what this does and does not bound.
+    BATCH_SIZE = 25
+
+    attr_reader :report
+
+    def initialize(report)
+      @report = report
+    end
+
+    # Yields the JSON document as a sequence of strings.
+    def each
+      return enum_for(:each) unless block_given?
+
+      yield %({"schema_version":#{SCHEMA_VERSION})
+      yield %(,"exported_at":#{Time.current.iso8601.to_json})
+
+      yield %(,"runs":[)
+      runs.each_with_index do |run, position|
+        yield "," unless position.zero?
+        emit_run(run) { |chunk| yield chunk }
+      end
+      yield "]}"
+    end
+
+    private
+
+    # The report asked for, plus its variant child when it has one. Exporting a
+    # child directly yields just that child, so a variant run is never described
+    # as a primary one.
+    def runs
+      [ report, variant_child_report ].compact
+    end
+
+    def emit_run(run)
+      head = {
+        role: run.parent_report_id.present? ? "variant" : "primary",
+        report: report_metadata(run),
+        target: target_metadata(run),
+        scores: scores(run),
+        detectors: detector_breakdown(run)
+      }
+
+      yield %(#{head.to_json.chop},"probe_results":[)
+      first = true
+      each_probe_result(run) do |probe_result|
+        yield "," unless first
+        first = false
+        emit_probe_row(probe_result) { |chunk| yield chunk }
+      end
+      yield "]}"
+    end
+
+    def report_metadata(run)
+      {
+        id: run.id,
+        uuid: run.uuid,
+        parent_report_id: run.parent_report_id,
+        status: run.status,
+        created_at: run.created_at.iso8601,
+        started_at: run.start_time&.iso8601,
+        completed_at: run.end_time&.iso8601,
+        result_completeness: run.result_completeness
+      }
+    end
+
+    # Resolved through Report#historical_target, which reads Target.with_deleted:
+    # Target's default scope hides soft-deleted rows, so `run.target` is nil for
+    # an archived target and dereferencing it would 500 an export the report page
+    # still offers.
+    #
+    # historical_target can itself return nil -- it bails on a blank target_id or
+    # company -- so every field stays nullable and the name falls back to the
+    # same constant the rest of the app shows.
+    def target_metadata(run)
+      target = run.historical_target
+
+      {
+        id: target&.id,
+        name: target&.name || Report::UNKNOWN_TARGET_NAME,
+        model: target&.model,
+        model_type: target&.model_type
+      }
+    end
+
+    def scores(run)
+      total = run.cached_total
+
+      {
+        passed: run.cached_passed,
+        total: total,
+        asr: asr(run.cached_passed, total)
+      }
+    end
+
+    # nil, not 0.0, when nothing was measurable. 0.0 asserts "measured, nothing
+    # succeeded"; a report whose every prompt was provider-filtered measured
+    # nothing at all, and reporting that as 0% reads as a perfectly defended
+    # target. Mirrors Reports::AsrFigure, which keeps the two apart for the UI.
+    def asr(passed, total)
+      return nil if total.to_i.zero?
+
+      (passed.to_f / total * 100).round(2)
+    end
+
+    # Ordered by name so two exports of the same report are byte-identical apart
+    # from exported_at. detector_results comes back in whatever order the table
+    # yields, which is not a contract a consumer diffing exports can rely on.
+    def detector_breakdown(run)
+      run.detector_results.map { |dr|
+        {
+          name: detector_names[dr.detector_id] || "Unknown",
+          passed: dr.passed,
+          total: dr.total,
+          asr: asr(dr.passed, dr.total)
+        }
+      }.sort_by { |row| [ row[:name], row[:total].to_i, row[:passed].to_i ] }
+    end
+
+    # Resolves detector names through with_deleted so retired detectors still
+    # appear with their real name rather than nil, across every run, so two runs
+    # never disagree about one detector's display name.
+    #
+    # The probe_result ids come from a pluck rather than from loaded rows: going
+    # through the association would materialize every probe_result -- attempts
+    # jsonb included -- before the first chunk was built.
+    def detector_names
+      @detector_names ||= begin
+        ids = runs.flat_map { |run|
+          run.probe_results.distinct.pluck(:detector_id) + run.detector_results.map(&:detector_id)
+        }.compact.uniq
+
+        ids.any? ? Detector.with_deleted.where(id: ids).pluck(:id, :name).to_h : {}
+      end
+    end
+
+    def each_probe_result(run, &block)
+      # No explicit order: find_each forces primary-key order and warns about any
+      # scope that disagrees, and primary-key order is what we want anyway.
+      run.probe_results
+         .includes(:probe, threat_variant: [ :threat_variant_industry, :threat_variant_subindustry ])
+         .find_each(batch_size: BATCH_SIZE, &block)
+    end
+
+    # A probe row goes out in pieces rather than as one serialized Hash, so a
+    # probe's attempts are never all held at once. `chop` drops the head object's
+    # closing brace so `"attempts"` can be appended to it; the head always has
+    # keys, so it is never the empty object.
+    def emit_probe_row(probe_result)
+      yield %(#{probe_head(probe_result).to_json.chop},"attempts":[)
+
+      probe_result.displayed_attempts.each_with_index do |attempt, index|
+        row = serialized_attempt(attempt, index)
+        yield index.zero? ? row.to_json : ",#{row.to_json}"
+      end
+
+      yield "]}"
+    end
+
+    # passed/total/asr describe this probe_result, and the attempts beneath it
+    # come from the same row, so the counts and the evidence always refer to the
+    # same measurement. The variant a row belongs to is named here rather than
+    # per attempt, because it is a property of the result.
+    def probe_head(probe_result)
+      {
+        probe_name: probe_result.probe&.name || "Unknown",
+        probe_guid: probe_result.probe&.guid,
+        detector_name: detector_names[probe_result.detector_id] || "Unknown",
+        passed: probe_result.passed,
+        total: probe_result.total,
+        asr: asr(probe_result.passed, probe_result.total),
+        variant: variant_metadata(probe_result)
+      }
+    end
+
+    def variant_metadata(probe_result)
+      return nil if probe_result.threat_variant_id.blank?
+
+      threat_variant = probe_result.threat_variant
+      return nil if threat_variant.nil?
+
+      # Machine-readable rather than the "Industry / Subindustry" label the UI
+      # builds, so a consumer can group without parsing a display string.
+      {
+        threat_variant_id: threat_variant.id,
+        industry: threat_variant.threat_variant_industry&.name,
+        subindustry: threat_variant.threat_variant_subindustry&.name
+      }
+    end
+
+    # De-duplicated through the same rule the report page and the evidence tab
+    # use: garak writes an attempt twice (start + completion) sharing one uuid,
+    # so rows sharing a uuid collapse and rows without one stay distinct. See
+    # ProbeResult#displayed_attempts. A uuid-less row cannot be a lifecycle copy,
+    # and dropping one loses a real response -- which can be a successful attack.
+    #
+    # Carries the per-attempt verdict through: Reports::Process records
+    # attack_succeeded (tri-state -- nil means garak scored nothing) and
+    # detector_scores on every attempt. Without them an export of a safety scan
+    # ships every prompt and response but cannot say which attacks succeeded.
+    # The rest of `notes` is deliberately left out: it is unbounded garak
+    # payload, and score_percentage is the only part the UI reads.
+    def serialized_attempt(attempt, index)
+      {
+        index: index,
+        uuid: attempt["uuid"],
+        prompt: attempt["prompt"],
+        attack_succeeded: attempt["attack_succeeded"],
+        detector_scores: attempt["detector_scores"],
+        score_percentage: attempt.dig("notes", "score_percentage"),
+        outputs: attempt_outputs(attempt["outputs"]).each_with_index.map do |output, output_index|
+          {
+            index: output_index,
+            response: output
+          }
+        end
+      }
+    end
+
+    # Kernel#Array is the wrong wrapper for a malformed outputs value: a hash
+    # becomes its key/value pairs, so a { "text" => ... } output would export as
+    # two bogus responses. This matches what the evidence tab shows for the same
+    # attempt, so the export and the UI never disagree about an attempt's
+    # responses.
+    def attempt_outputs(outputs)
+      case outputs
+      when nil then []
+      when Array then outputs
+      else [ outputs ]
+      end
+    end
+
+    def variant_child_report
+      return @variant_child_report if defined?(@variant_child_report)
+
+      @variant_child_report = report.has_variant_data? ? report.child_report : nil
+    end
+  end
+end

--- a/app/views/admin/reports/_report_header.html.erb
+++ b/app/views/admin/reports/_report_header.html.erb
@@ -29,6 +29,17 @@
       color: :gray,
       size: :base
     }
+    if policy(report).json_export?
+      action_buttons << {
+        label: "Export to JSON",
+        path: json_export_report_path(report),
+        data: { turbo: false },
+        icon: "icon-code",
+        variant: :default,
+        color: :gray,
+        size: :base
+      }
+    end
   end
 
   # Stop/Cancel button for running states

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
         get :probes_tab
         get :evidence
         get :evidence_attempt
+        get :json_export
         get :probe_attempts
         get :progress
         get :attempt_content

--- a/spec/requests/admin/reports_json_export_spec.rb
+++ b/spec/requests/admin/reports_json_export_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Report JSON export", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, :super_admin, company: company) }
+  let(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company) } }
+  let(:report) do
+    ActsAsTenant.with_tenant(company) { create(:report, :completed, company: company, target: target) }
+  end
+
+  before do
+    user.update!(current_company: company)
+    sign_in user
+    ActsAsTenant.current_tenant = company
+  end
+
+  def seed_attempt
+    ActsAsTenant.with_tenant(company) do
+      create(:probe_result, report: report, probe: create(:probe, name: "Export probe"),
+             attempts: [ { "uuid" => "a", "prompt" => "how is it made", "outputs" => [ "no" ],
+                           "attack_succeeded" => true } ])
+    end
+  end
+
+  it "downloads the report as parseable JSON" do
+    seed_attempt
+
+    get json_export_report_path(report)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq("application/json")
+    doc = JSON.parse(response.body)
+    expect(doc["runs"].first["probe_results"].first["attempts"].first["prompt"]).to eq("how is it made")
+  end
+
+  it "offers the file as a download named for the report" do
+    seed_attempt
+
+    get json_export_report_path(report)
+
+    expect(response.headers["Content-Disposition"]).to include("attachment")
+    expect(response.headers["Content-Disposition"]).to include(report.uuid)
+  end
+
+  it "sends a complete body with a length rather than an open-ended stream" do
+    # The export is buffered before any header goes out. Streaming would commit a
+    # 200 with the first chunk, before a single probe_result had been read, so a
+    # failure part-way through would hand the reader a truncated file that still
+    # looked like a successful download.
+    seed_attempt
+
+    get json_export_report_path(report)
+
+    expect(response.headers["Content-Length"].to_i).to eq(response.body.bytesize)
+    expect(response.headers["Content-Length"].to_i).to be > 0
+  end
+
+  it "tells caches not to keep it" do
+    # The file carries prompts and model responses.
+    seed_attempt
+
+    get json_export_report_path(report)
+
+    expect(response.headers["Cache-Control"]).to include("no-store")
+  end
+
+  it "leaves no spool file behind" do
+    seed_attempt
+    before_count = Dir.glob(File.join(Dir.tmpdir, "report_export*.json")).size
+
+    get json_export_report_path(report)
+    response.body
+
+    expect(Dir.glob(File.join(Dir.tmpdir, "report_export*.json")).size).to eq(before_count)
+  end
+
+  it "404s for a report in another tenant" do
+    other_company = create(:company)
+    foreign = ActsAsTenant.with_tenant(other_company) do
+      t = create(:target, company: other_company)
+      create(:report, :completed, company: other_company, target: t)
+    end
+
+    get json_export_report_path(foreign)
+
+    expect(response).to have_http_status(:not_found)
+    # Not served as a download, and not a JSON body: the other tenant's report
+    # is simply not reachable from here.
+    expect(response.headers["Content-Disposition"]).to be_nil
+    expect(response.media_type).not_to eq("application/json")
+  end
+
+  it "redirects an anonymous visitor to sign in" do
+    sign_out user
+
+    get json_export_report_path(report)
+
+    expect(response).to have_http_status(:found)
+    expect(response.location).to include("/login")
+  end
+
+  it "offers the button on a report with results" do
+    seed_attempt
+
+    get report_path(report)
+
+    expect(response.body).to include("Export to JSON")
+    expect(response.body).to include(json_export_report_path(report))
+  end
+end

--- a/spec/services/reports/json_export_payload_spec.rb
+++ b/spec/services/reports/json_export_payload_spec.rb
@@ -1,0 +1,330 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reports::JsonExportPayload do
+  let(:company) { create(:company) }
+  let(:target) { ActsAsTenant.with_tenant(company) { create(:target, company: company) } }
+  let(:report) do
+    ActsAsTenant.with_tenant(company) { create(:report, :completed, company: company, target: target) }
+  end
+
+  def export(record = report)
+    JSON.parse(described_class.new(record.reload).each.to_a.join)
+  end
+
+  def primary(doc)
+    doc["runs"].find { |run| run["role"] == "primary" }
+  end
+
+  def variant_run(doc)
+    doc["runs"].find { |run| run["role"] == "variant" }
+  end
+
+  def probe_result_with(attempts, on: report, probe_name: "Probe A", **attrs)
+    ActsAsTenant.with_tenant(company) do
+      create(:probe_result, report: on, probe: create(:probe, name: probe_name),
+             attempts: attempts, **attrs)
+    end
+  end
+
+  # Builds a scan that ran twice: a primary run and a variant child run.
+  def with_variant_child(child_probe_names: [])
+    ActsAsTenant.with_tenant(company) do
+      child = create(:report, :completed, company: company, target: target, parent_report: report)
+      industry = create(:threat_variant_industry, name: "automotive")
+      sub = create(:threat_variant_subindustry, threat_variant_industry: industry, name: "oem")
+      child_probe_names.each_with_index do |name, i|
+        # The same probe the primary run measured, where there is one -- that is
+        # the whole point of a variant run.
+        probe = Probe.find_by(name: name) || create(:probe, name: name)
+        variant = create(:threat_variant, threat_variant_subindustry: sub, probe: probe, prompt: "v#{i}")
+        create(:probe_result, report: child, probe: probe, threat_variant_id: variant.id,
+               passed: 7, total: 10,
+               attempts: [ { "uuid" => "c#{i}", "prompt" => "vq", "outputs" => [ "vr" ] } ])
+      end
+      child
+    end
+  end
+
+  it "emits a parseable document with the schema version" do
+    probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => [ "r" ] } ])
+
+    doc = export
+
+    expect(doc["schema_version"]).to eq(described_class::SCHEMA_VERSION)
+    expect(doc["runs"].size).to eq(1)
+    expect(primary(doc)["report"]["id"]).to eq(report.id)
+    expect(primary(doc)["probe_results"].size).to eq(1)
+  end
+
+  describe "runs" do
+    # A scan with threat variants executes twice. Folding the child run's
+    # attempts into the parent's probe rows made the counts disagree with the
+    # evidence and silently dropped whole results.
+    it "emits the variant child as its own run" do
+      probe_result_with([ { "uuid" => "m", "prompt" => "q", "outputs" => [ "r" ] } ], probe_name: "Shared")
+      with_variant_child(child_probe_names: [ "Shared" ])
+
+      expect(export["runs"].map { |r| r["role"] }).to eq(%w[primary variant])
+    end
+
+    it "keeps a child probe result whose probe has no parent counterpart" do
+      # Iterating the parent's probe_results only made this row and its evidence
+      # vanish while the file still looked complete.
+      probe_result_with([ { "uuid" => "m", "prompt" => "q", "outputs" => [ "r" ] } ], probe_name: "Shared")
+      with_variant_child(child_probe_names: [ "Shared", "ChildOnly" ])
+
+      names = variant_run(export)["probe_results"].map { |p| p["probe_name"] }
+
+      expect(names).to include("ChildOnly")
+    end
+
+    it "keeps each run's own scores" do
+      # The flattened shape reported the parent's numbers only, so the child's
+      # 7/10 could not be recovered from the file at all.
+      probe_result_with([ { "uuid" => "m", "prompt" => "q", "outputs" => [ "r" ] } ],
+                        probe_name: "Shared", passed: 0, total: 1)
+      with_variant_child(child_probe_names: [ "Shared" ])
+
+      doc = export
+
+      expect(primary(doc)["scores"]).to include("passed" => 0, "total" => 1)
+      expect(variant_run(doc)["scores"]).to include("passed" => 7, "total" => 10)
+    end
+
+    it "never lists more attempts under a probe row than that row measured" do
+      # The invariant the flattened shape broke: a row declaring 0/1 beside four
+      # attempts is not a contract a consumer can act on.
+      probe_result_with([ { "uuid" => "m", "prompt" => "q", "outputs" => [ "r" ] } ],
+                        probe_name: "Shared", passed: 0, total: 1)
+      with_variant_child(child_probe_names: [ "Shared" ])
+
+      export["runs"].each do |run|
+        run["probe_results"].each do |row|
+          expect(row["attempts"].size).to be <= row["total"],
+            "#{row['probe_name']} declares #{row['total']} but lists #{row['attempts'].size} attempts"
+        end
+      end
+    end
+
+    it "names the variant on the result rather than on each attempt" do
+      probe_result_with([ { "uuid" => "m", "prompt" => "q", "outputs" => [ "r" ] } ], probe_name: "Shared")
+      with_variant_child(child_probe_names: [ "Shared" ])
+
+      doc = export
+
+      expect(primary(doc)["probe_results"].first["variant"]).to be_nil
+      expect(variant_run(doc)["probe_results"].first["variant"])
+        .to include("industry" => "automotive", "subindustry" => "oem")
+    end
+
+    it "describes a directly exported child as a variant run" do
+      probe_result_with([ { "uuid" => "m", "prompt" => "q", "outputs" => [ "r" ] } ], probe_name: "Shared")
+      child = with_variant_child(child_probe_names: [ "Shared" ])
+
+      doc = export(child)
+
+      expect(doc["runs"].size).to eq(1)
+      expect(doc["runs"].first["role"]).to eq("variant")
+      expect(doc["runs"].first["report"]["parent_report_id"]).to eq(report.id)
+    end
+
+    it "emits one run for a report with no variants" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => [ "r" ] } ])
+
+      expect(export["runs"].map { |r| r["role"] }).to eq([ "primary" ])
+    end
+  end
+
+  describe "attempt de-duplication" do
+    it "collapses an attempt's start and completion rows" do
+      probe_result_with([
+        { "uuid" => "a", "prompt" => "q", "outputs" => [ "r" ], "attack_succeeded" => nil },
+        { "uuid" => "a", "prompt" => "q", "outputs" => [ "r" ], "attack_succeeded" => true }
+      ])
+
+      attempts = primary(export)["probe_results"].first["attempts"]
+
+      expect(attempts.size).to eq(1)
+      expect(attempts.first["attack_succeeded"]).to be(true)
+    end
+
+    it "keeps identical uuid-less rows, because a dropped response can be an attack" do
+      row = { "prompt" => "same", "outputs" => [ "same" ] }
+      probe_result_with([ row, row.dup ])
+
+      expect(primary(export)["probe_results"].first["attempts"].size).to eq(2)
+    end
+
+    it "exports exactly what the report page displays" do
+      pr = probe_result_with([
+        { "uuid" => "a", "prompt" => "q", "outputs" => [ "r" ] },
+        { "uuid" => "a", "prompt" => "q", "outputs" => [ "r" ] },
+        { "prompt" => "no uuid", "outputs" => [ "x" ] }
+      ])
+
+      expect(primary(export)["probe_results"].first["attempts"].size).to eq(pr.displayed_attempts.size)
+    end
+  end
+
+  describe "outputs" do
+    it "numbers every generation" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => [ "first", "second" ] } ])
+
+      outputs = primary(export)["probe_results"].first["attempts"].first["outputs"]
+
+      expect(outputs.map { |o| o["index"] }).to eq([ 0, 1 ])
+      expect(outputs.map { |o| o["response"] }).to eq([ "first", "second" ])
+    end
+
+    it "treats a bare hash as one response rather than its key/value pairs" do
+      # Kernel#Array turns { "text" => "x" } into [["text", "x"]] and would
+      # export two bogus responses. The evidence tab shows one; these agree.
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => { "text" => "only one" } } ])
+
+      outputs = primary(export)["probe_results"].first["attempts"].first["outputs"]
+
+      expect(outputs.size).to eq(1)
+      expect(outputs.first["response"]).to eq({ "text" => "only one" })
+    end
+
+    it "treats a bare string as one response" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => "bare" } ])
+
+      responses = primary(export)["probe_results"].first["attempts"].first["outputs"].map { |o| o["response"] }
+
+      expect(responses).to eq([ "bare" ])
+    end
+
+    it "exports no responses when there are none" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "q" } ])
+
+      expect(primary(export)["probe_results"].first["attempts"].first["outputs"]).to eq([])
+    end
+  end
+
+  describe "hostile content" do
+    # Prompts and responses are attacker-influenced by construction: the point of
+    # a probe is to make a model emit something it should not. The document has
+    # to survive whatever comes back and still parse.
+    HOSTILE_TEXT = {
+      "a quote and a backslash" => %(he said "hi" \\ bye),
+      "braces and brackets" => '{"not":"json"}]}',
+      "a newline and a tab" => "line\nnext\tcol",
+      "a null byte" => "before\u0000after",
+      "a literal backslash-u escape" => '\\ud800 literal',
+      "a unicode line separator" => "a\u2028b\u2029c",
+      "an emoji and a direction override" => "boom \u{1F4A5} \u202Egnirts",
+      "a closing script tag" => "</script><script>alert(1)</script>",
+      "a lone carriage return" => "before\rafter"
+    }.freeze
+
+    HOSTILE_TEXT.each do |name, text|
+      it "survives #{name} in a prompt and a response" do
+        probe_result_with([ { "uuid" => "a", "prompt" => text, "outputs" => [ text ] } ])
+
+        attempt = primary(export)["probe_results"].first["attempts"].first
+
+        expect(attempt["prompt"]).to eq(text)
+        expect(attempt["outputs"].first["response"]).to eq(text)
+      end
+    end
+
+    it "survives hostile text in a probe name" do
+      hostile_name = %(Probe "quoted" \\ {broken})
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => [ "r" ] } ],
+                        probe_name: hostile_name)
+
+      expect(primary(export)["probe_results"].first["probe_name"]).to eq(hostile_name)
+    end
+
+    it "survives a structured prompt carrying hostile turns" do
+      prompt = { "turns" => [ { "role" => "user", "content" => { "text" => %(a "b" \\ c) } } ] }
+      probe_result_with([ { "uuid" => "a", "prompt" => prompt, "outputs" => [ "r" ] } ])
+
+      expect(primary(export)["probe_results"].first["attempts"].first["prompt"]).to eq(prompt)
+    end
+  end
+
+  describe "determinism" do
+    it "produces byte-identical output apart from exported_at" do
+      # A consumer diffing two exports of the same report should see only the
+      # timestamp change.
+      d1 = create(:detector, name: "zeta.Detector")
+      d2 = create(:detector, name: "alpha.Detector")
+      ActsAsTenant.with_tenant(company) do
+        create(:detector_result, report: report, detector: d1, passed: 1, total: 2)
+        create(:detector_result, report: report, detector: d2, passed: 0, total: 2)
+      end
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => [ "r" ] } ])
+
+      strip = ->(doc) { doc.sub(/"exported_at":"[^"]+"/, "TIMESTAMP") }
+      first = strip.call(described_class.new(report.reload).each.to_a.join)
+      second = strip.call(described_class.new(report.reload).each.to_a.join)
+
+      expect(first).to eq(second)
+    end
+
+    it "orders detectors by name" do
+      d1 = create(:detector, name: "zeta.Detector")
+      d2 = create(:detector, name: "alpha.Detector")
+      ActsAsTenant.with_tenant(company) do
+        create(:detector_result, report: report, detector: d1, passed: 1, total: 2)
+        create(:detector_result, report: report, detector: d2, passed: 0, total: 2)
+      end
+
+      expect(primary(export)["detectors"].map { |d| d["name"] })
+        .to eq([ "alpha.Detector", "zeta.Detector" ])
+    end
+  end
+
+  describe "scores" do
+    it "reports nil asr when nothing was measurable" do
+      # 0.0 would claim the target defended perfectly; nothing was measured.
+      probe_result_with([], passed: 0, total: 0)
+
+      expect(primary(export)["scores"]["asr"]).to be_nil
+    end
+
+    it "computes asr when there is a denominator" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => [ "r" ] } ],
+                        passed: 1, total: 4)
+
+      expect(primary(export)["scores"]["asr"]).to eq(25.0)
+    end
+  end
+
+  describe "target" do
+    it "still names a soft-deleted target rather than blowing up" do
+      probe_result_with([ { "uuid" => "a", "prompt" => "q", "outputs" => [ "r" ] } ])
+      name = target.name
+      # Soft delete: Target's default scope hides it, which is what makes
+      # report.target nil while historical_target still resolves it.
+      ActsAsTenant.with_tenant(company) { target.update_columns(deleted_at: Time.current) }
+
+      expect(primary(export)["target"]["name"]).to eq(name)
+    end
+  end
+
+  describe "memory bounding" do
+    it "holds at most BATCH_SIZE probe_result rows at once" do
+      ActsAsTenant.with_tenant(company) do
+        (described_class::BATCH_SIZE + 5).times do |i|
+          create(:probe_result, report: report, probe: create(:probe, name: "Probe #{i}"),
+                 attempts: [ { "uuid" => "u#{i}", "prompt" => "q", "outputs" => [ "r" ] } ])
+        end
+      end
+
+      biggest = 0
+      subscriber = ActiveSupport::Notifications.subscribe("instantiation.active_record") do |*, payload|
+        biggest = [ biggest, payload[:record_count].to_i ].max if payload[:class_name] == "ProbeResult"
+      end
+
+      described_class.new(report.reload).each.to_a
+
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+      expect(biggest).to be <= described_class::BATCH_SIZE
+    end
+  end
+end


### PR DESCRIPTION
Adds an **Export to JSON** button to the report header. It downloads the whole report — prompts, responses, per-attempt verdicts and per-detector scores — so a scan's evidence can be diffed, archived, or fed into another tool without scraping the page.

## The document is a list of runs, not a flat list of probes

A scan with threat variants executes twice: a primary run and a variant child run, each with its own scores, detector totals and probe results. Flattening the child's attempts into the parent's probe rows loses facts a consumer cannot recover:

- a probe row would declare the parent's `passed`/`total` beside attempts drawn from **both** runs, so the counts and the evidence disagree
- the child's own `passed`/`total` and detector totals disappear
- a child probe result whose probe has no parent counterpart vanishes entirely, and the file still looks complete

Those counts can't be rebuilt from the attempts either, because the evaluated total isn't the number of attempts shown — provider filtering and partial processing move them apart. So each run is emitted whole. A consumer wanting the flat view the report page shows can build it with `runs.flat_map { ... }`.

## Other notes

- **De-duplication** follows the same rule as the report page and the evidence tab: garak writes each attempt twice sharing one uuid, so those collapse, while rows without a uuid stay distinct — a dropped response can be a successful attack.
- **Outputs**: a bare value in `outputs` is one response, not its key/value pairs, so the export and the evidence tab never disagree about an attempt's responses.
- **Buffered, not streamed.** The body is spooled to a tempfile before any header goes out and served with a `Content-Length`. Streaming would commit a 200 with the first chunk — before a single probe result had been read — so a later failure would hand the reader a truncated file that still looked like a success. The spool is deleted when the response closes, whether or not the download finished.
- `Cache-Control: no-store`, since the file carries prompts and model responses.
- Scoped by company explicitly as well as through `policy_scope`: tenancy isn't required app-wide, so a nil ambient tenant would otherwise widen the scope.

## Verification

- rspec 3267 examples, 0 failures (+40 new); rubocop clean; brakeman 0 warnings
- Removing the variant run fails 4 specs, including the one pinning that a child-only probe result survives
- Hostile-content specs cover quotes, backslashes, null bytes, unpaired-escape text, line/paragraph separators, a direction override, a closing script tag and a lone carriage return, in prompts, responses and probe names
- Determinism spec asserts two exports of one report are byte-identical apart from `exported_at`
- Headed browser: the button downloads a 200 `application/json` attachment with `Content-Length` and `no-store` that parses to `schema_version: 1`